### PR TITLE
BUGFIX: Update Aptitudes for TODO #49

### DIFF
--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Game.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Game.kt
@@ -61,7 +61,7 @@ class Game(val myContext: Context) {
 		style = Style("B", "B", "B", "B")
 	)
 	private var inheritancesDone = 0
-    private var bNeedToCheckAptitudes: Boolean = true
+    private var needToUpdateAptitudes: Boolean = true
 
 	data class Date(
 		val year: Int,
@@ -352,7 +352,7 @@ class Game(val myContext: Context) {
 			// Perform updates here if necessary.
             val finalsLocation = imageUtils.findImageWithBitmap("race_select_extra_locked_uma_finals", sourceBitmap, suppressError = true, region = imageUtils.regionBottomHalf)
             updateDate(isFinals = (finalsLocation != null))
-            if (bNeedToCheckAptitudes) updateAptitudes()
+            if (needToUpdateAptitudes) updateAptitudes()
 			true
 		} else if (!enablePopupCheck && imageUtils.findImageWithBitmap("cancel", sourceBitmap, region = imageUtils.regionBottomHalf) != null &&
 			imageUtils.findImageWithBitmap("race_confirm", sourceBitmap, region = imageUtils.regionBottomHalf) != null) {
@@ -529,7 +529,7 @@ class Game(val myContext: Context) {
 			
 			// Update preferred distance based on new aptitudes.
 			training.updatePreferredDistance()
-            bNeedToCheckAptitudes = false
+            needToUpdateAptitudes = false
 		}
 	}
 
@@ -594,7 +594,7 @@ class Game(val myContext: Context) {
 			if (findAndTapImage("inheritance", tries = 1, region = imageUtils.regionBottomHalf)) {
 				printToLog("\n[INFO] Claimed an inheritance on ${printFormattedDate()}.")
 				inheritancesDone++
-                bNeedToCheckAptitudes = true
+                needToUpdateAptitudes = true
 				true
 			} else {
 				false


### PR DESCRIPTION
# Brief

This PR resolves the issue mentioned in https://github.com/users/steve1316/projects/1/views/1?pane=issue&itemId=137512838&issue=steve1316%7Cuma-android-automation%7C49

Now any time the bot is started or an inheritance event takes place, a flag is triggered that forces the aptitudes to be updated on the next iteration of the main loop.

# Notes

I tested these changes by running the bot.

One thing I noticed is that the aptitudes are detected somewhat inaccurately. I have a plan to fix this in a future PR.