### PR TITLE
Ensure that Recreation popup is dismissed if mood recovery was not required

### DIFF
--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Game.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Game.kt
@@ -660,6 +660,8 @@ class Game(val myContext: Context) {
 			// Do the date if it is unlocked.
 			if (!handleRecreationDate(recoverMoodIfCompleted = true)) {
                 // Otherwise, recover mood as normal.
+                findAndTapImage("cancel", tries = 1, region = imageUtils.regionBottomHalf, suppressError = true)
+                wait(1.0)
                 if (!findAndTapImage("recover_mood", sourceBitmap, tries = 1, region = imageUtils.regionBottomHalf, suppressError = true)) {
                     findAndTapImage("recover_energy_summer", sourceBitmap, tries = 1, region = imageUtils.regionBottomHalf, suppressError = true)
                 }


### PR DESCRIPTION
## Description
- If mood recovery was not needed when the Recreation popup which is most likely from the energy recovery process and there is no more dating to be done, the popup will be dismissed and energy recovery will proceed as normal.