### PR TITLE
BUGFIX: Unity Cup Stuck at Race Skip Button Screen

### DIFF
--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Game.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Game.kt
@@ -15,6 +15,7 @@ import com.steve1316.uma_android_automation.utils.SettingsHelper
 import com.steve1316.uma_android_automation.utils.GameDateParser
 import com.steve1316.uma_android_automation.components.ButtonCraneGame
 import com.steve1316.uma_android_automation.components.ButtonCraneGameOk
+import com.steve1316.uma_android_automation.components.ButtonSkip
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import org.opencv.core.Point
@@ -822,7 +823,9 @@ class Game(val myContext: Context) {
 		} else if (findAndTapImage("back", tries = 1, region = imageUtils.regionBottomHalf, suppressError = true)) {
 			MessageLog.i(TAG, "[MISC] Navigating back a screen since all the other misc checks have been completed.")
 			wait(1.0)
-		} else if (!BotService.isRunning) {
+		} else if (ButtonSkip.click(imageUtils = imageUtils)) {
+            MessageLog.d(TAG, "[MISC] Clicked skip button.")
+        } else if (!BotService.isRunning) {
 			MessageLog.i(TAG, "\n[END] BotService is not running. Exiting now...")
 			throw InterruptedException()
 		} else {

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/UnityCup.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/UnityCup.kt
@@ -4,6 +4,7 @@ import com.steve1316.uma_android_automation.MainActivity
 import com.steve1316.uma_android_automation.bot.Campaign
 import com.steve1316.uma_android_automation.bot.Game
 import com.steve1316.automation_library.utils.MessageLog
+import com.steve1316.uma_android_automation.components.ButtonRace
 import org.opencv.core.Point
 
 class UnityCup(game: Game) : Campaign(game) {
@@ -36,7 +37,19 @@ class UnityCup(game: Game) : Campaign(game) {
             // Otherwise, handle the Unity Cup race.
 			handleRaceEventsUnityCup()
 			return true
-		} else if (game.findAndTapImage("unitycup_race_skip_results", region = game.imageUtils.regionBottomHalf)) {
+		} else if (
+            game.imageUtils.findImage("unitycup_race_skip_results", tries = 1, region = game.imageUtils.regionBottomHalf).first != null &&
+            game.imageUtils.findImage("race_skip_locked", tries = 1, region = game.imageUtils.regionBottomHalf).first == null
+        ) {
+            game.findAndTapImage("unitycup_race_skip_results", region = game.imageUtils.regionBottomHalf)
+            return true
+        } else if (
+            game.imageUtils.findImage("unitycup_race_manual", tries = 1, region = game.imageUtils.regionBottomHalf).first != null &&
+            game.imageUtils.findImage("race_skip_locked", tries = 1, region = game.imageUtils.regionBottomHalf).first != null
+        ) {
+            game.findAndTapImage("unitycup_race_manual", region = game.imageUtils.regionBottomHalf)
+            return true
+        } else if (ButtonRace.click(imageUtils = game.imageUtils)) {
             return true
         }
 
@@ -51,7 +64,19 @@ class UnityCup(game: Game) : Campaign(game) {
 			game.findAndTapImage("close")
 			handleRaceEventsUnityCup()
 			return true
-        } else if (game.findAndTapImage("unitycup_race_skip_results", region = game.imageUtils.regionBottomHalf)) {
+        } else if (
+            game.imageUtils.findImage("unitycup_race_skip_results", tries = 1, region = game.imageUtils.regionBottomHalf).first != null &&
+            game.imageUtils.findImage("race_skip_locked", tries = 1, region = game.imageUtils.regionBottomHalf).first == null
+        ) {
+            game.findAndTapImage("unitycup_race_skip_results", region = game.imageUtils.regionBottomHalf)
+            return true
+        } else if (
+            game.imageUtils.findImage("unitycup_race_manual", tries = 1, region = game.imageUtils.regionBottomHalf).first != null &&
+            game.imageUtils.findImage("race_skip_locked", tries = 1, region = game.imageUtils.regionBottomHalf).first != null
+        ) {
+            game.findAndTapImage("unitycup_race_manual", region = game.imageUtils.regionBottomHalf)
+            return true
+        } else if (ButtonRace.click(imageUtils = game.imageUtils)) {
             return true
         }
 		return false


### PR DESCRIPTION
# Brief

This PR prevents the bot from getting stuck at the screen below:
<img width="128" height="256" alt="image" src="https://github.com/user-attachments/assets/03392ea8-1612-4b18-a913-1da5f890972b" />

# Notes

This is a temporary bandaid to a bigger issue. Right now the logic for the main loop is not super robust so it is possible that the bot gets stuck at random screens if there are unexpectedly long delays in some cases. See https://github.com/steve1316/uma-android-automation/issues/77#issuecomment-3537686981 for my proposed solution.

I am holding off on reworking the main loop logic until some other PRs are completed to avoid having too many merge conflicts.