### PR TITLE
Fix bug where formatted line would become an empty string before Training Event condition checks

### DIFF
--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/TrainingEvent.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/TrainingEvent.kt
@@ -256,17 +256,17 @@ class TrainingEvent(private val game: Game) {
                         val formattedReward: List<String> = reward.split("\n")
 
                         formattedReward.forEach { line ->
-                            // Skip empty strings and divider lines (lines that are all dashes or start with 5 dashes).
-                            if (line.trim().isEmpty() || line.trim().length >= 5 && line.trim().substring(0, 5).all { it == '-' }) {
-                                return@forEach
-                            }
-
                             val formattedLine: String = regex
                                 .replace(line, "")
                                 .replace("(", "")
                                 .replace(")", "")
                                 .trim()
                                 .lowercase()
+
+                            // Skip empty strings and divider lines (lines that are all dashes or start with 5 dashes).
+                            if (line.trim().isEmpty() || line.trim().length >= 5 && line.trim().substring(0, 5).all { it == '-' }) {
+                                return@forEach
+                            }
 
                             MessageLog.i(TAG, "[TRAINING_EVENT] Original line is \"$line\".")
                             MessageLog.i(TAG, "[TRAINING_EVENT] Formatted line is \"$formattedLine\".")


### PR DESCRIPTION
## Description

<img width="360" height="65" alt="Discord_mfvKtdlSPC" src="https://github.com/user-attachments/assets/afc64ce0-2db3-4951-8f82-95f99f98e4c7" />

```
00:10:11.447 [ERROR] ウマ娘 Android Automation encountered an Exception: java.lang.NumberFormatException: For input string: ""
    at java.lang.Integer.parseInt(Integer.java:627)
    at java.lang.Integer.parseInt(Integer.java:650)
    at com.steve1316.uma_android_automation.bot.TrainingEvent.handleTrainingEvent(TrainingEvent.kt:346)
    at com.steve1316.uma_android_automation.bot.Campaign.handleTrainingEvent(Campaign.kt:22)
    at com.steve1316.uma_android_automation.bot.campaigns.UnityCup.handleTrainingEvent(UnityCup.kt:30)
    at com.steve1316.uma_android_automation.bot.Campaign.start(Campaign.kt:117)
    at com.steve1316.uma_android_automation.bot.Game.start(Game.kt:973)
    at com.steve1316.uma_android_automation.StartModule.onStartEvent(StartModule.kt:269)
    at java.lang.reflect.Method.invoke(Native Method)
    at org.greenrobot.eventbus.EventBus.invokeSubscriber(EventBus.java:517)
    at org.greenrobot.eventbus.EventBus.postToSubscription(EventBus.java:440)
    at org.greenrobot.eventbus.EventBus.postSingleEventForEventType(EventBus.java:421)
    at org.greenrobot.eventbus.EventBus.postSingleEvent(EventBus.java:394)
    at org.greenrobot.eventbus.EventBus.post(EventBus.java:275)
    at org.greenrobot.eventbus.EventBus.postSticky(EventBus.java:316)
    at com.steve1316.automation_library.utils.BotService$onCreate$1.onTouch$lambda$1(BotService.kt:204)
    at com.steve1316.automation_library.utils.BotService$onCreate$1.$r8$lambda$Es_lHoK_9pz8-eRbb24iILl2P-o(Unknown Source:0)
    at com.steve1316.automation_library.utils.BotService$onCreate$1$$ExternalSyntheticLambda1.invoke(D8$$SyntheticClass:0)
    at kotlin.concurrent.ThreadsKt$thread$thread$1.run(Thread.kt:30)
```