### PR TITLE
BUGFIX: Add Notification Delay for Date OCR Test 

### DIFF
--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Game.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Game.kt
@@ -301,6 +301,7 @@ class Game(val myContext: Context) {
 	fun startDateOCRTest() {
 		MessageLog.i(TAG, "\n[TEST] Now beginning the Date OCR test on the Main screen.")
 		MessageLog.i(TAG, "[TEST] Note that this test is dependent on having the correct scale.")
+        wait(5.0)
         updateDate()
 	}
 


### PR DESCRIPTION
# Brief

This PR adds a short delay before running the Date OCR test. This allows the notification banner to disappear before we run the test since the notification covers the part of the screen containing the date.

Without this delay, the test fails every time.