### PR TITLE
Fix the failure state for recreation energy recovery when there is a date available

### DIFF
--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Game.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Game.kt
@@ -785,10 +785,11 @@ class Game(val myContext: Context) {
                     findAndTapImage("cancel", region = imageUtils.regionBottomHalf)
                     true
                 }
-            } else {
+            } else if (findAndTapImage("recreation_dating_progress", region = imageUtils.regionMiddle)) {
                 MessageLog.i(TAG, "[RECREATION_DATE] Recreation date can be done.")
-                findAndTapImage("recreation_dating_progress", region = imageUtils.regionMiddle)
                 true
+            } else {
+                false
             }
         } else {
             false


### PR DESCRIPTION
## Description
- This PR fixes the bug where if the `recreation_dating_progress` image asset was not found when trying to recover energy, the function would return true instead of false.