### PR TITLE
Crane game timing refinement

### DIFF
--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Game.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Game.kt
@@ -831,8 +831,8 @@ class Game(val myContext: Context) {
 				// After attempts 1 and 2, wait for the button to reappear.
 				MessageLog.i(TAG, "[CRANE_GAME] Waiting for the crane game button to reappear after attempt $attempt...")
 				var buttonReappeared = false
-				val maxWaitTime = 10.0
-				val checkInterval = 0.5
+				val maxWaitTime = 30.0
+				val checkInterval = 1.0
 				var elapsedTime = 0.0
 
 				while (elapsedTime < maxWaitTime) {


### PR DESCRIPTION
## Description
- This PR refines the timings of the Crane Game attempts. It is now able to consistently target the first plushie location with some margin of error.
- This also fixes the issue of the Crane Game exiting too early since the app is running so fast.