### PR TITLE
Fix Mandatory Racing Plan bug

### DIFF
--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Racing.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Racing.kt
@@ -361,8 +361,9 @@ class Racing (private val game: Game) {
         }
 
         // If there is a popup warning about repeating races 3+ times, stop the process and do something else other than racing.
+        // Note that if the Racing Plan is set to be mandatory, then this popup is dismissed.
         if (game.imageUtils.findImage("race_repeat_warning").first != null) {
-            if (!enableForceRacing) {
+            if (!enableForceRacing && !enableMandatoryRacingPlan) {
                 raceRepeatWarningCheck = true
                 MessageLog.i(TAG, "[RACE] Closing popup warning of doing more than 3+ races and setting flag to prevent racing for now. Canceling the racing process and doing something else.")
                 game.findAndTapImage("cancel", region = game.imageUtils.regionBottomHalf)


### PR DESCRIPTION
## Description
- This PR fixes the bug where races for the Racing Plan when set to mandatory in the settings were being skipped due to the bot encountering the consecutive races warning and then proceeding to do something else.
- Now it will ignore the warning and do the race.