### PR TITLE
Add edge case handling of loading the user's in-game race agenda after losing debut race and then winning one maiden race

### DIFF
--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Racing.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Racing.kt
@@ -677,6 +677,11 @@ class Racing (private val game: Game) {
                 ButtonBack.click(imageUtils = game.imageUtils)
                 return false
             }
+        } else {
+            // No maiden races available on this day. Back out and try again later.
+            MessageLog.i(TAG, "[RACE] No maiden races available on this day. Aborting racing...")
+            ButtonBack.click(imageUtils = game.imageUtils)
+            return false
         }
 
         // Confirm the selection and the resultant popup and then wait for the game to load.
@@ -1327,17 +1332,20 @@ class Racing (private val game: Game) {
         // It is assumed that the user is already at the screen with the list of selectable races.
         // Now tap on the Agenda button.
         if (!game.findAndTapImage("race_agenda", tries = 1, region = game.imageUtils.regionBottomHalf)) {
-            MessageLog.w(TAG, "[RACE] Could not find the Agenda button. Skipping agenda loading.")
+            MessageLog.w(TAG, "[RACE] Could not find the Agenda button. Backing out and skipping agenda loading.")
+            ButtonBack.click(game.imageUtils)
+            game.waitForLoading()
             return
         }
         game.waitForLoading()
 
         // Now tap on the My Agenda button.
         if (!game.findAndTapImage("race_my_agenda", tries = 1, region = game.imageUtils.regionBottomHalf)) {
-            MessageLog.w(TAG, "[RACE] Could not find the My Agenda button. Closing and skipping agenda loading.")
+            MessageLog.w(TAG, "[RACE] Could not find the My Agenda button. Closing and backing out.")
             ButtonClose.click(game.imageUtils)
-            game.waitForLoading()
             game.wait(0.5)
+            ButtonBack.click(game.imageUtils)
+            game.waitForLoading()
             return
         }
         game.waitForLoading()


### PR DESCRIPTION
## Description
- This PR resolves #133 by adding edge case handling of this.
- Have not encountered this myself but I imagine it is good to have regardless just in case.