### PR TITLE
BUGFIX: UnityCup Opponent Selection Infinite Loop

### DIFF
--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/UnityCup.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/UnityCup.kt
@@ -172,7 +172,9 @@ class UnityCup(game: Game) : Campaign(game) {
                     }
                     val opponent = opponents[selectedOpponentIndex]
                     game.gestureUtils.tap(opponent.x, opponent.y, LabelUnityCupOpponentSelectionLaurel.template.path)
+                    MessageLog.d(TAG, "[UNITY CUP] Selecting opponent #${selectedOpponentIndex} at ${opponent}")
                     ButtonSelectOpponent.click(imageUtils = game.imageUtils, sourceBitmap = sourceBitmap)
+                    game.wait(0.5, skipWaitingForLoading = true)
                 }
                 // If the skip button is locked, need to manually run the race.
                 ButtonViewResultsLocked.check(game.imageUtils, sourceBitmap = sourceBitmap) -> {


### PR DESCRIPTION
Fixes bug caused by my most recent performance improvements. They made the bot too fast! :)

At some point I forgot to add a delay after clicking the `SelectOpponent` button. So after improving the performance, the bot would quickly attempt and fail to detect a dialog which caused it to enter an infinite loop. Before the performance improvements, there was enough delay caused by OCR that the dialog was able to open before getting stuck in a loop.

I'm still testing this change so the PR is just a draft at the moment. I'll take it out of draft after I run like 50 more career playthroughs.