### PR TITLE
Bump Automation Library to version 2.4.1 to use the new GlobalExceptionHandler

### DIFF
--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -14,7 +14,7 @@ androidGradleBuildTools = "8.13.0"
 junitJupiter = "6.0.2"
 junitPlatformLauncher = "6.0.2"
 kotlinGradlePlugin = "2.2.0"
-androidCvAutomationLibrary = "2.4.0"
+androidCvAutomationLibrary = "2.4.1"
 lottie = "6.6.9"
 
 [libraries]


### PR DESCRIPTION
## Description
- This PR updates the `Automation Library` to the latest in order to make use of the new `GlobalExceptionHandler` in order to try to catch and log uncaught Exceptions that would have otherwise crashed it out entirely.