### PR TITLE
Fix bug where Profile modal on devices with higher DPIs had the bottom cut off

### DIFF
--- a/src/components/ProfileComparison/index.tsx
+++ b/src/components/ProfileComparison/index.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from "react"
-import { View, Text, ScrollView, StyleSheet } from "react-native"
+import { View, Text, StyleSheet } from "react-native"
 import { useTheme } from "../../context/ThemeContext"
 import CustomButton from "../CustomButton"
 import { SettingsCategory } from "../../hooks/useProfileManager"
@@ -37,6 +37,12 @@ const ProfileComparison: React.FC<ProfileComparisonProps> = ({ comparison, onCon
 
     const buttonLabel = useMemo(() => (actionType === "overwrite" ? "Overwrite Settings" : "Apply Profile"), [actionType])
 
+    /**
+     * NOTE: This component no longer contains its own ScrollView.
+     * It is designed to be a pure presentation component rendered within
+     * the unified ScrollView of the ProfileManagerModal. This simplifies
+     * the layout and prevents nested scroll conflicts.
+     */
     const styles = StyleSheet.create({
         container: {
             marginTop: 16,
@@ -60,9 +66,6 @@ const ProfileComparison: React.FC<ProfileComparisonProps> = ({ comparison, onCon
             fontWeight: "600",
             color: colors.foreground,
             marginBottom: 8,
-        },
-        scrollView: {
-            maxHeight: 300,
         },
         changeItem: {
             marginBottom: 8,
@@ -100,22 +103,20 @@ const ProfileComparison: React.FC<ProfileComparisonProps> = ({ comparison, onCon
         <View style={styles.container}>
             <Text style={styles.title}>{title}</Text>
 
-            <ScrollView style={styles.scrollView} nestedScrollEnabled={true}>
-                <View style={styles.section}>
-                    <Text style={styles.sectionTitle}>{sectionTitle}</Text>
-                    {Object.entries(comparison).map(([key, { current, profile }]) => (
-                        <View key={key} style={styles.changeItem}>
-                            <Text style={styles.changeKey}>{key}:</Text>
-                            <View style={styles.changeRow}>
-                                <Text style={[styles.changeValue, { color: colors.destructive }]}>Current: {formatValue(current)}</Text>
-                            </View>
-                            <View style={styles.changeRow}>
-                                <Text style={[styles.changeValue, { color: colors.primary }]}>→ Profile: {formatValue(profile)}</Text>
-                            </View>
+            <View style={styles.section}>
+                <Text style={styles.sectionTitle}>{sectionTitle}</Text>
+                {Object.entries(comparison).map(([key, { current, profile }]) => (
+                    <View key={key} style={styles.changeItem}>
+                        <Text style={styles.changeKey}>{key}:</Text>
+                        <View style={styles.changeRow}>
+                            <Text style={[styles.changeValue, { color: colors.destructive }]}>Current: {formatValue(current)}</Text>
                         </View>
-                    ))}
-                </View>
-            </ScrollView>
+                        <View style={styles.changeRow}>
+                            <Text style={[styles.changeValue, { color: colors.primary }]}>→ Profile: {formatValue(profile)}</Text>
+                        </View>
+                    </View>
+                ))}
+            </View>
 
             <View style={styles.buttonRow}>
                 <CustomButton onPress={onCancel} variant="outline">

--- a/src/components/ProfileManagerModal/index.tsx
+++ b/src/components/ProfileManagerModal/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from "react"
+import React, { useState, useEffect, useCallback, useRef } from "react"
 import { View, Text, StyleSheet, ScrollView, TouchableOpacity, Modal as RNModal } from "react-native"
 import { useTheme } from "../../context/ThemeContext"
 import CustomButton from "../CustomButton"
@@ -41,6 +41,59 @@ const ProfileManagerModal: React.FC<ProfileManagerModalProps> = ({
     const [overwriteProfileId, setOverwriteProfileId] = useState<number | null>(null)
     const [comparisonData, setComparisonData] = useState<Record<string, { current: any; profile: any }> | null>(null)
 
+    /**
+     * These refs and handlers implement a manual touch-to-scroll mechanism (replicating
+     * the proven pattern in MultiSelector.tsx).
+     */
+    const scrollViewRef = useRef<ScrollView | null>(null)
+    const lastTouchY = useRef(0)
+    const currentScrollY = useRef(0)
+    const isScrolling = useRef(false)
+
+    /**
+     * Handles the start of a touch event to initialize scrolling.
+     * @param event The native touch event.
+     */
+    const handleTouchStart = (event: any) => {
+        const touch = event.nativeEvent.touches[0]
+        lastTouchY.current = touch.pageY
+        isScrolling.current = false
+    }
+
+    /**
+     * Handles the movement of a touch event to manually scroll the ScrollView.
+     * @param event The native touch event.
+     */
+    const handleTouchMove = (event: any) => {
+        if (!scrollViewRef.current) return
+
+        const touch = event.nativeEvent.touches[0]
+        const currentY = touch.pageY
+        const deltaY = lastTouchY.current - currentY
+
+        // Only scroll if there is significant movement.
+        if (Math.abs(deltaY) > 1) {
+            isScrolling.current = true
+            // Use a balanced scroll factor for smooth but responsive movement.
+            const scrollFactor = 2.0
+            const newScrollY = Math.max(0, currentScrollY.current + deltaY * scrollFactor)
+            currentScrollY.current = newScrollY
+
+            scrollViewRef.current.scrollTo({
+                y: newScrollY,
+                animated: false,
+            })
+            lastTouchY.current = currentY
+        }
+    }
+
+    /**
+     * Handles the end of a touch event.
+     */
+    const handleTouchEnd = () => {
+        isScrolling.current = false
+    }
+
     const styles = StyleSheet.create({
         modal: {
             flex: 1,
@@ -48,12 +101,19 @@ const ProfileManagerModal: React.FC<ProfileManagerModalProps> = ({
             alignItems: "center",
             backgroundColor: "rgba(70, 70, 70, 0.5)",
         },
+        /**
+         * The main content area of the modal.
+         * Using maxHeight: "80%" ensures it stays on screen on all devices.
+         * flexShrink: 1 allows it to grow with content but stay within screen limits.
+         */
         modalContent: {
             backgroundColor: colors.background,
             borderRadius: 12,
             padding: 20,
             width: "90%",
             maxHeight: "80%",
+            overflow: "hidden",
+            flexShrink: 1,
         },
         header: {
             flexDirection: "row",
@@ -70,7 +130,21 @@ const ProfileManagerModal: React.FC<ProfileManagerModalProps> = ({
             padding: 4,
         },
         profileList: {
-            marginTop: 16,
+            marginTop: 0,
+        },
+        /**
+         * The main ScrollView for the modal content.
+         * Using flexShrink: 1 allows it to occupy the remaining space
+         * and trigger scrolling when content exceeds modalContent maxHeight.
+         *
+         * NOTE: Manual touch handlers are implemented in the component logic to ensure scrolling reliability.
+         */
+        mainScroll: {
+            flexShrink: 1,
+        },
+        mainScrollContent: {
+            flexGrow: 1,
+            paddingBottom: 20, // Extra padding to ensure bottom content is reachable.
         },
         profileItem: {
             flexDirection: "row",
@@ -133,7 +207,7 @@ const ProfileManagerModal: React.FC<ProfileManagerModalProps> = ({
                 setEditingProfileId(profileId)
             }
         },
-        [profiles]
+        [profiles],
     )
 
     const handleUpdateProfile = useCallback(async () => {
@@ -218,7 +292,7 @@ const ProfileManagerModal: React.FC<ProfileManagerModalProps> = ({
                 onNoChangesDetected?.(profile.name)
             }
         },
-        [profiles, onOverwriteSettings, compareWithProfile, currentTrainingSettings, currentTrainingStatTargetSettings, onNoChangesDetected]
+        [profiles, onOverwriteSettings, compareWithProfile, currentTrainingSettings, currentTrainingStatTargetSettings, onNoChangesDetected],
     )
 
     const handleConfirmOverwrite = useCallback(
@@ -240,7 +314,7 @@ const ProfileManagerModal: React.FC<ProfileManagerModalProps> = ({
                 onError?.(errorMessage)
             }
         },
-        [currentTrainingSettings, currentTrainingStatTargetSettings, updateProfile, onProfileUpdated, onClose, onError]
+        [currentTrainingSettings, currentTrainingStatTargetSettings, updateProfile, onProfileUpdated, onClose, onError],
     )
 
     const handleCancelOverwrite = useCallback(() => {
@@ -253,7 +327,7 @@ const ProfileManagerModal: React.FC<ProfileManagerModalProps> = ({
         <>
             <RNModal visible={visible && !showDeleteDialog} transparent={true} animationType="fade" onRequestClose={onClose}>
                 <TouchableOpacity style={styles.modal} activeOpacity={1} onPress={onClose}>
-                    <View style={styles.modalContent} onStartShouldSetResponder={() => true}>
+                    <TouchableOpacity style={styles.modalContent} activeOpacity={1} onPress={(e) => e.stopPropagation()}>
                         <View style={styles.header}>
                             <Text style={styles.title}>Manage Profiles</Text>
                             <TouchableOpacity style={styles.closeButton} onPress={onClose}>
@@ -261,72 +335,92 @@ const ProfileManagerModal: React.FC<ProfileManagerModalProps> = ({
                             </TouchableOpacity>
                         </View>
 
-                        <View style={styles.profileList}>
-                            {profiles.length === 0 ? (
-                                <View style={styles.emptyState}>
-                                    <Text style={styles.emptyText}>No profiles yet.</Text>
-                                </View>
-                            ) : (
-                                <ScrollView style={{ maxHeight: 400 }} nestedScrollEnabled={true}>
-                                    {profiles.map((profile) => {
-                                        const isEditing = editingProfileId === profile.id
-                                        return (
-                                            <View key={profile.id} style={styles.profileItem}>
-                                                {isEditing ? (
-                                                    <Input
-                                                        placeholder="Profile name"
-                                                        value={profileName}
-                                                        onChangeText={setProfileName}
-                                                        onSubmitEditing={handleUpdateProfile}
-                                                        style={[styles.profileNameInput, { color: colors.foreground, backgroundColor: colors.background || "#ffffff" }]}
-                                                        autoFocus
-                                                    />
-                                                ) : (
-                                                    <Text style={styles.profileName}>{profile.name}</Text>
-                                                )}
-                                                <View style={styles.profileActions}>
+                        {/*
+                         * We use manual touch handlers to manage scrolling because the standard
+                         * native ScrollView events are swallowed by the RNModal or
+                         * its containing overlays in this project's environment.
+                         */}
+                        <ScrollView
+                            style={styles.mainScroll}
+                            contentContainerStyle={styles.mainScrollContent}
+                            showsVerticalScrollIndicator={true}
+                            nestedScrollEnabled={true}
+                            onTouchStart={handleTouchStart}
+                            onTouchMove={handleTouchMove}
+                            onTouchEnd={handleTouchEnd}
+                            ref={scrollViewRef}
+                            onScroll={(event) => {
+                                const offsetY = event.nativeEvent.contentOffset.y
+                                currentScrollY.current = offsetY
+                            }}
+                        >
+                            <View style={styles.profileList}>
+                                {profiles.length === 0 ? (
+                                    <View style={styles.emptyState}>
+                                        <Text style={styles.emptyText}>No profiles yet.</Text>
+                                    </View>
+                                ) : (
+                                    <>
+                                        {profiles.map((profile) => {
+                                            const isEditing = editingProfileId === profile.id
+                                            return (
+                                                <View key={profile.id} style={styles.profileItem}>
                                                     {isEditing ? (
-                                                        <>
-                                                            <TouchableOpacity style={styles.actionButton} onPress={handleUpdateProfile}>
-                                                                <Check size={18} color={colors.primary} />
-                                                            </TouchableOpacity>
-                                                            <TouchableOpacity style={styles.actionButton} onPress={handleCancelEdit}>
-                                                                <X size={18} color={colors.foreground} />
-                                                            </TouchableOpacity>
-                                                        </>
+                                                        <Input
+                                                            placeholder="Profile name"
+                                                            value={profileName}
+                                                            onChangeText={setProfileName}
+                                                            onSubmitEditing={handleUpdateProfile}
+                                                            style={[styles.profileNameInput, { color: colors.foreground, backgroundColor: colors.background || "#ffffff" }]}
+                                                            autoFocus
+                                                        />
                                                     ) : (
-                                                        <>
-                                                            <TouchableOpacity style={styles.actionButton} onPress={() => handleEditProfile(profile.id)}>
-                                                                <Edit2 size={18} color={colors.primary} />
-                                                            </TouchableOpacity>
-                                                            <TouchableOpacity style={styles.actionButton} onPress={() => handleDeleteClick(profile.id)}>
-                                                                <Trash2 size={18} color={colors.destructive} />
-                                                            </TouchableOpacity>
-                                                        </>
+                                                        <Text style={styles.profileName}>{profile.name}</Text>
                                                     )}
-                                                    {!isEditing && onOverwriteSettings && (
-                                                        <TouchableOpacity style={styles.actionButton} onPress={() => handleSaveClick(profile.id)}>
-                                                            <Save size={18} color={colors.primary} />
-                                                        </TouchableOpacity>
-                                                    )}
+                                                    <View style={styles.profileActions}>
+                                                        {isEditing ? (
+                                                            <>
+                                                                <TouchableOpacity style={styles.actionButton} onPress={handleUpdateProfile}>
+                                                                    <Check size={18} color={colors.primary} />
+                                                                </TouchableOpacity>
+                                                                <TouchableOpacity style={styles.actionButton} onPress={handleCancelEdit}>
+                                                                    <X size={18} color={colors.foreground} />
+                                                                </TouchableOpacity>
+                                                            </>
+                                                        ) : (
+                                                            <>
+                                                                <TouchableOpacity style={styles.actionButton} onPress={() => handleEditProfile(profile.id)}>
+                                                                    <Edit2 size={18} color={colors.primary} />
+                                                                </TouchableOpacity>
+                                                                <TouchableOpacity style={styles.actionButton} onPress={() => handleDeleteClick(profile.id)}>
+                                                                    <Trash2 size={18} color={colors.destructive} />
+                                                                </TouchableOpacity>
+                                                            </>
+                                                        )}
+                                                        {!isEditing && onOverwriteSettings && (
+                                                            <TouchableOpacity style={styles.actionButton} onPress={() => handleSaveClick(profile.id)}>
+                                                                <Save size={18} color={colors.primary} />
+                                                            </TouchableOpacity>
+                                                        )}
+                                                    </View>
                                                 </View>
-                                            </View>
-                                        )
-                                    })}
-                                </ScrollView>
-                            )}
-                        </View>
+                                            )
+                                        })}
+                                    </>
+                                )}
+                            </View>
 
-                        {showComparison && comparisonData && overwriteProfileId && (
-                            <ProfileComparison
-                                comparison={comparisonData}
-                                onConfirm={() => handleConfirmOverwrite(overwriteProfileId)}
-                                onCancel={handleCancelOverwrite}
-                                actionType="overwrite"
-                                category="training"
-                            />
-                        )}
-                    </View>
+                            {showComparison && comparisonData && overwriteProfileId && (
+                                <ProfileComparison
+                                    comparison={comparisonData}
+                                    onConfirm={() => handleConfirmOverwrite(overwriteProfileId)}
+                                    onCancel={handleCancelOverwrite}
+                                    actionType="overwrite"
+                                    category="training"
+                                />
+                            )}
+                        </ScrollView>
+                    </TouchableOpacity>
                 </TouchableOpacity>
             </RNModal>
 


### PR DESCRIPTION
## Description
- This PR resolves #166.
- For users with many Profiles, then pushes the bottom of the modal vertically past the bottom of the screen. This moves the `ScrollView` into `ProfileManagerModal` and have it manage its own height of 80% of the screen's height. This also required manual handling of the scrolling behavior due to being nested inside the Portal which would have normally intercepted the scroll gesture.