### PR TITLE
BUGFIX: Fix training stat selection misses.

### DIFF
--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Training.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Training.kt
@@ -705,7 +705,14 @@ class Training(private val game: Game) {
             StatName.WIT to IconTrainingHeaderWit,
         )
 
-        fun gotoStat(statName: StatName, retries: Int = 3): Boolean {
+        /** Changes the active (selected) training stat in the training screen.
+         *
+         * @param statName The stat to switch to.
+         * @param retries The number of times to attempt to switch to the [statName].
+         *
+         * @return Whether the operation was successful.
+         */
+        fun goToStat(statName: StatName, retries: Int = 3): Boolean {
             // KeyError indicates programmer error.
             val header: ComponentInterface = iconTrainingHeaders[statName]!!
             val button: ComponentInterface = trainingButtons[statName]!!
@@ -732,7 +739,7 @@ class Training(private val game: Game) {
         }
 
         // If not doing single training and speed training isn't active, make it active.
-        if (!singleTraining && !gotoStat(StatName.SPEED)) {
+        if (!singleTraining && !goToStat(StatName.SPEED)) {
             MessageLog.w(TAG, "Skipping training due to not being able to confirm whether the bot is at the training screen.")
             return
         }
@@ -795,7 +802,7 @@ class Training(private val game: Game) {
                 }
 
                 // Only go to a different stat if we aren't doing single training.
-                if (!singleTraining && !gotoStat(statName)) {
+                if (!singleTraining && !goToStat(statName)) {
                     MessageLog.e(TAG, "[TRAINING] Failed to click training button for $statName. Aborting training...")
                     return
                 }


### PR DESCRIPTION
# Brief

This PR fixes an issue where the bot enters the training screen and fails to properly navigate to the SPEED training prior to analyzing all trainings.

## Details

This issue can present itself when the previous training was anything other than SPEED. The first thing we do when entering the training screen is look for the SPEED stat training header. Sometimes we can detect this super fast, at which point we attempt to click the SPEED training button to make it the active training. However, upon entering the training screen, there is a short period of time where none of the stat training buttons are clickable. So if we are moving too fast, the bot clicks the button and since there was no validation logic in place, it just assumed that the speed training was active.

Also when the bot enters the training screen, the stat training header icon has a short animation that plays. This can cause some misses when attempting to find the header.

To remedy these issues, we've added a function for clicking the training buttons which uses retry logic and header validation to ensure that we're at the right screen after clicking a training button.