### PR TITLE
Fix React Native Reusables' Select component scrolling

### DIFF
--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,12 +1,12 @@
 import { Icon } from "@/src/components/ui/icon"
-import { NativeOnlyAnimatedView } from "@/src/components/ui/native-only-animated-view"
+// Removed the NativeOnlyAnimatedView import to fix the issue with this component not being properly scrollable on Android.
+// https://github.com/founded-labs/react-native-reusables/issues/424#issuecomment-3298693345
 import { TextClassContext } from "@/src/components/ui/text"
 import { cn } from "@/src/lib/utils"
 import * as SelectPrimitive from "@rn-primitives/select"
 import { Check, ChevronDown, ChevronDownIcon, ChevronUpIcon } from "lucide-react-native"
 import * as React from "react"
 import { Platform, ScrollView, StyleSheet, View } from "react-native"
-import { FadeIn, FadeOut } from "react-native-reanimated"
 import { FullWindowOverlay as RNFullWindowOverlay } from "react-native-screens"
 
 type Option = SelectPrimitive.Option
@@ -76,45 +76,43 @@ function SelectContent({
             <FullWindowOverlay>
                 <SelectPrimitive.Overlay style={Platform.select({ native: StyleSheet.absoluteFill })}>
                     <TextClassContext.Provider value="text-popover-foreground">
-                        <NativeOnlyAnimatedView className="z-50" entering={FadeIn} exiting={FadeOut}>
-                            <SelectPrimitive.Content
-                                className={cn(
-                                    "bg-popover border-border relative z-50 min-w-[8rem] rounded-md border shadow-md shadow-black/5",
+                        <SelectPrimitive.Content
+                            className={cn(
+                                "bg-popover border-border relative z-50 min-w-[8rem] rounded-md border shadow-md shadow-black/5",
+                                Platform.select({
+                                    web: cn(
+                                        "animate-in fade-in-0 zoom-in-95 origin-(--radix-select-content-transform-origin) max-h-52 overflow-y-auto overflow-x-hidden",
+                                        props.side === "bottom" && "slide-in-from-top-2",
+                                        props.side === "top" && "slide-in-from-bottom-2",
+                                    ),
+                                    native: "p-1",
+                                }),
+                                position === "popper" &&
                                     Platform.select({
-                                        web: cn(
-                                            "animate-in fade-in-0 zoom-in-95 origin-(--radix-select-content-transform-origin) max-h-52 overflow-y-auto overflow-x-hidden",
-                                            props.side === "bottom" && "slide-in-from-top-2",
-                                            props.side === "top" && "slide-in-from-bottom-2"
-                                        ),
-                                        native: "p-1",
+                                        web: cn(props.side === "bottom" && "translate-y-1", props.side === "top" && "-translate-y-1"),
                                     }),
+                                className,
+                            )}
+                            position={position}
+                            {...props}
+                        >
+                            <SelectScrollUpButton />
+                            <SelectPrimitive.Viewport
+                                className={cn(
+                                    "p-1",
                                     position === "popper" &&
-                                        Platform.select({
-                                            web: cn(props.side === "bottom" && "translate-y-1", props.side === "top" && "-translate-y-1"),
-                                        }),
-                                    className
+                                        cn(
+                                            "w-full",
+                                            Platform.select({
+                                                web: "h-[var(--radix-select-trigger-height)] min-w-[var(--radix-select-trigger-width)]",
+                                            }),
+                                        ),
                                 )}
-                                position={position}
-                                {...props}
                             >
-                                <SelectScrollUpButton />
-                                <SelectPrimitive.Viewport
-                                    className={cn(
-                                        "p-1",
-                                        position === "popper" &&
-                                            cn(
-                                                "w-full",
-                                                Platform.select({
-                                                    web: "h-[var(--radix-select-trigger-height)] min-w-[var(--radix-select-trigger-width)]",
-                                                })
-                                            )
-                                    )}
-                                >
-                                    {children}
-                                </SelectPrimitive.Viewport>
-                                <SelectScrollDownButton />
-                            </SelectPrimitive.Content>
-                        </NativeOnlyAnimatedView>
+                                {children}
+                            </SelectPrimitive.Viewport>
+                            <SelectScrollDownButton />
+                        </SelectPrimitive.Content>
                     </TextClassContext.Provider>
                 </SelectPrimitive.Overlay>
             </FullWindowOverlay>


### PR DESCRIPTION
## Description
- https://github.com/founded-labs/react-native-reusables/issues/424#issuecomment-3298693345 offered the solution where RNR's usage of `NativeOnlyAnimatedView` caused conflicts and scrolling was impacted.