### PR TITLE
Address edge case where fan requirement is being hindered by disabled fan farming

### DIFF
--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Racing.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Racing.kt
@@ -567,10 +567,9 @@ class Racing (private val game: Game) {
                 return false
             }
         } else {
-            // No maiden races available on this day. Back out and try again later.
-            MessageLog.i(TAG, "[RACE] No maiden races available on this day. Aborting racing...")
-            ButtonBack.click(imageUtils = game.imageUtils)
-            return false
+            // No maiden races available on this day. Check for extra races instead.
+            MessageLog.i(TAG, "[RACE] No maiden races available on this day. Checking for extra races instead...")
+            return handleExtraRace()
         }
 
         // Confirm the selection and the resultant popup and then wait for the game to load.


### PR DESCRIPTION
## Description
- This PR addresses the edge case where the user disabled fan farming but a fan requirement is active and the logic defaulted to the logic handling maiden races.