### PR TITLE
Bugfixes: Zero stat issue and Agenda initial loading

### DIFF
--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Racing.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Racing.kt
@@ -524,6 +524,8 @@ class Racing(private val game: Game, private val campaign: Campaign) {
         MessageLog.i(TAG, "[RACE] Loading user's in-game race agenda: $effectiveAgendaName")
 
         // It is assumed that the user is already at the screen with the list of selectable races.
+        game.wait(game.dialogWaitDelay)
+
         // Taps on the Agenda button.
         if (!ButtonAgenda.click(game.imageUtils)) {
             MessageLog.w(TAG, "[WARN] loadUserRaceAgenda:: Could not find the Agenda button. Backing out and skipping agenda loading.")

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/Trackblazer.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/Trackblazer.kt
@@ -387,13 +387,13 @@ class Trackblazer(game: Game) : Campaign(game) {
     }
 
     override fun recoverEnergy(sourceBitmap: Bitmap?): Boolean {
-        MessageLog.i(TAG, "[TRACKBLAZER] Resetting consecutive race counter due to energy recovery.")
+        MessageLog.i(TAG, "[TRACKBLAZER] Resetting $consecutiveRaceCount consecutive race counts due to energy recovery.")
         consecutiveRaceCount = 0
         return super.recoverEnergy(sourceBitmap)
     }
 
     override fun recoverMood(sourceBitmap: Bitmap?, targetMood: Mood): Boolean {
-        MessageLog.i(TAG, "[TRACKBLAZER] Resetting consecutive race counter due to mood recovery.")
+        MessageLog.i(TAG, "[TRACKBLAZER] Resetting $consecutiveRaceCount consecutive race counts due to mood recovery.")
         consecutiveRaceCount = 0
         return super.recoverMood(sourceBitmap, targetMood)
     }

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/utils/CustomImageUtils.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/utils/CustomImageUtils.kt
@@ -352,7 +352,7 @@ class CustomImageUtils(context: Context, private val game: Game) : ImageUtils(co
             // Determine crop region and small adjustments for improved OCR rates.
             val (offsetX, offsetY, width, height) = listOf(-50, 10, relWidth(100), relHeight(55))
 
-            // Perform OCR with 3x scaling and thresholding (small text compensation).
+            // Perform OCR with 2x scaling and no thresholding.
             val detectedText =
                 performOCROnRegion(
                     sourceBitmap!!,
@@ -360,9 +360,9 @@ class CustomImageUtils(context: Context, private val game: Game) : ImageUtils(co
                     relY(trainingSelectionLocation.y, offsetY),
                     width,
                     height,
-                    useThreshold = true,
+                    useThreshold = false,
                     useGrayscale = true,
-                    scale = 3.0,
+                    scale = 2.0,
                     ocrEngine = "mlkit",
                     debugName = "TrainingFailureChance",
                 )

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/utils/CustomImageUtils.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/utils/CustomImageUtils.kt
@@ -335,6 +335,9 @@ class CustomImageUtils(context: Context, private val game: Game) : ImageUtils(co
     fun findTrainingFailureChance(sourceBitmap: Bitmap? = null, trainingSelectionLocation: Point? = null, tries: Int = 1): Int {
         fun detectTrainingFailureChance(sourceBitmap: Bitmap? = null, trainingSelectionLocation: Point? = null): Int {
             // Crop the source screenshot to hold the success percentage only.
+            // Delay for failure bubble tween.
+            game.waitForLoading()
+
             val (trainingSelectionLocation, sourceBitmap) =
                 if (sourceBitmap == null && trainingSelectionLocation == null) {
                     LabelTrainingFailureChance.find(this)
@@ -346,10 +349,10 @@ class CustomImageUtils(context: Context, private val game: Game) : ImageUtils(co
                 return -1
             }
 
-            // Determine crop region.
-            val (offsetX, offsetY, width, height) = listOf(-45, 15, relWidth(100), relHeight(70))
+            // Determine crop region and small adjustments for improved OCR rates.
+            val (offsetX, offsetY, width, height) = listOf(-50, 10, relWidth(100), relHeight(55))
 
-            // Perform OCR with 2x scaling and no thresholding.
+            // Perform OCR with 3x scaling and thresholding (small text compensation).
             val detectedText =
                 performOCROnRegion(
                     sourceBitmap!!,
@@ -357,9 +360,9 @@ class CustomImageUtils(context: Context, private val game: Game) : ImageUtils(co
                     relY(trainingSelectionLocation.y, offsetY),
                     width,
                     height,
-                    useThreshold = false,
+                    useThreshold = true,
                     useGrayscale = true,
-                    scale = 2.0,
+                    scale = 3.0,
                     ocrEngine = "mlkit",
                     debugName = "TrainingFailureChance",
                 )
@@ -404,9 +407,9 @@ class CustomImageUtils(context: Context, private val game: Game) : ImageUtils(co
         }
 
         if (debugMode) {
-            MessageLog.i(TAG, "[INFO] Failure chance detected to be at $result%.")
+            MessageLog.i(TAG, "[INFO] Failure chance of '$result'% at $trainingSelectionLocation")
         } else {
-            Log.i(TAG, "[INFO] Failure chance detected to be at $result%.")
+            Log.i(TAG, "[INFO] Failure chance of '$result'% at $trainingSelectionLocation")
         }
         return result
     }
@@ -825,7 +828,7 @@ class CustomImageUtils(context: Context, private val game: Game) : ImageUtils(co
                 relHeight(height),
                 useThreshold = false,
                 useGrayscale = true,
-                scale = 1.0,
+                scale = 2.0,
                 ocrEngine = "tesseract_digits",
                 debugName = "${statName}StatValue",
             )
@@ -834,12 +837,15 @@ class CustomImageUtils(context: Context, private val game: Game) : ImageUtils(co
         Log.d(TAG, "[DEBUG] determineSingleStatValue:: Detected number of stats for $statName from Tesseract before formatting: $text")
         if (text.lowercase().contains("max") || text.lowercase().contains("ax")) {
             Log.d(TAG, "[DEBUG] determineSingleStatValue:: $statName seems to be maxed out. Setting it to $manualStatCap.")
-            return manualStatCap
+            val cleanedText = text.replace(Regex("[^0-9]"), "")
+            val parsed = cleanedText.toInt()
+            return if (manualStatCap > 0) parsed.coerceIn(0, manualStatCap) else parsed.coerceAtLeast(0)
         } else {
             try {
                 Log.d(TAG, "[DEBUG] determineSingleStatValue:: Converting $text to integer for $statName stat value")
                 val cleanedText = text.replace(Regex("[^0-9]"), "")
-                return cleanedText.toInt().coerceIn(0, manualStatCap)
+                val parsed = cleanedText.toInt()
+                return if (manualStatCap > 0) parsed.coerceIn(0, manualStatCap) else parsed.coerceAtLeast(0)
             } catch (_: NumberFormatException) {
                 return -1
             }
@@ -893,10 +899,11 @@ class CustomImageUtils(context: Context, private val game: Game) : ImageUtils(co
                     width = 105
                     height = 40
                 } else {
+                    // Minor adjustments for OCR accuracy.
                     offsetX = -862 + (index * 170)
-                    offsetY = 25
+                    offsetY = 20
                     width = 98
-                    height = 42
+                    height = 50
                 }
 
                 // Perform OCR with no thresholding (stats are on solid background).
@@ -915,17 +922,31 @@ class CustomImageUtils(context: Context, private val game: Game) : ImageUtils(co
                     )
 
                 // Parse the text.
-                Log.d(TAG, "[DEBUG] determineStatValues:: Detected number of stats for $statName from Tesseract before formatting: $text")
+                Log.d(TAG, "[DEBUG] determineStatValues:: Raw OCR text for $statName: '$text' (length: ${text.length})")
+
                 if (text.lowercase().contains("max") || text.lowercase().contains("ax")) {
                     Log.d(TAG, "[DEBUG] determineStatValues:: $statName seems to be maxed out. Setting it to $manualStatCap.")
-                    result[statName] = manualStatCap
+                    result[statName] = if (manualStatCap > 0) manualStatCap else 1200
                 } else {
                     try {
-                        Log.d(TAG, "[DEBUG] determineStatValues:: Converting $text to integer for $statName stat value")
-                        val cleanedText = text.replace(Regex("[^0-9]"), "")
-                        result[statName] = cleanedText.toInt().coerceIn(0, manualStatCap)
-                    } catch (_: NumberFormatException) {
+                    // Extract all numbers from the text
+                    val numbers = Regex("\\d+").findAll(text).map { it.value.toInt() }.toList()
+
+                    if (numbers.isEmpty()) {
+                        MessageLog.w(TAG, "[WARN] determineStatValues:: No numbers found in '$text' for $statName")
                         result[statName] = -1
+                    } else {
+                        val validNumbers = numbers.filter { it in 0..1200 }
+                        val value = if (validNumbers.isNotEmpty()) {
+                            validNumbers.max()
+                        } else {
+                            numbers.max()
+                        }
+                        result[statName] = if (manualStatCap > 0) value.coerceIn(0, manualStatCap) else value.coerceAtLeast(0)
+                    }
+                } catch (e: Exception) {
+                    MessageLog.e(TAG, "[ERROR] determineStatValues:: Failed to parse '$text' for $statName: ${e.message}")
+                    result[statName] = -1
                     }
                 }
             }


### PR DESCRIPTION
### Summary
Fixes possible zero-stat issue occurrence for devices, add delay for agenda check before rest.

### Changes
- manualStatCap had inconsistent behavior that seemed to override the OCR results of the stat values (possibly non-thread-safe) to 0. determineSingleStatValue and determineStatValues, replaced unconditional coerceIn(0, manualStatCap) with a guard:

- If manualStatCap > 0 (user has configured a cap), clamp as before

- If manualStatCap = 0 (unset/default), fall back to coerceAtLeast(0) to floor at 0 without applying any upper cap 

manualStatCap = 0 → no upper cap applied, raw parsed value is used
manualStatCap = 800 or any positive value → clamps as intended
Maxed stat detection → uses manualStatCap if set, otherwise defaults to 1200

- Added game.wait(game.dialogWaitDelay) before the Agenda click event in loadUserRaceAgenda to delay when the bot tries to interact with the agenda before the UI has fully transitioned.

- Added race count on the recoverEnergy and recoverMood to log any outlying recovery events.