### PR TITLE
Reduce effective stat cap by expected finale race gains to avoid wasting free stats

### DIFF
--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Training.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Training.kt
@@ -322,6 +322,31 @@ class Training(private val game: Game, private val campaign: Campaign) {
             return getScenarioStatCap(config.scenario, statName)
         }
 
+        /** Stats gained per finale race win, per stat. Slightly above the actual +10 to account for misc event/card gains. */
+        private const val FINALE_RACE_STAT_BONUS = 15
+
+        /**
+         * Calculate the number of remaining finale races based on the current turn.
+         *
+         * Finale races occur on turns 73, 74, and 75. Before the finale (turn <= 72), all 3 races remain.
+         *
+         * @param currentDay The current turn number (1-75).
+         * @return The number of remaining finale races (0-3).
+         */
+        fun getRemainingFinaleRaces(currentDay: Int): Int {
+            return (75 - maxOf(currentDay, 72)).coerceAtLeast(0)
+        }
+
+        /**
+         * Calculate the expected total stat bonus from remaining finale race wins.
+         *
+         * @param currentDay The current turn number (1-75).
+         * @return The expected stat gain per stat from remaining finale races.
+         */
+        fun getFinaleStatBonus(currentDay: Int): Int {
+            return getRemainingFinaleRaces(currentDay) * FINALE_RACE_STAT_BONUS
+        }
+
         /**
          * Score the training option based on friendship bar progress.
          *
@@ -652,7 +677,8 @@ class Training(private val game: Game, private val campaign: Campaign) {
             val currentStat: Int = config.currentStats.getOrDefault(training.name, 0)
             val potentialStat: Int = currentStat + training.statGains.getOrElse(training.name) { 0 }
             val statCap = getCurrentStatCap(training.name, config)
-            val effectiveStatCap = statCap - 100
+            val finaleBonus = getFinaleStatBonus(config.currentDate.day)
+            val effectiveStatCap = statCap - 100 - finaleBonus
 
             // Don't score for stats that are close to the absolute cap.
             if (currentStat >= statCap) {
@@ -2159,7 +2185,8 @@ class Training(private val game: Game, private val campaign: Campaign) {
                 val currentStat = campaign.trainee.stats.asMap()[trainingSelected] ?: 0
                 val potentialStat = currentStat + (training.statGains[trainingSelected] ?: 0)
                 val statCap = getCurrentStatCap(trainingSelected)
-                val effectiveStatCap = statCap - 100
+                val finaleBonus = getFinaleStatBonus(campaign.date.day)
+                val effectiveStatCap = statCap - 100 - finaleBonus
 
                 if ((currentStat >= effectiveStatCap || potentialStat >= effectiveStatCap) && trainingSelected !in statsTrainedOverBuffer) {
                     MessageLog.v(TAG, "[TRAINING] [$trainingSelected] One-time stat cap buffer allowance used for this stat.")

--- a/android/app/src/test/java/com/steve1316/uma_android_automation/bot/TrainingScoringTest.kt
+++ b/android/app/src/test/java/com/steve1316/uma_android_automation/bot/TrainingScoringTest.kt
@@ -4,6 +4,8 @@ import com.steve1316.uma_android_automation.bot.Training.Companion.calculateMisc
 import com.steve1316.uma_android_automation.bot.Training.Companion.calculateRawTrainingScore
 import com.steve1316.uma_android_automation.bot.Training.Companion.calculateRelationshipScore
 import com.steve1316.uma_android_automation.bot.Training.Companion.calculateStatEfficiencyScore
+import com.steve1316.uma_android_automation.bot.Training.Companion.getFinaleStatBonus
+import com.steve1316.uma_android_automation.bot.Training.Companion.getRemainingFinaleRaces
 import com.steve1316.uma_android_automation.bot.Training.Companion.scoreFriendshipTraining
 import com.steve1316.uma_android_automation.bot.Training.Companion.scoreUnityCupTraining
 import com.steve1316.uma_android_automation.bot.Training.TrainingConfig
@@ -1071,5 +1073,128 @@ class TrainingScoringTest {
         val bestTraining = scores.maxByOrNull { it.value }?.key
 
         assertEquals(testCase.expectedTraining, bestTraining?.name, testCase.description)
+    }
+
+    // ///////////////////////////////////////////////////////////////////////////////////////////
+    // Finale Race Stat Bonus Tests
+    // ///////////////////////////////////////////////////////////////////////////////////////////
+
+    @Test
+    @DisplayName("getRemainingFinaleRaces returns correct values for boundary turns")
+    fun testGetRemainingFinaleRaces() {
+        assertEquals(3, getRemainingFinaleRaces(1), "Turn 1: all 3 finale races remaining")
+        assertEquals(3, getRemainingFinaleRaces(60), "Turn 60: all 3 finale races remaining")
+        assertEquals(3, getRemainingFinaleRaces(72), "Turn 72: all 3 finale races remaining")
+        assertEquals(2, getRemainingFinaleRaces(73), "Turn 73: 2 finale races remaining")
+        assertEquals(1, getRemainingFinaleRaces(74), "Turn 74: 1 finale race remaining")
+        assertEquals(0, getRemainingFinaleRaces(75), "Turn 75: no finale races remaining")
+    }
+
+    @Test
+    @DisplayName("getFinaleStatBonus returns correct bonus values")
+    fun testGetFinaleStatBonus() {
+        assertEquals(45, getFinaleStatBonus(60), "Turn 60: 3 races * 15 = 45")
+        assertEquals(30, getFinaleStatBonus(73), "Turn 73: 2 races * 15 = 30")
+        assertEquals(15, getFinaleStatBonus(74), "Turn 74: 1 race * 15 = 15")
+        assertEquals(0, getFinaleStatBonus(75), "Turn 75: 0 races * 15 = 0")
+    }
+
+    @Test
+    @DisplayName("Stat near cap blocked by finale bonus adjustment (turn 60, 3 races remaining)")
+    fun testFinaleAdjustmentBlocksTrainingNearCap() {
+        // With 3 finale races remaining, effective cap = 1200 - 100 - 45 = 1055.
+        // A stat at 1060 should be blocked.
+        val currentStats =
+            mapOf(
+                StatName.SPEED to 1060,
+                StatName.STAMINA to 400,
+                StatName.POWER to 400,
+                StatName.GUTS to 400,
+                StatName.WIT to 400,
+            )
+
+        val training =
+            createDefaultTrainingOption(
+                name = StatName.SPEED,
+                statGains = statGainsToMap(intArrayOf(60, 0, 30, 0, 0)),
+            )
+
+        val config =
+            createDefaultConfig(
+                trainingOptions = listOf(training),
+                currentStats = currentStats,
+                disableTrainingOnMaxedStat = true,
+                currentDate = GameDate(day = 60),
+            )
+
+        val score = calculateRawTrainingScore(config, training)
+
+        assertEquals(0.0, score, "Stat at 1060 should be blocked when effective cap is 1055 (turn 60, 3 finale races)")
+    }
+
+    @Test
+    @DisplayName("Same stat allowed when fewer finale races remain (turn 74, 1 race remaining)")
+    fun testFinaleAdjustmentAllowsTrainingWithFewerRaces() {
+        // With 1 finale race remaining, effective cap = 1200 - 100 - 15 = 1085.
+        // A stat at 1060 should NOT be blocked.
+        val currentStats =
+            mapOf(
+                StatName.SPEED to 1060,
+                StatName.STAMINA to 400,
+                StatName.POWER to 400,
+                StatName.GUTS to 400,
+                StatName.WIT to 400,
+            )
+
+        val training =
+            createDefaultTrainingOption(
+                name = StatName.SPEED,
+                statGains = statGainsToMap(intArrayOf(20, 0, 10, 0, 0)),
+            )
+
+        val config =
+            createDefaultConfig(
+                trainingOptions = listOf(training),
+                currentStats = currentStats,
+                disableTrainingOnMaxedStat = true,
+                currentDate = GameDate(day = 74),
+            )
+
+        val score = calculateRawTrainingScore(config, training)
+
+        assertTrue(score > 0.0, "Stat at 1060 should be allowed when effective cap is 1085 (turn 74, 1 finale race)")
+    }
+
+    @Test
+    @DisplayName("No finale adjustment on turn 75 (all races done)")
+    fun testNoFinaleAdjustmentOnFinalTurn() {
+        // With 0 finale races remaining, effective cap = 1200 - 100 = 1100 (unchanged).
+        // A stat at 1060 with potential 1080 should NOT be blocked.
+        val currentStats =
+            mapOf(
+                StatName.SPEED to 1060,
+                StatName.STAMINA to 400,
+                StatName.POWER to 400,
+                StatName.GUTS to 400,
+                StatName.WIT to 400,
+            )
+
+        val training =
+            createDefaultTrainingOption(
+                name = StatName.SPEED,
+                statGains = statGainsToMap(intArrayOf(20, 0, 10, 0, 0)),
+            )
+
+        val config =
+            createDefaultConfig(
+                trainingOptions = listOf(training),
+                currentStats = currentStats,
+                disableTrainingOnMaxedStat = true,
+                currentDate = GameDate(day = 75),
+            )
+
+        val score = calculateRawTrainingScore(config, training)
+
+        assertTrue(score > 0.0, "Stat at 1060 should be allowed on turn 75 with no finale adjustment (effective cap = 1100)")
     }
 }


### PR DESCRIPTION
## Description
- This PR resolves #142.
- Account for expected finale race stat gains (+15 per race per stat) when evaluating whether a stat is near the cap, preventing the bot from wasting training turns on stats that will receive free gains from winning finale races.