### PR TITLE
Skip training analysis when energy is depleted and no charm is available

### DIFF
--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Training.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Training.kt
@@ -830,6 +830,15 @@ class Training(private val game: Game, private val campaign: Campaign) {
         val ignoreFailureChance = args["ignoreFailureChance"] as? Boolean ?: false
         val isIrregularEvaluation = args["isIrregularEvaluation"] as? Boolean ?: false
 
+        // Skip training analysis entirely when energy is depleted and no charm is available to offset the failure chance.
+        if (!test && !ignoreFailureChance && !campaign.checkFinals() && campaign.trainee.energy <= 0) {
+            MessageLog.i(TAG, "[TRAINING] Skipping training analysis as energy is ${campaign.trainee.energy}% with no Good-Luck Charm to offset failure chance.")
+            needsEnergyRecovery = true
+            trainingMap.clear()
+            skippedTrainingMap.clear()
+            return
+        }
+
         if (test) {
             MessageLog.v(TAG, "\n[TRAINING] Now starting process to analyze all 5 Trainings for Testing.")
         } else if (singleTraining) {

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/Trackblazer.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/Trackblazer.kt
@@ -686,9 +686,11 @@ class Trackblazer(game: Game) : Campaign(game) {
             val isMandatoryRace = IconRaceDayRibbon.check(game.imageUtils) || IconGoalRibbon.check(game.imageUtils)
 
             if (!isScheduledRace && !isMandatoryRace) {
-                MessageLog.i(TAG, "[TRACKBLAZER] Evaluating for Irregular Training...")
-
-                if (ButtonTraining.click(game.imageUtils)) {
+                // Skip irregular training evaluation when energy is depleted and no charm can offset the failure chance.
+                if (trainee.energy <= 0 && !hasCharmAvailable) {
+                    MessageLog.i(TAG, "[TRACKBLAZER] Skipping Irregular Training evaluation as energy is ${trainee.energy}% with no Good-Luck Charm available.")
+                    bHasCheckedIrregularTrainingThisTurn = true
+                } else if (ButtonTraining.click(game.imageUtils)) {
                     game.wait(game.dialogWaitDelay)
 
                     val isIrregularEvaluation = true


### PR DESCRIPTION
## Description
- This PR is a part of #262.
- Will skip training analysis if zero energy and no `Good-Luck Charm` to ignore the failure chances.