### PR TITLE
Cross-validate training failure chances to correct OCR misreads

### DIFF
--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Training.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Training.kt
@@ -351,9 +351,10 @@ class Training(private val game: Game, private val campaign: Campaign) {
          * Cross-validate failure chances and return corrected values.
          *
          * Failure chances are monotonically non-decreasing in training order
-         * (Speed <= Stamina <= Power <= Guts <= Wit). If an earlier training's
-         * failure chance is significantly lower than the next, it is likely an
-         * OCR misread and should be corrected upward.
+         * (Speed <= Stamina <= Power <= Guts). Wit is excluded because it
+         * naturally has a lower failure chance than the other trainings.
+         * If an earlier training's failure chance is significantly lower than
+         * the next, it is likely an OCR misread and should be corrected upward.
          *
          * @param failureChances List of ([StatName], failureChance) pairs with valid (>= 0) values.
          * @param suspiciousJumpThreshold Minimum difference to consider suspicious.
@@ -363,9 +364,13 @@ class Training(private val game: Game, private val campaign: Campaign) {
             failureChances: List<Pair<StatName, Int>>,
             suspiciousJumpThreshold: Int = 20,
         ): Map<StatName, Int> {
-            if (failureChances.size < 2) return failureChances.toMap()
+            // Wit is excluded from cross-validation as it naturally has a lower failure chance.
+            val witEntry = failureChances.filter { it.first == StatName.WIT }
+            val withoutWit = failureChances.filter { it.first != StatName.WIT }
 
-            val sorted = failureChances.sortedBy { it.first.ordinal }.toMutableList()
+            if (withoutWit.size < 2) return failureChances.toMap()
+
+            val sorted = withoutWit.sortedBy { it.first.ordinal }.toMutableList()
 
             // Walk backwards: correct any value that is suspiciously lower than its successor.
             for (i in sorted.size - 2 downTo 0) {
@@ -376,7 +381,7 @@ class Training(private val game: Game, private val campaign: Campaign) {
                 }
             }
 
-            return sorted.toMap()
+            return (sorted + witEntry).toMap()
         }
 
         /**

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Training.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Training.kt
@@ -348,6 +348,38 @@ class Training(private val game: Game, private val campaign: Campaign) {
         }
 
         /**
+         * Cross-validate failure chances and return corrected values.
+         *
+         * Failure chances are monotonically non-decreasing in training order
+         * (Speed <= Stamina <= Power <= Guts <= Wit). If an earlier training's
+         * failure chance is significantly lower than the next, it is likely an
+         * OCR misread and should be corrected upward.
+         *
+         * @param failureChances List of ([StatName], failureChance) pairs with valid (>= 0) values.
+         * @param suspiciousJumpThreshold Minimum difference to consider suspicious.
+         * @return Map of [StatName] to corrected failure chance.
+         */
+        fun crossValidateFailureChances(
+            failureChances: List<Pair<StatName, Int>>,
+            suspiciousJumpThreshold: Int = 20,
+        ): Map<StatName, Int> {
+            if (failureChances.size < 2) return failureChances.toMap()
+
+            val sorted = failureChances.sortedBy { it.first.ordinal }.toMutableList()
+
+            // Walk backwards: correct any value that is suspiciously lower than its successor.
+            for (i in sorted.size - 2 downTo 0) {
+                val (currentName, currentChance) = sorted[i]
+                val (_, nextChance) = sorted[i + 1]
+                if (nextChance - currentChance > suspiciousJumpThreshold) {
+                    sorted[i] = currentName to nextChance
+                }
+            }
+
+            return sorted.toMap()
+        }
+
+        /**
          * Score the training option based on friendship bar progress.
          *
          * This method prefers training options with the least relationship progress, specifically focusing on blue bars.
@@ -1348,6 +1380,9 @@ class Training(private val game: Game, private val campaign: Campaign) {
                     }
                 }
 
+                // Cross-validate failure chances across trainings to correct OCR misreads.
+                normalizeFailureChances(analysisResults)
+
                 // Process results and populate training maps.
                 processAnalysisResults(analysisResults, ignoreFailureChance, isIrregularEvaluation, test)
 
@@ -1499,6 +1534,35 @@ class Training(private val game: Game, private val campaign: Campaign) {
         trainingMap.clear()
         skippedTrainingMap.clear()
         restrictedTrainingNames.clear()
+    }
+
+    /**
+     * Cross-validate and normalize failure chances across all training results.
+     *
+     * Failure chances are monotonically non-decreasing in training order
+     * (Speed <= Stamina <= Power <= Guts <= Wit). If an earlier training's
+     * failure chance is significantly lower than the next, it is likely an
+     * OCR misread and should be corrected upward.
+     *
+     * @param results The list of [TrainingAnalysisResult] to normalize.
+     */
+    private fun normalizeFailureChances(results: List<TrainingAnalysisResult>) {
+        val validResults = results.filter { it.failureChance >= 0 }
+        if (validResults.size < 2) return
+
+        val input = validResults.map { it.name to it.failureChance }
+        val corrected = crossValidateFailureChances(input)
+
+        for (result in validResults) {
+            val newValue = corrected[result.name] ?: continue
+            if (newValue != result.failureChance) {
+                MessageLog.w(
+                    TAG,
+                    "[WARN] normalizeFailureChances:: ${result.name} failure chance corrected from ${result.failureChance}% to $newValue% based on cross-validation with neighboring trainings.",
+                )
+                result.failureChance = newValue
+            }
+        }
     }
 
     /**

--- a/android/app/src/test/java/com/steve1316/uma_android_automation/bot/TrainingScoringTest.kt
+++ b/android/app/src/test/java/com/steve1316/uma_android_automation/bot/TrainingScoringTest.kt
@@ -4,6 +4,7 @@ import com.steve1316.uma_android_automation.bot.Training.Companion.calculateMisc
 import com.steve1316.uma_android_automation.bot.Training.Companion.calculateRawTrainingScore
 import com.steve1316.uma_android_automation.bot.Training.Companion.calculateRelationshipScore
 import com.steve1316.uma_android_automation.bot.Training.Companion.calculateStatEfficiencyScore
+import com.steve1316.uma_android_automation.bot.Training.Companion.crossValidateFailureChances
 import com.steve1316.uma_android_automation.bot.Training.Companion.getFinaleStatBonus
 import com.steve1316.uma_android_automation.bot.Training.Companion.getRemainingFinaleRaces
 import com.steve1316.uma_android_automation.bot.Training.Companion.scoreFriendshipTraining
@@ -1196,5 +1197,120 @@ class TrainingScoringTest {
         val score = calculateRawTrainingScore(config, training)
 
         assertTrue(score > 0.0, "Stat at 1060 should be allowed on turn 75 with no finale adjustment (effective cap = 1100)")
+    }
+
+    // ── Cross-validate failure chances ──────────────────────────────────────
+
+    @Test
+    @DisplayName("crossValidateFailureChances corrects OCR misread where Speed is far below Stamina")
+    fun testCrossValidate_bugScenario() {
+        val input =
+            listOf(
+                StatName.SPEED to 1,
+                StatName.STAMINA to 68,
+                StatName.POWER to 70,
+                StatName.GUTS to 73,
+            )
+        val result = crossValidateFailureChances(input)
+        assertEquals(68, result[StatName.SPEED], "Speed should be corrected up to match Stamina")
+        assertEquals(68, result[StatName.STAMINA])
+        assertEquals(70, result[StatName.POWER])
+        assertEquals(73, result[StatName.GUTS])
+    }
+
+    @Test
+    @DisplayName("crossValidateFailureChances corrects a chain of low values")
+    fun testCrossValidate_chainCorrection() {
+        val input =
+            listOf(
+                StatName.SPEED to 1,
+                StatName.STAMINA to 1,
+                StatName.POWER to 68,
+                StatName.GUTS to 73,
+            )
+        val result = crossValidateFailureChances(input)
+        assertEquals(68, result[StatName.SPEED])
+        assertEquals(68, result[StatName.STAMINA])
+        assertEquals(68, result[StatName.POWER])
+        assertEquals(73, result[StatName.GUTS])
+    }
+
+    @Test
+    @DisplayName("crossValidateFailureChances does not correct small differences")
+    fun testCrossValidate_noCorrection() {
+        val input =
+            listOf(
+                StatName.SPEED to 25,
+                StatName.STAMINA to 28,
+                StatName.POWER to 30,
+                StatName.GUTS to 35,
+            )
+        val result = crossValidateFailureChances(input)
+        assertEquals(25, result[StatName.SPEED])
+        assertEquals(28, result[StatName.STAMINA])
+        assertEquals(30, result[StatName.POWER])
+        assertEquals(35, result[StatName.GUTS])
+    }
+
+    @Test
+    @DisplayName("crossValidateFailureChances returns single result unchanged")
+    fun testCrossValidate_singleResult() {
+        val input = listOf(StatName.SPEED to 5)
+        val result = crossValidateFailureChances(input)
+        assertEquals(5, result[StatName.SPEED])
+    }
+
+    @Test
+    @DisplayName("crossValidateFailureChances handles two results with large gap")
+    fun testCrossValidate_twoResultsLargeGap() {
+        val input =
+            listOf(
+                StatName.SPEED to 1,
+                StatName.GUTS to 68,
+            )
+        val result = crossValidateFailureChances(input)
+        assertEquals(68, result[StatName.SPEED], "Speed should be corrected up to match Guts")
+        assertEquals(68, result[StatName.GUTS])
+    }
+
+    @Test
+    @DisplayName("crossValidateFailureChances leaves equal values unchanged")
+    fun testCrossValidate_allEqual() {
+        val input =
+            listOf(
+                StatName.SPEED to 50,
+                StatName.STAMINA to 50,
+                StatName.POWER to 50,
+            )
+        val result = crossValidateFailureChances(input)
+        assertEquals(50, result[StatName.SPEED])
+        assertEquals(50, result[StatName.STAMINA])
+        assertEquals(50, result[StatName.POWER])
+    }
+
+    @Test
+    @DisplayName("crossValidateFailureChances does not correct at exactly the threshold boundary")
+    fun testCrossValidate_exactThreshold() {
+        val input =
+            listOf(
+                StatName.SPEED to 10,
+                StatName.STAMINA to 30,
+            )
+        val result = crossValidateFailureChances(input)
+        assertEquals(10, result[StatName.SPEED], "Difference of exactly 20 should not trigger correction")
+        assertEquals(30, result[StatName.STAMINA])
+    }
+
+    @Test
+    @DisplayName("crossValidateFailureChances corrects just above the threshold boundary")
+    fun testCrossValidate_aboveThreshold() {
+        val input =
+            listOf(
+                StatName.SPEED to 10,
+                StatName.STAMINA to 31,
+            )
+        val result = crossValidateFailureChances(input)
+        assertEquals(31, result[StatName.SPEED], "Difference of 21 should trigger correction")
+        assertEquals(31, result[StatName.STAMINA])
     }
 }

--- a/android/app/src/test/java/com/steve1316/uma_android_automation/bot/TrainingScoringTest.kt
+++ b/android/app/src/test/java/com/steve1316/uma_android_automation/bot/TrainingScoringTest.kt
@@ -1313,4 +1313,33 @@ class TrainingScoringTest {
         assertEquals(31, result[StatName.SPEED], "Difference of 21 should trigger correction")
         assertEquals(31, result[StatName.STAMINA])
     }
+
+    @Test
+    @DisplayName("crossValidateFailureChances excludes Wit from cross-validation")
+    fun testCrossValidate_witExcluded() {
+        val input =
+            listOf(
+                StatName.SPEED to 1,
+                StatName.STAMINA to 68,
+                StatName.POWER to 70,
+                StatName.GUTS to 73,
+                StatName.WIT to 28,
+            )
+        val result = crossValidateFailureChances(input)
+        assertEquals(68, result[StatName.SPEED], "Speed should be corrected up to match Stamina")
+        assertEquals(28, result[StatName.WIT], "Wit should not be affected by cross-validation")
+    }
+
+    @Test
+    @DisplayName("crossValidateFailureChances passes through Wit when only Wit and one other stat present")
+    fun testCrossValidate_witWithSingleStat() {
+        val input =
+            listOf(
+                StatName.SPEED to 5,
+                StatName.WIT to 28,
+            )
+        val result = crossValidateFailureChances(input)
+        assertEquals(5, result[StatName.SPEED], "Speed should be unchanged with only one non-Wit stat")
+        assertEquals(28, result[StatName.WIT], "Wit should be passed through unchanged")
+    }
 }


### PR DESCRIPTION
## Description
- This PR resolves the rest of #262.
- Cross-validate OCR-detected training failure chances across Speed/Stamina/Power/Guts to correct misreads where one training's value is suspiciously lower than its successor.