### PR TITLE
Conserve energy item for emergency race recovery at 3+ consecutive races

### DIFF
--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/Trackblazer.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/Trackblazer.kt
@@ -146,6 +146,7 @@ class Trackblazer(game: Game) : Campaign(game) {
             "Vita 65" to 65,
             "Vita 40" to 40,
             "Vita 20" to 20,
+            "Energy Drink MAX" to 5,
         )
 
     /** Threshold for energy level to use energy items. */
@@ -156,6 +157,12 @@ class Trackblazer(game: Game) : Campaign(game) {
 
     /** Whether to enable Irregular Training in between races during Trackblazer. */
     private val enableIrregularTraining: Boolean = SettingsHelper.getBooleanSetting("scenarioOverrides", "trackblazerEnableIrregularTraining", false)
+
+    /** Ordered list of energy items from lowest to highest gain, used for conservation priority. */
+    private val energyItemConservationOrder = listOf("Energy Drink MAX", "Vita 20", "Vita 40", "Vita 65")
+
+    /** Flag to bypass conservation and force-use the reserved energy item. */
+    private var bForceUseReservedItem: Boolean = false
 
     /** The frequency to check the shop after a race. */
     private val shopCheckFrequency: Int = SettingsHelper.getIntSetting("scenarioOverrides", "trackblazerShopCheckFrequency", 3)
@@ -439,10 +446,18 @@ class Trackblazer(game: Game) : Campaign(game) {
     override fun shouldAllowConsecutiveRace(args: Map<String, Any>): Boolean {
         // Block racing at 0-1 energy with 3+ consecutive races to avoid -30 stat penalty.
         if (trainee.energy <= 1 && consecutiveRaceCount >= 3) {
-            MessageLog.w(
-                TAG,
-                "[WARN] shouldAllowConsecutiveRace:: Energy is critically low (${trainee.energy}%) with $consecutiveRaceCount consecutive races. Blocking to avoid possible -30 stat penalty.",
-            )
+            val conserveItem = energyItemConservationOrder.firstOrNull { (currentInventory[it] ?: 0) > 0 }
+            if (conserveItem != null) {
+                MessageLog.w(
+                    TAG,
+                    "[WARN] shouldAllowConsecutiveRace:: Energy critically low but $conserveItem exists in inventory. This should have been used in decideNextAction(). Blocking race as safety net.",
+                )
+            } else {
+                MessageLog.w(
+                    TAG,
+                    "[WARN] shouldAllowConsecutiveRace:: Energy is critically low (${trainee.energy}%) with $consecutiveRaceCount consecutive races. Blocking to avoid possible -30 stat penalty.",
+                )
+            }
             racing.encounteredRacingPopup = false
             return false
         }
@@ -674,11 +689,46 @@ class Trackblazer(game: Game) : Campaign(game) {
         // can bypass high failure chances that come with low energy.
         val hasCharmAvailable = !bUsedCharmToday && (currentInventory["Good-Luck Charm"] ?: 0) > 0
         if (trainee.energy <= 10 && consecutiveRaceCount >= 3 && !hasCharmAvailable) {
-            MessageLog.w(
-                TAG,
-                "[TRACKBLAZER] Energy is low (${trainee.energy}%) with $consecutiveRaceCount consecutive races and no Good-Luck Charm available. Resting to avoid -30 stat penalty.",
-            )
-            return MainScreenAction.REST
+            // Before resting, attempt to use a conserved energy item for emergency race recovery.
+            val conserveItem = energyItemConservationOrder.firstOrNull { (currentInventory[it] ?: 0) > 0 }
+            if (conserveItem != null) {
+                MessageLog.i(
+                    TAG,
+                    "[TRACKBLAZER] Energy is low (${trainee.energy}%) with $consecutiveRaceCount consecutive races. Using conserved $conserveItem for emergency recovery.",
+                )
+                if (shopList.openTrainingItemsDialog()) {
+                    bForceUseReservedItem = true
+                    val itemsUsed = shopList.useSpecificItems(listOf(conserveItem), reason = "Emergency race recovery to avoid -30 stat penalty.")
+                    bForceUseReservedItem = false
+                    itemsUsed.forEach { (name, _) ->
+                        val gain = energyGains[name] ?: 0
+                        val oldEnergy = trainee.energy
+                        trainee.energy = (trainee.energy + gain).coerceAtMost(100)
+                        useInventoryItem(name)
+                        MessageLog.i(TAG, "[TRACKBLAZER] Emergency recovery: $oldEnergy% -> ${trainee.energy}%.")
+                    }
+                    if (itemsUsed.isNotEmpty()) {
+                        confirmAndCloseItemDialog(itemsUsed.size)
+                    } else {
+                        ButtonClose.click(game.imageUtils)
+                        game.wait(game.dialogWaitDelay)
+                    }
+                }
+
+                if (trainee.energy > 10) {
+                    MessageLog.i(TAG, "[TRACKBLAZER] Energy recovered to ${trainee.energy}%. Resuming normal decision flow.")
+                    // Fall through to normal racing/training logic below.
+                } else {
+                    MessageLog.w(TAG, "[WARN] decideNextAction:: Energy still low (${trainee.energy}%) after emergency recovery. Resting.")
+                    return MainScreenAction.REST
+                }
+            } else {
+                MessageLog.w(
+                    TAG,
+                    "[WARN] decideNextAction:: Energy is low (${trainee.energy}%) with $consecutiveRaceCount consecutive races and no energy items available. Resting to avoid -30 stat penalty.",
+                )
+                return MainScreenAction.REST
+            }
         }
 
         if (enableIrregularTraining && date.year > DateYear.JUNIOR && !bHasCheckedIrregularTrainingThisTurn) {
@@ -1626,6 +1676,15 @@ class Trackblazer(game: Game) : Campaign(game) {
 
         // Energy Items Check.
         if (!charmBeingUsedThisTurn && trainee.energy <= energyThresholdToUseEnergyItems && shopList.energyItemNames.contains(itemName)) {
+            // Conservation: skip the last unit of the lowest-level energy item for race recovery.
+            if (!bForceUseReservedItem && consecutiveRaceCount >= 2) {
+                val conserveItem = energyItemConservationOrder.firstOrNull { (nextInventory[it] ?: 0) > 0 }
+                if (conserveItem == itemName && (nextInventory[itemName] ?: 0) <= 1) {
+                    MessageLog.i(TAG, "[TRACKBLAZER] Conserving last $itemName for emergency race recovery (consecutive races: $consecutiveRaceCount).")
+                    return null
+                }
+            }
+
             if (isBestEnergyItemToUse(trainee, itemName, nextInventory, remainingItemsOfInterest)) {
                 val gain = energyGains[itemName] ?: 0
                 val reason = "Restored energy (current: ${trainee.energy}%) because it fell below the $energyThresholdToUseEnergyItems% threshold."
@@ -1866,13 +1925,20 @@ class Trackblazer(game: Game) : Campaign(game) {
 
         // Collect all available energy items from this scan pass.
         val availableEnergyItems = mutableListOf<Int>()
+        val conserveItem = if (!bForceUseReservedItem && consecutiveRaceCount >= 2) energyItemConservationOrder.firstOrNull { (nextInventory[it] ?: 0) > 0 } else null
         remainingItemsOfInterest.forEach { name ->
             val gain = energyGains[name]
             if (gain != null) {
                 // If this is Kale Juice, only include it if it's usable.
                 if (name == "Royal Kale Juice" && !isKaleJuiceUsable) return@forEach
 
-                val count = (nextInventory[name] ?: 0)
+                var count = (nextInventory[name] ?: 0)
+
+                // Exclude one unit of the conserved item from the greedy pool.
+                if (name == conserveItem && count > 0) {
+                    count--
+                }
+
                 repeat(count) { availableEnergyItems.add(gain) }
             }
         }

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/types/TrackblazerShopList.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/types/TrackblazerShopList.kt
@@ -113,7 +113,7 @@ class TrackblazerShopList(private val game: Game) {
     val statItemNames get() = shopItems.filter { it.value.category == "Stats" }.keys.toList()
 
     /** List of names for items that restore energy. */
-    val energyItemNames get() = listOf("Vita 65", "Vita 40", "Vita 20")
+    val energyItemNames get() = listOf("Vita 65", "Vita 40", "Vita 20", "Energy Drink MAX")
 
     /** List of names for items that heal bad status conditions. */
     val badConditionHealItemNames get() = shopItems.filter { it.value.category == "Heal Bad Conditions" }.keys.toList()
@@ -142,8 +142,8 @@ class TrackblazerShopList(private val game: Game) {
             "Vita 40" to TrackblazerItemInfo(55, "Energy +40", false, "Energy and Motivation"),
             "Vita 65" to TrackblazerItemInfo(75, "Energy +65", false, "Energy and Motivation"),
             "Royal Kale Juice" to TrackblazerItemInfo(70, "Energy +100, Motivation -1", false, "Energy and Motivation"),
-            "Energy Drink MAX" to TrackblazerItemInfo(30, "Maximum energy +4, Energy +5", true, "Energy and Motivation"),
-            "Energy Drink MAX EX" to TrackblazerItemInfo(50, "Maximum energy +8", true, "Energy and Motivation"),
+            "Energy Drink MAX" to TrackblazerItemInfo(30, "Maximum energy +4, Energy +5", false, "Energy and Motivation"),
+            "Energy Drink MAX EX" to TrackblazerItemInfo(50, "Maximum energy +8", false, "Energy and Motivation"),
             "Plain Cupcake" to TrackblazerItemInfo(30, "Motivation +1", true, "Energy and Motivation"),
             "Berry Sweet Cupcake" to TrackblazerItemInfo(55, "Motivation +2", true, "Energy and Motivation"),
             // Bond

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/utils/LogStreamServer.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/utils/LogStreamServer.kt
@@ -108,8 +108,8 @@ object LogStreamServer {
     /** Regex pattern to detect successful energy recovery. */
     private val actionEnergyPattern = Pattern.compile("\\[ENERGY] Successfully recovered energy via (.*)", Pattern.CASE_INSENSITIVE)
 
-    /** Regex pattern to detect energy level updates from item usage. */
-    private val actionEnergyUpdatePattern = Pattern.compile("Trainee energy updated: (\\d+)%\\s*->\\s*(\\d+)%", Pattern.CASE_INSENSITIVE)
+    /** Regex pattern to detect energy level updates from item usage or emergency recovery. */
+    private val actionEnergyUpdatePattern = Pattern.compile("(?:Trainee energy updated|Emergency recovery): (\\d+)%\\s*->\\s*(\\d+)%", Pattern.CASE_INSENSITIVE)
 
     /** Regex pattern to detect injury detection and healing attempts. */
     private val actionInjuryPattern = Pattern.compile("\\[INJURY] Injury detected and attempted to heal")


### PR DESCRIPTION
## Description
- This PR resolves a part of #253.
- Instead of forcing REST when energy is critically low at 3+ consecutive races, the bot now conserves the lowest-level energy item in inventory and uses it for emergency recovery to continue racing to "cheat" the 3+ consecutive race stat penalty.
- `Energy Drink MAX` and `Energy Drink MAX EX` are changed from quick-usage to inventory items so they can be conserved for later.