### PR TITLE
Ignore consecutive race limit on Late December turns

### DIFF
--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/Trackblazer.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/Trackblazer.kt
@@ -457,8 +457,16 @@ class Trackblazer(game: Game) : Campaign(game) {
         val turnsRemaining = game.imageUtils.determineTurnsRemainingBeforeNextGoal()
         val onlyOneTurnLeft = turnsRemaining == 1
 
-        if (consecutiveRaceCount < (consecutiveRacesLimit + 1) || onlyOneTurnLeft) {
-            if (onlyOneTurnLeft && consecutiveRaceCount >= (consecutiveRacesLimit + 1)) {
+        // Late December is the last racing opportunity before a mandatory goal race, so ignore the limit.
+        val isLateDecember = date.month == DateMonth.DECEMBER && date.phase == DatePhase.LATE
+
+        if (consecutiveRaceCount < (consecutiveRacesLimit + 1) || onlyOneTurnLeft || isLateDecember) {
+            if (isLateDecember && consecutiveRaceCount >= (consecutiveRacesLimit + 1)) {
+                MessageLog.i(
+                    TAG,
+                    "[TRACKBLAZER] Consecutive race count $consecutiveRaceCount >= ${consecutiveRacesLimit + 1}, but it is Late December. Ignoring limit to maximize races before mandatory goal race.",
+                )
+            } else if (onlyOneTurnLeft && consecutiveRaceCount >= (consecutiveRacesLimit + 1)) {
                 MessageLog.i(
                     TAG,
                     "[TRACKBLAZER] Consecutive race count $consecutiveRaceCount >= ${consecutiveRacesLimit + 1}, but only 1 turn remains before mandatory race. Racing is safe. Continuing.",


### PR DESCRIPTION
## Description
- This PR resolves a part of #253.
- Late December is the last racing opportunity before a mandatory goal race, so the consecutive race counter threshold is now bypassed on those turns. The energy hard block (0-1% at 3+ races) still applies to prevent the -30 stat penalty.