### PR TITLE
Add energy-based selection for post-race event options

### DIFF
--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/TrainingEvent.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/TrainingEvent.kt
@@ -41,6 +41,7 @@ class TrainingEvent(private val game: Game, private val campaign: Campaign) {
                         EventOverride(
                             selectedOption = eventData.getString("selectedOption"),
                             requiresConfirmation = eventData.getBoolean("requiresConfirmation"),
+                            enableEnergyBasedSelection = eventData.optBoolean("enableEnergyBasedSelection", false),
                         )
                 }
                 overridesMap
@@ -114,8 +115,9 @@ class TrainingEvent(private val game: Game, private val campaign: Campaign) {
      *
      * @property selectedOption The name of the option to select.
      * @property requiresConfirmation Whether the selection requires a confirmation dialog.
+     * @property enableEnergyBasedSelection Whether to dynamically pick options based on trainee energy.
      */
-    data class EventOverride(val selectedOption: String, val requiresConfirmation: Boolean)
+    data class EventOverride(val selectedOption: String, val requiresConfirmation: Boolean, val enableEnergyBasedSelection: Boolean = false)
 
     companion object {
         private val TAG: String = "[${MainActivity.loggerTag}]TrainingEvent"
@@ -138,6 +140,13 @@ class TrainingEvent(private val game: Game, private val campaign: Campaign) {
                 val matches = patterns.any { pattern -> eventTitle.contains(pattern) }
                 if (matches) {
                     MessageLog.v(TAG, "[TRAINING_EVENT] Detected special event: $eventName")
+
+                    // Energy-based selection: pick Option 1 at 0-20% energy, otherwise Option 2.
+                    if (override.enableEnergyBasedSelection) {
+                        val optionIndex = if (campaign.trainee.energy <= 20) 0 else 1
+                        MessageLog.v(TAG, "[TRAINING_EVENT] Energy-based selection for $eventName: energy=${campaign.trainee.energy}%, picking Option ${optionIndex + 1}.")
+                        return Pair(optionIndex, override.requiresConfirmation)
+                    }
 
                     // Parse the option number from the setting (e.g., "Option 5: Energy +10" -> 5).
                     val optionIndex =

--- a/src/components/CustomSelect/index.tsx
+++ b/src/components/CustomSelect/index.tsx
@@ -143,7 +143,7 @@ const CustomSelect: React.FC<CustomSelectProps> = ({
             )}
             <Select onValueChange={handleValueChange} value={value as any} defaultValue={defaultValue as any} disabled={disabled}>
                 <View ref={triggerRef} style={[{ width: width as any }]} onLayout={onTriggerLayout}>
-                    <SelectTrigger style={{ backgroundColor: colors.background, borderColor: colors.border }}>
+                    <SelectTrigger disabled={disabled} style={{ backgroundColor: colors.background, borderColor: colors.border }}>
                         <SelectValue placeholder={value || defaultValue ? (currentLabel ?? "ERROR") : placeholder} style={{ color: colors.foreground }} />
                     </SelectTrigger>
                 </View>

--- a/src/context/BotStateContext.tsx
+++ b/src/context/BotStateContext.tsx
@@ -85,7 +85,7 @@ export interface Settings {
         enableAutomaticOCRRetry: boolean
         ocrConfidence: number
         enableHideOCRComparisonResults: boolean
-        specialEventOverrides: Record<string, { selectedOption: string; requiresConfirmation: boolean }>
+        specialEventOverrides: Record<string, { selectedOption: string; requiresConfirmation: boolean; enableEnergyBasedSelection?: boolean }>
         characterEventOverrides: Record<string, number>
         supportEventOverrides: Record<string, number>
         scenarioEventOverrides: Record<string, number>
@@ -283,14 +283,17 @@ export const defaultSettings: Settings = {
             "Victory!": {
                 selectedOption: "Option 2: Energy -5 and random stat gain",
                 requiresConfirmation: false,
+                enableEnergyBasedSelection: false,
             },
             "Solid Showing": {
                 selectedOption: "Option 2: Energy -5/-20 and random stat gain",
                 requiresConfirmation: false,
+                enableEnergyBasedSelection: false,
             },
             Defeat: {
                 selectedOption: "Option 1: Energy -25 and random stat gain",
                 requiresConfirmation: false,
+                enableEnergyBasedSelection: false,
             },
             "Get Well Soon!": {
                 selectedOption: "Option 2: (Random) Mood -1 / Stat decrease / Get Practice Poor negative status",

--- a/src/pages/TrainingEventSettings/index.tsx
+++ b/src/pages/TrainingEventSettings/index.tsx
@@ -153,7 +153,7 @@ const TrainingEventSettings = () => {
      * @param field The field to update (`selectedOption` or `requiresConfirmation`).
      * @param value The new value for the field.
      */
-    const updateSpecialEventOverride = (eventName: string, field: "selectedOption" | "requiresConfirmation", value: any) => {
+    const updateSpecialEventOverride = (eventName: string, field: "selectedOption" | "requiresConfirmation" | "enableEnergyBasedSelection", value: any) => {
         setSettings({
             ...bsc.settings,
             trainingEvent: {
@@ -770,6 +770,14 @@ const TrainingEventSettings = () => {
                                                     onValueChange={(value) => updateSpecialEventOverride("Victory!", "selectedOption", value)}
                                                     placeholder="Select Option"
                                                     width="100%"
+                                                    disabled={specialEventOverrides["Victory!"]?.enableEnergyBasedSelection || false}
+                                                />
+                                                <CustomCheckbox
+                                                    style={{ marginTop: 12 }}
+                                                    checked={specialEventOverrides["Victory!"]?.enableEnergyBasedSelection || false}
+                                                    onCheckedChange={(checked) => updateSpecialEventOverride("Victory!", "enableEnergyBasedSelection", checked)}
+                                                    label="Energy-based selection"
+                                                    description="Pick Option 1 at 0-20% energy, otherwise Option 2."
                                                 />
                                             </View>
 
@@ -781,6 +789,14 @@ const TrainingEventSettings = () => {
                                                     onValueChange={(value) => updateSpecialEventOverride("Solid Showing", "selectedOption", value)}
                                                     placeholder="Select Option"
                                                     width="100%"
+                                                    disabled={specialEventOverrides["Solid Showing"]?.enableEnergyBasedSelection || false}
+                                                />
+                                                <CustomCheckbox
+                                                    style={{ marginTop: 12 }}
+                                                    checked={specialEventOverrides["Solid Showing"]?.enableEnergyBasedSelection || false}
+                                                    onCheckedChange={(checked) => updateSpecialEventOverride("Solid Showing", "enableEnergyBasedSelection", checked)}
+                                                    label="Energy-based selection"
+                                                    description="Pick Option 1 at 0-20% energy, otherwise Option 2."
                                                 />
                                             </View>
 
@@ -792,6 +808,14 @@ const TrainingEventSettings = () => {
                                                     onValueChange={(value) => updateSpecialEventOverride("Defeat", "selectedOption", value)}
                                                     placeholder="Select Option"
                                                     width="100%"
+                                                    disabled={specialEventOverrides["Defeat"]?.enableEnergyBasedSelection || false}
+                                                />
+                                                <CustomCheckbox
+                                                    style={{ marginTop: 12 }}
+                                                    checked={specialEventOverrides["Defeat"]?.enableEnergyBasedSelection || false}
+                                                    onCheckedChange={(checked) => updateSpecialEventOverride("Defeat", "enableEnergyBasedSelection", checked)}
+                                                    label="Energy-based selection"
+                                                    description="Pick Option 1 at 0-20% energy, otherwise Option 2."
                                                 />
                                             </View>
                                         </View>


### PR DESCRIPTION
## Description
- This PR rounds out #253.
- Adds an option to dynamically select post-race choices based on trainee energy in the `Training Event Settings` page inside the `Race Result Events` section under the `Special Event Overrides`. When enabled, Option 1 is picked at 0-20% energy and Option 2 is picked otherwise to gamble on the decreased energy cost. Each race result event (`Victory`, `Solid Showing`, `Defeat`) gets their own checkbox for this.