### PR TITLE
Add dedicated mood display to remote log viewer

### DIFF
--- a/android/app/src/main/assets/log_viewer.html
+++ b/android/app/src/main/assets/log_viewer.html
@@ -1068,13 +1068,43 @@
                 color: #519ffb;
                 border-color: rgba(81, 159, 251, 0.3);
             }
+        .condition-neutral {
+            background: rgba(136, 136, 160, 0.15);
+            color: var(--text-secondary);
+            border-color: rgba(136, 136, 160, 0.3);
+        }
             .condition-empty {
                 font-style: italic;
                 color: var(--text-muted);
                 font-size: 11px;
             }
 
-
+        /* Mood Section */
+        .mood-great {
+            background: rgba(247, 84, 136, 0.15);
+            color: #f75488;
+            border-color: rgba(247, 84, 136, 0.3);
+        }
+        .mood-good {
+            background: rgba(255, 125, 57, 0.15);
+            color: #ff7d39;
+            border-color: rgba(255, 125, 57, 0.3);
+        }
+        .mood-normal {
+            background: rgba(255, 166, 6, 0.15);
+            color: #ffa606;
+            border-color: rgba(255, 166, 6, 0.3);
+        }
+        .mood-bad {
+            background: rgba(16, 137, 247, 0.15);
+            color: #1089f7;
+            border-color: rgba(16, 137, 247, 0.3);
+        }
+        .mood-awful {
+            background: rgba(172, 85, 255, 0.15);
+            color: #ac55ff;
+            border-color: rgba(172, 85, 255, 0.3);
+        }
 
             /* Custom Tooltip */
             .custom-tooltip {
@@ -1284,6 +1314,12 @@
             </table>
                 <!-- Trainee Conditions -->
                 <div class="conditions-section">
+            <div class="condition-group">
+                <div class="condition-group-label">Mood Conditions</div>
+                <div id="moodConditions" class="condition-list">
+                    <span class="condition-empty">Unknown</span>
+                </div>
+            </div>
                     <div class="condition-group">
                         <div class="condition-group-label">Positive Conditions</div>
                         <div id="positiveConditions" class="condition-list">
@@ -2056,6 +2092,7 @@
                     skillPoints: null,
                     date: null,
                     turn: null,
+                    mood: null,
                     stats: {},
                     apts: {},
                     positiveStatuses: null,
@@ -2304,6 +2341,7 @@
                 // Reset conditions.
                 document.getElementById("positiveConditions").innerHTML = '<span class="condition-empty">None</span>'
                 document.getElementById("negativeConditions").innerHTML = '<span class="condition-empty">None</span>'
+                document.getElementById("moodConditions").innerHTML = '<span class="condition-empty">Unknown</span>'
 
                 // Reset dashboard info.
                 document.getElementById("dashboardDate").textContent = "-"
@@ -2519,6 +2557,8 @@
                 if (stateTarget) {
                     if (category === "Name") {
                         stateTarget.name = data.trim()
+                    } else if (category === "Mood") {
+                        stateTarget.mood = data.trim()
                     } else if (category === "Positive Statuses") {
                         stateTarget.positiveStatuses = data.split(", ").map((s) => s.trim())
                     } else if (category === "Negative Statuses") {
@@ -2596,6 +2636,9 @@
                 if (state.skillPoints) {
                     document.getElementById("dashboardSkillPoints").textContent = formatNumberWithCommas(state.skillPoints)
                 }
+                if (state.mood !== null && state.mood !== undefined) {
+                    updateMoodBadge(state.mood)
+                }
                 if (state.positiveStatuses) {
                     updateConditionBadges(document.getElementById("positiveConditions"), state.positiveStatuses, "condition-positive")
                 }
@@ -2663,6 +2706,35 @@
                 }
             }
 
+            /**
+             * Maps a Mood enum name (AWFUL/BAD/NORMAL/GOOD/GREAT) to a badge in the Mood Conditions panel.
+             * @param {string} mood - The mood name from the Mood enum (case-insensitive).
+             */
+            function updateMoodBadge(mood) {
+                const container = document.getElementById("moodConditions")
+                if (!container) return
+
+                const moodConfig = {
+                    AWFUL:  { label: "😞 Awful",  cls: "mood-awful",  tip: "Training Results: -20%, Race Attributes: -4%" },
+                    BAD:    { label: "😕 Bad",    cls: "mood-bad",    tip: "Training Results: -10%, Race Attributes: -2%" },
+                    NORMAL: { label: "😐 Normal", cls: "mood-normal", tip: "Training Results: 0%, Race Attributes: 0%" },
+                    GOOD:   { label: "😊 Good",   cls: "mood-good",   tip: "Training Results: +10%, Race Attributes: 2%" },
+                    GREAT:  { label: "😄 Great",  cls: "mood-great",  tip: "Training Results: +20%, Race Attributes: 4%" }
+                }
+
+                const cfg = moodConfig[mood.toUpperCase()]
+                if (!cfg) return
+
+                container.innerHTML = ""
+
+                const span = document.createElement("span")
+                span.className = "condition-badge " + cfg.cls
+                span.textContent = cfg.label
+                span.title = cfg.tip
+
+                container.appendChild(span)
+            }
+
             /** Helper to update condition badges. */
             function updateConditionBadges(container, statuses, className) {
                 if (!container) return
@@ -2712,6 +2784,12 @@
                         stateTarget.name = data.trim()
                     } else {
                         document.getElementById("dashboardName").textContent = data.trim()
+                    }
+                } else if (category === "Mood") {
+                    if (stateTarget) {
+                        stateTarget.mood = data.trim()
+                    } else {
+                        updateMoodBadge(data.trim())
                     }
                 } else if (category === "Positive Statuses") {
                     const statuses = data.split(", ").map((s) => s.trim())

--- a/android/app/src/main/assets/log_viewer.html
+++ b/android/app/src/main/assets/log_viewer.html
@@ -1068,11 +1068,6 @@
                 color: #519ffb;
                 border-color: rgba(81, 159, 251, 0.3);
             }
-        .condition-neutral {
-            background: rgba(136, 136, 160, 0.15);
-            color: var(--text-secondary);
-            border-color: rgba(136, 136, 160, 0.3);
-        }
             .condition-empty {
                 font-style: italic;
                 color: var(--text-muted);

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/types/Trainee.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/types/Trainee.kt
@@ -905,6 +905,7 @@ class Trainee {
         }
         MessageLog.v(TAG, "[TRAINEE] Stats: $stats")
         MessageLog.v(TAG, "[TRAINEE] Energy: $energy%")
+        MessageLog.v(TAG, "[TRAINEE] Mood: ${mood.name}")
         MessageLog.v(TAG, "[TRAINEE] Fans: $fans")
         MessageLog.v(TAG, "[TRAINEE] Skill Points: $skillPoints")
         val trackString = "Turf=${trackSurfaceAptitudes[TrackSurface.TURF]}, Dirt=${trackSurfaceAptitudes[TrackSurface.DIRT]}"


### PR DESCRIPTION
### Summary
(Originally a part of https://github.com/steve1316/uma-android-automation/pull/264)

Adds a dedicated mood display to the remote log viewer on top of the trainee conditions section to easier identify current mood of the trainee while the bot is running.