### PR TITLE
Optimize final training and items

### DIFF
--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/Trackblazer.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/Trackblazer.kt
@@ -1299,14 +1299,34 @@ class Trackblazer(game: Game) : Campaign(game) {
             training.executeTraining(trainingSelected)
             training.firstTrainingCheck = false
         } else {
-            MessageLog.i(TAG, "[TRACKBLAZER] Still no suitable training found. Backing out to rest/recollect.")
-            ButtonBack.click(game.imageUtils)
-            game.wait(1.0)
-            if (checkMainScreen()) {
-                recoverEnergy()
+            // Most optimal action must be taken if no suitable training is found to avoid a dead/wasted turn.
+            // Resting has 62.5% chance of being +50 energy, Shrine (remove status conditions) has 30% chance in recreation.
+            if (trainee.mood <= Mood.NORMAL || trainee.energy <= 50) {
+                MessageLog.i(TAG, "[TRACKBLAZER] Still no suitable training found. Backing out for recovery.")
+
+                // firstTrainingCheck set to false since to avoid possible rest/recreation looping for next turn.
+                training.firstTrainingCheck = false
+                ButtonBack.click(game.imageUtils)
+                game.wait(1.0)
+
+                if (checkMainScreen()) {
+                    if (trainee.mood == Mood.AWFUL || (trainee.mood <= Mood.NORMAL && trainee.energy >= 20)) {
+                        MessageLog.i(TAG, "[TRACKBLAZER] Mood is ${trainee.mood}. Attempting to recover mood.")
+                        recoverMood()
+                    } else {
+                        MessageLog.i(TAG, "[TRACKBLAZER] Energy is ${trainee.energy}%. Attempting to recover energy.")
+                        recoverEnergy()
+                    }
+                }
+            } else {
+                // Force a training (Only Wit if negative conditions to avoid possible stat reductions such as Slow Metabolism)
+                // 80 Energy is optimal for Wit, as there may be post events that provide additional energy.
+                val forcedStat = if (trainee.energy >= 80 && trainee.currentNegativeStatuses.isNotEmpty()) StatName.SPEED else StatName.WIT
+                MessageLog.i(TAG, "[TRACKBLAZER] Still no suitable training found. Energy (${trainee.energy}%) and Mood (${trainee.mood}) are sufficient. Forcing $forcedStat training.")
+                training.executeTraining(forcedStat)
+                training.firstTrainingCheck = false
             }
         }
-
         bIsIrregularTraining = false
     }
 

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/Trackblazer.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/Trackblazer.kt
@@ -1399,7 +1399,7 @@ class Trackblazer(game: Game) : Campaign(game) {
             false
         }
 
-        // Artisan takes priority before day 73 to burn through them before the finale.
+        // Master takes priority at the finale since it provides a higher bonus (35% vs 20%).
         val hammerToUse = if (date.day < 73) {
             when {
                 canUseArtisanHammer -> "Artisan Cleat Hammer"
@@ -1415,18 +1415,12 @@ class Trackblazer(game: Game) : Campaign(game) {
         }
 
         // Glow Sticks Logic
-        val finaleRaces = listOf(
-            Pair(73, fansOnDay73),
-            Pair(74, fansOnDay74),
-            Pair(75, fansOnDay75)
-        )
-        val highFanFinaleDays = finaleRaces.count { (_, f) -> f >= 20000 }
+        // Day 73+: only use if we have enough to cover remaining finale days.
         val useGlowSticks = if (date.day >= 73) {
-            val remainingHighFanDays = finaleRaces.count { (day, f) -> day >= date.day && f >= 20000 }
-            fans >= 20000 && glowSticksCount >= remainingHighFanDays
+            val remainingFinaleDays = listOf(73, 74, 75).count { it >= date.day }
+            fans >= 20000 && glowSticksCount >= remainingFinaleDays
         } else {
-            // Only use if we have spare sticks beyond what the finale needs
-            fans >= 20000 && glowSticksCount > highFanFinaleDays
+            fans >= 20000 && glowSticksCount > 1
         }
 
         if (hammerToUse != null || useGlowSticks) {
@@ -1453,11 +1447,11 @@ class Trackblazer(game: Game) : Campaign(game) {
                 }
             }
         } else {
-            if (date.day == 73 && (masterHammerCount > 0 || artisanHammerCount > 0 || glowSticksCount > 0)) {
+            if (date.day == 73 && (masterHammerCount > 0 || glowSticksCount > 0)) {
                 MessageLog.i(
                     TAG,
                     "[TRACKBLAZER] Conserving race items for Semi-Final/Final (turns 74-75). " +
-                        "Hammer: ${masterHammerCount + artisanHammerCount}, Glow Sticks: $glowSticksCount.",
+                        "Master Hammer: $masterHammerCount, Artisan Hammer: $artisanHammerCount, Glow Sticks: $glowSticksCount.",
                 )
             } else {
                 MessageLog.i(TAG, "[TRACKBLAZER] No relevant race items in cached inventory for $grade.")

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/Trackblazer.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/Trackblazer.kt
@@ -1263,7 +1263,9 @@ class Trackblazer(game: Game) : Campaign(game) {
         // Reset Whistle Check: Use if recommendations are poor.
         // We define "poor" as no training being selected or certain other conditions.
         // Block whistling during irregular training evaluations.
-        if (date.day >= 13 && !bUsedWhistleToday && trainingSelected == null && !bIsIrregularTraining && !training.needsEnergyRecovery) {
+
+        // Limit automated whistle usage to during summer or near end of senior (Turns 37-40, >60)
+        if ((date.day in 37..40 || date.day > 60) && !bUsedWhistleToday && trainingSelected == null && !bIsIrregularTraining && !training.needsEnergyRecovery) {
             val hasWhistle = (currentInventory["Reset Whistle"] ?: 0) > 0
             if (hasWhistle) {
                 MessageLog.i(TAG, "[TRACKBLAZER] No suitable training found. Using Reset Whistle.")
@@ -1304,7 +1306,7 @@ class Trackblazer(game: Game) : Campaign(game) {
             if (trainee.mood <= Mood.NORMAL || trainee.energy <= 50) {
                 MessageLog.i(TAG, "[TRACKBLAZER] Still no suitable training found. Backing out for recovery.")
 
-                // firstTrainingCheck set to false since to avoid possible rest/recreation looping for next turn.
+                // firstTrainingCheck is false since there is no suitable training (breaks looping on recovery/energy)
                 training.firstTrainingCheck = false
                 ButtonBack.click(game.imageUtils)
                 game.wait(1.0)
@@ -1327,6 +1329,7 @@ class Trackblazer(game: Game) : Campaign(game) {
                 training.firstTrainingCheck = false
             }
         }
+
         bIsIrregularTraining = false
     }
 
@@ -1343,7 +1346,7 @@ class Trackblazer(game: Game) : Campaign(game) {
         if (date.bIsFinaleSeason && (date.day == 73 || date.day == 74 || date.day == 75)) {
             grade = RaceGrade.G1
             racing.lastRaceGrade = RaceGrade.FINALE
-            fans = if (date.day == 75) 30000 else 10000
+            fans = if (date.day == 75) 30000 else 20000
         }
 
         if (grade != null && (grade == RaceGrade.G1 || grade == RaceGrade.G2 || grade == RaceGrade.G3)) {
@@ -1370,50 +1373,61 @@ class Trackblazer(game: Game) : Campaign(game) {
         val artisanHammerCount = currentInventory["Artisan Cleat Hammer"] ?: 0
         val glowSticksCount = currentInventory["Glow Sticks"] ?: 0
 
-        val hasMasterHammer =
-            if (date.day == 73) {
-                // Save the last Master Cleat Hammer for the Semi-Final and Final (turns 74-75).
-                masterHammerCount >= 2
-            } else {
-                masterHammerCount > 0
-            }
-        val hasArtisanHammer =
-            if (date.day == 73) {
-                // Save the last Artisan Cleat Hammer for the Semi-Final and Final (turns 74-75).
-                artisanHammerCount >= 2
-            } else {
-                artisanHammerCount > 0
-            }
-        val hasGlowSticks =
-            if (date.day in 73..74) {
-                // Save the last Glow Stick for the Finals (turn 75).
-                glowSticksCount >= 2
-            } else {
-                glowSticksCount > 0
-            }
+        // Always reserve 2 master hammers for the finale (days 73-75)
+        val spareMasterHammers = (masterHammerCount - 2).coerceAtLeast(0)
 
-        val hammerToUse =
-            if (grade == RaceGrade.G1) {
-                if (hasMasterHammer) {
-                    "Master Cleat Hammer"
-                } else if (hasArtisanHammer) {
-                    "Artisan Cleat Hammer"
-                } else {
-                    null
-                }
-            } else if (grade == RaceGrade.G2 || grade == RaceGrade.G3) {
-                if (hasArtisanHammer) "Artisan Cleat Hammer" else null
-            } else {
-                null
-            }
+        // Master Hammer Logic
+        val canUseMasterHammer = if (date.day < 73) {
+            // Only use spare masters beyond the 2 reserved for the finale
+            spareMasterHammers > 0 && (grade == RaceGrade.G1 || grade == RaceGrade.G2)
+        } else {
+            // Ensure we still have enough for remaining finale days.
+            val remainingFinaleDays = listOf(73, 74, 75).count { it >= date.day }
+            val hasEnough = masterHammerCount > remainingFinaleDays.coerceAtMost(masterHammerCount - 1).coerceAtLeast(0)
+            hasEnough && grade == RaceGrade.G1
+        }
 
-        val useGlowSticks =
-            if (date.day >= 73) {
-                // During Finale races (turns 73-75), ignore the standard 20k fan requirement.
-                grade == RaceGrade.G1 && hasGlowSticks
-            } else {
-                grade == RaceGrade.G1 && fans >= 20000 && hasGlowSticks
+        // Artisan Hammer Logic
+        // Grade priority: G1 > G2 > G3, with G3 only allowed if 3+ artisan hammers.
+        val canUseArtisanHammer = if (artisanHammerCount >= 3) {
+            true
+        } else if (artisanHammerCount >= 2) {
+            grade == RaceGrade.G1 || grade == RaceGrade.G2
+        } else if (artisanHammerCount == 1) {
+            grade == RaceGrade.G1
+        } else {
+            false
+        }
+
+        // Artisan takes priority before day 73 to burn through them before the finale.
+        val hammerToUse = if (date.day < 73) {
+            when {
+                canUseArtisanHammer -> "Artisan Cleat Hammer"
+                canUseMasterHammer -> "Master Cleat Hammer"
+                else -> null
             }
+        } else {
+            when {
+                canUseMasterHammer -> "Master Cleat Hammer"
+                canUseArtisanHammer -> "Artisan Cleat Hammer"
+                else -> null
+            }
+        }
+
+        // Glow Sticks Logic
+        val finaleRaces = listOf(
+            Pair(73, fansOnDay73),
+            Pair(74, fansOnDay74),
+            Pair(75, fansOnDay75)
+        )
+        val highFanFinaleDays = finaleRaces.count { (_, f) -> f >= 20000 }
+        val useGlowSticks = if (date.day >= 73) {
+            val remainingHighFanDays = finaleRaces.count { (day, f) -> day >= date.day && f >= 20000 }
+            fans >= 20000 && glowSticksCount >= remainingHighFanDays
+        } else {
+            // Only use if we have spare sticks beyond what the finale needs
+            fans >= 20000 && glowSticksCount > highFanFinaleDays
+        }
 
         if (hammerToUse != null || useGlowSticks) {
             MessageLog.i(TAG, "[TRACKBLAZER] Suitable race items found in inventory (Hammer: $hammerToUse, Glow Sticks: $useGlowSticks). Opening Training Items dialog.")

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/Trackblazer.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/Trackblazer.kt
@@ -1451,7 +1451,7 @@ class Trackblazer(game: Game) : Campaign(game) {
                 MessageLog.i(
                     TAG,
                     "[TRACKBLAZER] Conserving race items for Semi-Final/Final (turns 74-75). " +
-                        "Master Hammer: $masterHammerCount, Artisan Hammer: $artisanHammerCount, Glow Sticks: $glowSticksCount.",
+                        "Hammer: ${masterHammerCount + artisanHammerCount}, Glow Sticks: $glowSticksCount.",
                 )
             } else {
                 MessageLog.i(TAG, "[TRACKBLAZER] No relevant race items in cached inventory for $grade.")


### PR DESCRIPTION
### Summary
(Originally a part of https://github.com/steve1316/uma-android-automation/pull/264)

This pull request optimizes the existing final training section of `Trackblazer.kt` where originally it would only rest if there were no other optimal training options. The existing implementation had a few problems where if training were insufficient enough, it would opt to rest whilst the trainee is at full energy and end up wasting a turn. This update introduces an 'optimization' for the current trainee's conditions to pick a more suitable final training option in order to reduce the chances of a wasted turn.

Also improves the hammer, whistle and glow stick usage to be used efficiently in the finale.