### PR TITLE
Add `ignoreLowEnergyRacingBlock` setting to bypass low-energy race blocking

### DIFF
--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Racing.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Racing.kt
@@ -68,6 +68,9 @@ class Racing(private val game: Game, private val campaign: Campaign) {
     /** Whether to ignore the warning that appears when racing three times in a row. */
     val ignoreConsecutiveRaceWarning = SettingsHelper.getBooleanSetting("racing", "ignoreConsecutiveRaceWarning")
 
+    /** Whether to bypass the low-energy racing block in Trackblazer. */
+    val ignoreLowEnergyRacingBlock = SettingsHelper.getBooleanSetting("racing", "ignoreLowEnergyRacingBlock")
+
     /** The number of days to wait between running extra races. */
     private val daysToRunExtraRaces: Int = SettingsHelper.getIntSetting("racing", "daysToRunExtraRaces")
 

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/Trackblazer.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/Trackblazer.kt
@@ -486,20 +486,27 @@ class Trackblazer(game: Game) : Campaign(game) {
     override fun shouldAllowConsecutiveRace(args: Map<String, Any>): Boolean {
         // Block racing at 0-1 energy with 3+ consecutive races to avoid -30 stat penalty.
         if (trainee.energy <= 1 && consecutiveRaceCount >= 3) {
-            val conserveItem = energyItemConservationOrder.firstOrNull { (currentInventory[it] ?: 0) > 0 }
-            if (conserveItem != null) {
+            if (racing.ignoreLowEnergyRacingBlock) {
                 MessageLog.w(
                     TAG,
-                    "[WARN] shouldAllowConsecutiveRace:: Energy critically low but $conserveItem exists in inventory. This should have been used in decideNextAction(). Blocking race as safety net.",
+                    "[WARN] shouldAllowConsecutiveRace:: Energy critically low (${trainee.energy}%) with $consecutiveRaceCount consecutive races, but ignoreLowEnergyRacingBlock is enabled. Allowing race.",
                 )
             } else {
-                MessageLog.w(
-                    TAG,
-                    "[WARN] shouldAllowConsecutiveRace:: Energy is critically low (${trainee.energy}%) with $consecutiveRaceCount consecutive races. Blocking to avoid possible -30 stat penalty.",
-                )
+                val conserveItem = energyItemConservationOrder.firstOrNull { (currentInventory[it] ?: 0) > 0 }
+                if (conserveItem != null) {
+                    MessageLog.w(
+                        TAG,
+                        "[WARN] shouldAllowConsecutiveRace:: Energy critically low but $conserveItem exists in inventory. This should have been used in decideNextAction(). Blocking race as safety net.",
+                    )
+                } else {
+                    MessageLog.w(
+                        TAG,
+                        "[WARN] shouldAllowConsecutiveRace:: Energy is critically low (${trainee.energy}%) with $consecutiveRaceCount consecutive races. Blocking to avoid possible -30 stat penalty.",
+                    )
+                }
+                racing.encounteredRacingPopup = false
+                return false
             }
-            racing.encounteredRacingPopup = false
-            return false
         }
 
         // A -30 stat penalty can apply starting from 3 consecutive races.

--- a/src/components/MessageLog/index.tsx
+++ b/src/components/MessageLog/index.tsx
@@ -310,6 +310,7 @@ ${longTargetsString}
 👥 Prioritize Farming Fans: ${settings.racing.enableFarmingFans ? "✅" : "❌"}
 ⏰ Modulo Days to Farm Fans: ${settings.racing.enableFarmingFans ? `${settings.racing.daysToRunExtraRaces} days` : "❌"}
 🚫 Ignore Consecutive Race Warning: ${settings.racing.ignoreConsecutiveRaceWarning ? "✅" : "❌"}
+⚡ Ignore Low Energy Racing Block: ${settings.racing.ignoreLowEnergyRacingBlock ? "✅" : "❌"}
 🔄 Disable Race Retries: ${settings.racing.disableRaceRetries ? "✅" : "❌"}
 \t🔄 Allow Daily Free Race Retry: ${settings.racing.enableFreeRaceRetry ? "✅" : "❌"}
 🏁 Stop on Mandatory Race: ${settings.racing.enableStopOnMandatoryRaces ? "✅" : "❌"}

--- a/src/context/BotStateContext.tsx
+++ b/src/context/BotStateContext.tsx
@@ -41,6 +41,7 @@ export interface Settings {
     racing: {
         enableFarmingFans: boolean
         ignoreConsecutiveRaceWarning: boolean
+        ignoreLowEnergyRacingBlock: boolean
         daysToRunExtraRaces: number
         disableRaceRetries: boolean
         enableFreeRaceRetry: boolean
@@ -218,6 +219,7 @@ export const defaultSettings: Settings = {
     racing: {
         enableFarmingFans: false,
         ignoreConsecutiveRaceWarning: false,
+        ignoreLowEnergyRacingBlock: false,
         daysToRunExtraRaces: 5,
         disableRaceRetries: false,
         enableFreeRaceRetry: false,

--- a/src/data/searchConfig.ts
+++ b/src/data/searchConfig.ts
@@ -281,6 +281,12 @@ const searchConfig: SearchOption[] = [
         page: "RacingSettings",
     },
     {
+        id: "ignore-low-energy-racing-block",
+        title: "Ignore Low Energy Racing Block",
+        description: "When enabled, the Trackblazer bot will not block racing when energy is critically low with consecutive races.",
+        page: "RacingSettings",
+    },
+    {
         id: "disable-race-retries",
         title: "Disable Race Retries",
         description: "When enabled, the bot will not retry mandatory races if they fail and will stop.",

--- a/src/pages/RacingSettings/index.tsx
+++ b/src/pages/RacingSettings/index.tsx
@@ -32,6 +32,7 @@ const RacingSettings = () => {
     const {
         enableFarmingFans,
         ignoreConsecutiveRaceWarning,
+        ignoreLowEnergyRacingBlock,
         daysToRunExtraRaces,
         disableRaceRetries,
         enableFreeRaceRetry,
@@ -162,6 +163,17 @@ const RacingSettings = () => {
                                 onCheckedChange={(checked) => updateRacingSetting("ignoreConsecutiveRaceWarning", checked)}
                                 label="Ignore Consecutive Race Warning"
                                 description="When enabled, the bot will ignore the warning popup about consecutive races and continue racing."
+                                className="my-2"
+                            />
+                        </View>
+
+                        <View style={styles.section}>
+                            <CustomCheckbox
+                                searchId="ignore-low-energy-racing-block"
+                                checked={ignoreLowEnergyRacingBlock}
+                                onCheckedChange={(checked) => updateRacingSetting("ignoreLowEnergyRacingBlock", checked)}
+                                label="Ignore Low Energy Racing Block"
+                                description="When enabled, the Trackblazer bot will not block racing when energy is critically low (<=1%) with 3+ consecutive races. Useful to avoid the larger -80 penalty from skipping derby races."
                                 className="my-2"
                             />
                         </View>


### PR DESCRIPTION
## Description
- This PR adds a new toggle `Ignore Low Energy Racing Block` under `Racing Settings` that lets users bypass the critical energy check `(<=1% with 3+ consecutive races)` introduced in `v5.4.7`. This prevents the bot from skipping certain races.