### PR TITLE
Skip Trackblazer grade retry when race retries are disabled

### DIFF
--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Racing.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Racing.kt
@@ -1355,7 +1355,8 @@ class Racing(private val game: Game, private val campaign: Campaign) {
                     game.wait(1.0)
 
                     // After closing the popup, check if we can retry a specific race grade.
-                    if (lastRaceGrade != null &&
+                    if (!disableRaceRetries &&
+                        lastRaceGrade != null &&
                         retryEligibleGrades.contains(lastRaceGrade) &&
                         raceRetries > 0 &&
                         retriesThisRace < maxRetriesPerRace &&
@@ -1367,7 +1368,8 @@ class Racing(private val game: Game, private val campaign: Campaign) {
                             retriesThisRace++
                             raceRetries--
                         }
-                    } else if (lastRaceIsRival &&
+                    } else if (!disableRaceRetries &&
+                        lastRaceIsRival &&
                         lastRaceGrade != null &&
                         retryEligibleGrades.contains(lastRaceGrade) &&
                         !bRetriedCurrentRace &&
@@ -1387,7 +1389,8 @@ class Racing(private val game: Game, private val campaign: Campaign) {
                     }
                 }
 
-                lastRaceGrade != null &&
+                !disableRaceRetries &&
+                    lastRaceGrade != null &&
                     retryEligibleGrades.contains(lastRaceGrade) &&
                     raceRetries > 0 &&
                     retriesThisRace < maxRetriesPerRace &&
@@ -1403,7 +1406,8 @@ class Racing(private val game: Game, private val campaign: Campaign) {
                     }
                 }
 
-                lastRaceIsRival &&
+                !disableRaceRetries &&
+                    lastRaceIsRival &&
                     lastRaceGrade != null &&
                     retryEligibleGrades.contains(lastRaceGrade) &&
                     !bRetriedCurrentRace &&


### PR DESCRIPTION
## Description
- This PR fixes #284, where enabling "Disable Race Retries" in Trackblazer still caused the bot to click Try Again on a lost G1/G2/G3 race because the four `ButtonTryAgainAlt` retry branches in `runRaceWithRetries()` only gated on `raceRetries > 0` and ignored `disableRaceRetries`, which surfaced the `try_again` dialog and triggered the mandatory-race-failure stop. All four branches now additionally require `!disableRaceRetries` so the race loop exits cleanly after a loss when retries are disabled.
