### PR TITLE
Clamp OCR crop region to bitmap bounds to prevent negative-coordinate crash

### DIFF
--- a/android/app/src/main/java/com/steve1316/uma_android_automation/utils/CustomImageUtils.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/utils/CustomImageUtils.kt
@@ -2456,9 +2456,22 @@ class CustomImageUtils(context: Context, private val game: Game) : ImageUtils(co
         ocrEngine: String = "tesseract",
         debugName: String = "",
     ): String {
+        // Clamp the crop region to the bitmap bounds. relX/relY can produce negative coordinates
+        // which would otherwise crash Bitmap.createBitmap with "y must be >= 0".
+        val safeX = x.coerceIn(0, (sourceBitmap.width - 1).coerceAtLeast(0))
+        val safeY = y.coerceIn(0, (sourceBitmap.height - 1).coerceAtLeast(0))
+        val safeWidth = width.coerceAtLeast(1).coerceAtMost(sourceBitmap.width - safeX)
+        val safeHeight = height.coerceAtLeast(1).coerceAtMost(sourceBitmap.height - safeY)
+        if (safeX != x || safeY != y || safeWidth != width || safeHeight != height) {
+            MessageLog.w(
+                TAG,
+                "[WARN] performOCROnRegion:: Crop region ($x, $y, ${width}x$height) clamped to ($safeX, $safeY, ${safeWidth}x$safeHeight) for bitmap ${sourceBitmap.width}x${sourceBitmap.height}${if (debugName.isNotEmpty()) " [$debugName]" else ""}.",
+            )
+        }
+
         // Perform OCR using findText() from ImageUtils.
         return findText(
-            cropRegion = intArrayOf(x, y, width, height),
+            cropRegion = intArrayOf(safeX, safeY, safeWidth, safeHeight),
             grayscale = useGrayscale,
             thresh = useThreshold,
             threshold = threshold.toDouble(),


### PR DESCRIPTION
## Description
- This PR fixes a crash reported where `determineTurnsRemainingBeforeNextGoal()` threw `IllegalArgumentException: y must be >= 0` from `Bitmap.createBitmap` because `relY()` produced a negative coordinate when `LabelEnergy` was detected near the top of the screen. `performOCROnRegion()` now clamps the crop region to the `sourceBitmap` bounds before calling `findText()`, preventing every caller from crashing on out-of-bounds crops.
- If `LabelEnergy` was detected in such a way that it was considered in the negative y area, users may need to re-adjust their template matching and/or display settings.