### PR TITLE
Log every training-selection fallback path with a typed source

### DIFF
--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Training.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Training.kt
@@ -42,12 +42,35 @@ import kotlin.math.pow
  * @property game The [Game] instance for interacting with the game state.
  * @property campaign The [Campaign] instance for accessing campaign-specific data.
  */
+
+/**
+ * Identifies which branch of `recommendTraining` produced the most recent selection so that
+ * callers (and the logs) can distinguish an analysis-driven pick from a fallback pick.
+ */
+enum class SelectionSource {
+    /** Returned the highest-scoring training from `trainingScores` (normal happy path). */
+    ANALYSIS,
+
+    /** Analysis rejected everything; `forceSelection=true` picked the highest-scored skipped training. */
+    FORCED_FROM_SKIPPED,
+
+    /** Analysis rejected everything and no skipped scores existed; `forceSelection=true` defaulted to first non-blacklisted. */
+    FORCED_DEFAULT,
+
+    /** Analysis returned no winner and `forceSelection=false`; first non-blacklisted returned for the caller to handle. */
+    UNFORCED_DEFAULT,
+}
+
 open class Training(protected val game: Game, protected val campaign: Campaign) {
     /** Map to store detected training options. */
     internal var trainingMap: MutableMap<StatName, TrainingOption> = mutableMapOf()
 
     /** Map to store training options that were skipped. */
     internal var skippedTrainingMap: MutableMap<StatName, TrainingOption> = mutableMapOf()
+
+    /** Records which branch of `recommendTraining` produced the most recent selection (analysis vs. fallback). */
+    var lastSelectionSource: SelectionSource? = null
+        private set
 
     /** List of training names that are restricted or unavailable. */
     private var restrictedTrainingNames: MutableSet<StatName> = mutableSetOf()
@@ -1887,11 +1910,43 @@ open class Training(protected val game: Game, protected val campaign: Campaign) 
         val finalScoringMode = if (isIrregularEvaluation) "Trackblazer (Irregular Training)" else scoringMode
         logSelectionReasoning(trainingConfig, finalScoringMode, trainingScores, skippedScores, best, args)
 
-        return best?.name ?: if (forceSelection) {
-            skippedScores.maxByOrNull { it.value }?.key?.name ?: trainingMap.keys.firstOrNull { it !in blacklist }
-        } else {
-            trainingMap.keys.firstOrNull { it !in blacklist }
+        if (best != null) {
+            lastSelectionSource = SelectionSource.ANALYSIS
+            return best.name
         }
+
+        // Analysis produced no winning training. Pick a fallback and log which branch fired so that
+        // a downstream `Selected Training: X` is never preceded by an unexplained "no training selected".
+        if (forceSelection) {
+            val topSkipped = skippedScores.maxByOrNull { it.value }
+            if (topSkipped != null) {
+                val pick = topSkipped.key
+                val mainGain = pick.statGains[pick.name] ?: 0
+                MessageLog.i(
+                    TAG,
+                    "[TRAINING] Analysis rejected all trainings. forceSelection=true → picking highest-scored REJECTED training: " +
+                        "${pick.name} (score=${String.format("%.2f", topSkipped.value)}, fail=${pick.failureChance}%, mainGain=$mainGain). " +
+                        "This selection will execute despite analysis rejection.",
+                )
+                lastSelectionSource = SelectionSource.FORCED_FROM_SKIPPED
+                return pick.name
+            }
+            val defaulted = trainingMap.keys.firstOrNull { it !in blacklist }
+            MessageLog.i(
+                TAG,
+                "[TRAINING] Analysis produced no scored entries. forceSelection=true → defaulting to first non-blacklisted training: ${defaulted ?: "none available"}.",
+            )
+            lastSelectionSource = SelectionSource.FORCED_DEFAULT
+            return defaulted
+        }
+
+        val unforced = trainingMap.keys.firstOrNull { it !in blacklist }
+        MessageLog.i(
+            TAG,
+            "[TRAINING] Analysis returned no winning training. forceSelection=false → returning first non-blacklisted training: ${unforced ?: "none available"}. Caller decides whether to execute.",
+        )
+        lastSelectionSource = SelectionSource.UNFORCED_DEFAULT
+        return unforced
     }
 
     /**
@@ -2254,7 +2309,13 @@ open class Training(protected val game: Game, protected val campaign: Campaign) 
             game.wait(0.5)
             // Acquire the percentages and stat gains for each training.
             analyzeTrainings()
-            trainingSelected = forceStat ?: recommendTraining()
+            trainingSelected =
+                if (forceStat != null) {
+                    MessageLog.i(TAG, "[TRAINING] forceStat override active — selecting $forceStat without running recommendTraining.")
+                    forceStat
+                } else {
+                    recommendTraining()
+                }
 
             if (trainingMap.isEmpty()) {
                 // Check if we should force Wit training during the Finale instead of recovering energy.

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/Trackblazer.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/Trackblazer.kt
@@ -9,6 +9,7 @@ import com.steve1316.uma_android_automation.bot.DialogHandlerResult
 import com.steve1316.uma_android_automation.bot.Game
 import com.steve1316.uma_android_automation.bot.MainScreenAction
 import com.steve1316.uma_android_automation.bot.Racing
+import com.steve1316.uma_android_automation.bot.SelectionSource
 import com.steve1316.uma_android_automation.components.ButtonBack
 import com.steve1316.uma_android_automation.components.ButtonCancel
 import com.steve1316.uma_android_automation.components.ButtonClose
@@ -1051,6 +1052,9 @@ class Trackblazer(game: Game) : Campaign(game) {
                     )
 
                     val bestTraining = training.recommendTraining(args = mapOf("isIrregularEvaluation" to true, "irregularTrainingMinStatGain" to minIrregularGain))
+                    if (bestTraining != null && training.lastSelectionSource != SelectionSource.ANALYSIS) {
+                        MessageLog.i(TAG, "[TRACKBLAZER] Pre-screen evaluation used fallback (${training.lastSelectionSource}): $bestTraining.")
+                    }
 
                     if (bestTraining != null) {
                         // Stay on the training screen in order to perform the training.
@@ -1479,6 +1483,9 @@ class Trackblazer(game: Game) : Campaign(game) {
         if (bIsIrregularTraining) {
             MessageLog.i(TAG, "[TRACKBLAZER] Using existing irregular training analysis (already on Training screen).")
             val trainingSelected: StatName? = training.recommendTraining(args = mapOf("isIrregularEvaluation" to true, "irregularTrainingMinStatGain" to minIrregularGain))
+            if (trainingSelected != null && training.lastSelectionSource != SelectionSource.ANALYSIS) {
+                MessageLog.i(TAG, "[TRACKBLAZER] On-screen evaluation used fallback (${training.lastSelectionSource}): $trainingSelected.")
+            }
 
             // Still use training items (megaphones, ankle weights, charms, energy, stat items, etc.)
             if (date.day >= 13) {
@@ -1509,6 +1516,9 @@ class Trackblazer(game: Game) : Campaign(game) {
         val hasCharm = date.day >= 13 && !bUsedCharmToday && (currentInventory["Good-Luck Charm"] ?: 0) > 0
         training.analyzeTrainings(mapOf("ignoreFailureChance" to hasCharm, "minStatGainForCharm" to minCharmGain))
         var trainingSelected: StatName? = training.recommendTraining()
+        if (trainingSelected != null && training.lastSelectionSource != SelectionSource.ANALYSIS) {
+            MessageLog.i(TAG, "[TRACKBLAZER] Initial training selection used fallback (${training.lastSelectionSource}): $trainingSelected.")
+        }
 
         // Finally, perform a consolidated item usage pass after the training is finalized.
         if (date.day >= 13) {
@@ -1535,6 +1545,20 @@ class Trackblazer(game: Game) : Campaign(game) {
                         MessageLog.i(TAG, "[TRACKBLAZER] Re-analyzing trainings after Reset Whistle.")
                         training.analyzeTrainings(mapOf("ignoreFailureChance" to hasCharm, "minStatGainForCharm" to minCharmGain))
                         trainingSelected = training.recommendTraining(forceSelection = whistleForcesTraining)
+                        when {
+                            trainingSelected == null ->
+                                MessageLog.i(TAG, "[TRACKBLAZER] Reset Whistle re-analysis returned no training; nothing to execute.")
+                            training.lastSelectionSource == SelectionSource.FORCED_FROM_SKIPPED ->
+                                MessageLog.i(
+                                    TAG,
+                                    "[TRACKBLAZER] Reset Whistle re-analysis still rejected all trainings; Whistle Forces Training is enabled, " +
+                                        "so executing forced pick: $trainingSelected. Megaphone (if available) will be applied to this forced selection.",
+                                )
+                            training.lastSelectionSource != SelectionSource.ANALYSIS ->
+                                MessageLog.i(TAG, "[TRACKBLAZER] Reset Whistle re-analysis used fallback (${training.lastSelectionSource}): $trainingSelected.")
+                            else ->
+                                MessageLog.i(TAG, "[TRACKBLAZER] Reset Whistle re-analysis selected: $trainingSelected.")
+                        }
 
                         // Perform another consolidated item usage pass if needed after shuffle.
                         useItems(trainee, trainingSelected)


### PR DESCRIPTION
## Description
- This PR makes every `recommendTraining()` fallback visible in the logs by adding a `SelectionSource` enum (`ANALYSIS`, `FORCED_FROM_SKIPPED`, `FORCED_DEFAULT`, `UNFORCED_DEFAULT`) and emitting a log line whenever analysis returned no winner, so a downstream `Selected Training: X` is never preceded by an unexplained "no training selected" summary.
- It also logs the post-Whistle outcome, the irregular-training fallbacks, and the `forceStat` override in `Trackblazer.kt` and `Training.kt`, so users can tell at a glance whether a pick came from analysis or from `whistleForcesTraining` overriding a charm-rejected training.
