### PR TITLE
Use pass-start energy snapshot so Trackblazer queues all greedy-recommended energy items in one pass

### DIFF
--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/Trackblazer.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/Trackblazer.kt
@@ -1817,6 +1817,10 @@ class Trackblazer(game: Game) : Campaign(game) {
 
         val itemsUsedWithReasons = mutableListOf<Pair<String, String>>()
         val itemNameMapInManage = mutableMapOf<Int, String>()
+        // Snapshot energy at the start of the pass so the energy-item threshold gate stays
+        // open after earlier items in the same pass raise `trainee.energy`. The greedy
+        // selection in `isBestEnergyItemToUse` still drives which specific items are queued.
+        val passStartEnergy = trainee?.energy ?: 0
         shopList.processItemsWithFallback(
             keyExtractor = { entry ->
                 val name = shopList.getShopItemName(entry, ButtonSkillUp.checkDisabled(game.imageUtils, entry.bitmap) == true)
@@ -1893,7 +1897,7 @@ class Trackblazer(game: Game) : Campaign(game) {
                             }
                         } else if (trainee != null) {
                             // Handle Energy, Mood, Ankle Weights, Charm, Megaphones, etc.
-                            val reason = handleInlineUsage(trainee, itemName, entry, isDisabled, trainingSelected, nextInventory, remainingItemsOfInterest)
+                            val reason = handleInlineUsage(trainee, itemName, entry, isDisabled, trainingSelected, nextInventory, remainingItemsOfInterest, passStartEnergy)
                             if (reason != null) {
                                 itemsUsedCount++
                                 itemsUsedWithReasons.add(itemName to reason)
@@ -1986,6 +1990,8 @@ class Trackblazer(game: Game) : Campaign(game) {
      * @param trainingSelected The stat name of the selected training.
      * @param nextInventory The updated inventory map reflecting changes in this pass.
      * @param remainingItemsOfInterest The set of items we are still looking for.
+     * @param passStartEnergy Trainee energy snapshotted at the start of the pass; used by the
+     *   energy-item threshold gate so it does not close mid-pass after earlier items raise energy.
      * @return The specific reason why the item was used, or null if not used.
      */
     private fun handleInlineUsage(
@@ -1996,6 +2002,7 @@ class Trackblazer(game: Game) : Campaign(game) {
         trainingSelected: StatName?,
         nextInventory: MutableMap<String, Int>,
         remainingItemsOfInterest: Set<String>,
+        passStartEnergy: Int,
     ): String? {
         if (isDisabled) return null
 
@@ -2035,7 +2042,7 @@ class Trackblazer(game: Game) : Campaign(game) {
                 (date.day >= 13 && failureChance >= 20 && (nextInventory["Good-Luck Charm"] ?: 0) > 0)
 
         // Energy Items Check.
-        if (!charmBeingUsedThisTurn && trainee.energy <= energyThresholdToUseEnergyItems && shopList.energyItemNames.contains(itemName)) {
+        if (!charmBeingUsedThisTurn && passStartEnergy <= energyThresholdToUseEnergyItems && shopList.energyItemNames.contains(itemName)) {
             // Conservation: always keep the last unit of the lowest-level energy item for emergency race recovery.
             if (!bForceUseReservedItem) {
                 val conserveItem = energyItemConservationOrder.firstOrNull { (nextInventory[it] ?: 0) > 0 }
@@ -2047,7 +2054,7 @@ class Trackblazer(game: Game) : Campaign(game) {
 
             if (isBestEnergyItemToUse(trainee, itemName, nextInventory, remainingItemsOfInterest)) {
                 val gain = energyGains[itemName] ?: 0
-                val reason = "Restored energy (current: ${trainee.energy}%) because it fell below the $energyThresholdToUseEnergyItems% threshold."
+                val reason = "Restored energy (current: ${trainee.energy}%, pass start: $passStartEnergy%) because it fell below the $energyThresholdToUseEnergyItems% threshold."
                 if (clickItemPlusButton(itemName, entry, "[TRACKBLAZER] Queuing $itemName for use (Energy: ${trainee.energy}%, Gain: +$gain).", nextInventory, reason = reason)) {
                     val oldEnergy = trainee.energy
                     trainee.energy = (trainee.energy + gain).coerceAtMost(100)


### PR DESCRIPTION
## Description
- This PR snapshots `trainee.energy` once at the start of each Trackblazer inventory pass and uses that `passStartEnergy` for the energy-item threshold gate in `handleInlineUsage()`, so the gate no longer closes mid-pass after an earlier item raises live energy above the threshold.
- Without this, when energy was 0% and threshold was 0%, only `Vita 20` got queued and `Vita 65` was silently skipped even though `isBestEnergyItemToUse()` would have picked both; the greedy selection logic itself is unchanged.
