### PR TITLE
Debounce formatted settings banner so toggling settings stays snappy with imported data

### DIFF
--- a/src/components/DrawerContent/index.tsx
+++ b/src/components/DrawerContent/index.tsx
@@ -6,7 +6,7 @@ import { Ionicons } from "@expo/vector-icons"
 import { Avatar, AvatarImage } from "../ui/avatar"
 import { markNavigationStart } from "../../lib/performanceLogger"
 import { useTheme } from "../../context/ThemeContext"
-import { BotStateContext } from "../../context/BotStateContext"
+import { ChatContext, BotMetaContext } from "../../context/BotStateContext"
 import { skillPlanSettingsPages } from "../../pages/SkillPlanSettings/config"
 
 interface MenuItem {
@@ -29,7 +29,8 @@ interface MenuItem {
 const DrawerContent: React.FC<DrawerContentComponentProps> = (props) => {
     const { colors } = useTheme()
     const { state, navigation } = props
-    const bsc = useContext(BotStateContext)
+    const { chat } = useContext(ChatContext)
+    const { appVersion } = useContext(BotMetaContext)
     const drawerStatus = useDrawerStatus()
     // Initialize with Settings expanded by default.
     const [expandedSections, setExpandedSections] = useState<Set<string>>(new Set(["Settings"]))
@@ -192,7 +193,7 @@ const DrawerContent: React.FC<DrawerContentComponentProps> = (props) => {
         [colors]
     )
 
-    const askTheDocsEnabled = bsc.settings.chat?.enableAskTheDocs ?? false
+    const askTheDocsEnabled = chat?.enableAskTheDocs ?? false
 
     // Define the menu item configurations for the drawer.
     const menuItems: MenuItem[] = [
@@ -524,7 +525,7 @@ const DrawerContent: React.FC<DrawerContentComponentProps> = (props) => {
                 <View style={styles.header}>
                     <View style={styles.headerTextContainer}>
                         <Text style={styles.headerTitle}>Uma Android Automation</Text>
-                        <Text style={styles.headerSubtitle}>{bsc.appVersion}</Text>
+                        <Text style={styles.headerSubtitle}>{appVersion}</Text>
                     </View>
                     <Avatar alt="UAA" style={{ width: 72, height: 72 }}>
                         <AvatarImage source={require("../../assets/app_icon.png")} />

--- a/src/components/MessageLog/index.tsx
+++ b/src/components/MessageLog/index.tsx
@@ -235,10 +235,10 @@ const MessageLog = () => {
         setShowErrorDialog(true)
     }, [])
 
-    // Format settings when settings change.
-    const formattedSettingsString = useMemo(() => {
-        const settings = bsc.settings
-
+    // Build the formatted settings welcome banner. Pure function of the settings snapshot;
+    // the surrounding effect defers invocation so the heavy template-literal work stays off
+    // the synchronous toggle path.
+    const buildFormattedSettings = useCallback((settings: typeof bsc.settings): string => {
         // Training stat targets by distance.
         const sprintTargetsString = `Sprint: \n\t\tSpeed: ${settings.trainingStatTarget.trainingSprintStatTarget_speedStatTarget}\t\tStamina: ${settings.trainingStatTarget.trainingSprintStatTarget_staminaStatTarget}\t\tPower: ${settings.trainingStatTarget.trainingSprintStatTarget_powerStatTarget}\n\t\tGuts: ${settings.trainingStatTarget.trainingSprintStatTarget_gutsStatTarget}\t\t\tWit: ${settings.trainingStatTarget.trainingSprintStatTarget_witStatTarget}`
         const mileTargetsString = `Mile: \n\t\tSpeed: ${settings.trainingStatTarget.trainingMileStatTarget_speedStatTarget}\t\tStamina: ${settings.trainingStatTarget.trainingMileStatTarget_staminaStatTarget}\t\tPower: ${settings.trainingStatTarget.trainingMileStatTarget_powerStatTarget}\n\t\tGuts: ${settings.trainingStatTarget.trainingMileStatTarget_gutsStatTarget}\t\t\tWit: ${settings.trainingStatTarget.trainingMileStatTarget_witStatTarget}`
@@ -406,12 +406,30 @@ ${longTargetsString}
 🔑 Discord Bot Token: ${settings.discord?.discordToken ? "Configured" : "Not Set"}
 
 ****************************************`
-    }, [bsc.settings])
+    }, [])
+
+    // Debounced state for the formatted settings banner. Recomputing the ~30-line template
+    // literal (including `JSON.parse(racingPlan)` and `Object.keys(...)` over each override map)
+    // synchronously on every settings change was making toggles feel sluggish once the user
+    // imported a populated settings file. We now compute it 250ms after the last settings
+    // change, off the toggle's render commit. The intro/log path keeps using the previous
+    // value until the new one lands; downstream memos bail out via `Object.is`.
+    const [formattedSettingsString, setFormattedSettingsString] = useState<string>(() => buildFormattedSettings(bsc.settings))
+    const formattedStringTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+    useEffect(() => {
+        if (formattedStringTimerRef.current) clearTimeout(formattedStringTimerRef.current)
+        formattedStringTimerRef.current = setTimeout(() => {
+            const next = buildFormattedSettings(bsc.settings)
+            setFormattedSettingsString((prev) => (prev === next ? prev : next))
+        }, 250)
+        return () => {
+            if (formattedStringTimerRef.current) clearTimeout(formattedStringTimerRef.current)
+        }
+    }, [bsc.settings, buildFormattedSettings])
 
     // Persist the formatted string directly to SQLite. The Kotlin runtime is the only consumer
     // (via SettingsHelper.getStringSetting), so writing through `setSettings` would just trigger
     // an extra full re-render of every BotStateContext consumer for each user toggle.
-    // Debounce coalesces bursts of rapid setting changes into a single DB write.
     const formattedStringWriteTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
     useEffect(() => {
         if (formattedStringWriteTimer.current) clearTimeout(formattedStringWriteTimer.current)

--- a/src/components/MessageLog/index.tsx
+++ b/src/components/MessageLog/index.tsx
@@ -2,6 +2,7 @@ import { useContext, useState, useMemo, useCallback, memo, useEffect, useRef } f
 import { MessageLogContext } from "../../context/MessageLogContext"
 import { BotStateContext } from "../../context/BotStateContext"
 import { useSettings } from "../../context/SettingsContext"
+import { databaseManager } from "../../lib/database"
 import { StyleSheet, Text, View, TextInput, TouchableOpacity, Animated } from "react-native"
 import * as Clipboard from "expo-clipboard"
 import { Copy, Plus, Minus, Type, X, ArrowUp, ArrowDown, ArrowUpAZ, ArrowDownZA } from "lucide-react-native"
@@ -407,12 +408,19 @@ ${longTargetsString}
 ****************************************`
     }, [bsc.settings])
 
-    // Save the formatted string to the context for persistence.
+    // Persist the formatted string directly to SQLite. The Kotlin runtime is the only consumer
+    // (via SettingsHelper.getStringSetting), so writing through `setSettings` would just trigger
+    // an extra full re-render of every BotStateContext consumer for each user toggle.
+    // Debounce coalesces bursts of rapid setting changes into a single DB write.
+    const formattedStringWriteTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
     useEffect(() => {
-        bsc.setSettings({
-            ...bsc.settings,
-            misc: { ...bsc.settings.misc, formattedSettingsString: formattedSettingsString },
-        })
+        if (formattedStringWriteTimer.current) clearTimeout(formattedStringWriteTimer.current)
+        formattedStringWriteTimer.current = setTimeout(() => {
+            databaseManager.saveSetting("misc", "formattedSettingsString", formattedSettingsString, true).catch(() => {})
+        }, 250)
+        return () => {
+            if (formattedStringWriteTimer.current) clearTimeout(formattedStringWriteTimer.current)
+        }
     }, [formattedSettingsString])
 
     /**

--- a/src/context/BotStateContext.tsx
+++ b/src/context/BotStateContext.tsx
@@ -456,6 +456,10 @@ export const defaultSettings: Settings = {
 /**
  * Context value interface for the BotState provider.
  * Exposes application-wide state including readiness, settings, and app metadata.
+ * Kept for the three full-settings consumers (`useSettingsManager`, `useSettingsFileManager`,
+ * `MessageLog`'s formatted-string memo). Per-page consumers should subscribe to a slice
+ * context (`RacingContext`, `TrainingContext`, ...) so a single-domain edit doesn't
+ * re-render every page tree.
  */
 export interface BotStateProviderProps {
     /** Whether the bot/app is ready (initialized and settings loaded). */
@@ -479,6 +483,84 @@ export interface BotStateProviderProps {
 }
 
 export const BotStateContext = createContext<BotStateProviderProps>({} as BotStateProviderProps)
+
+/**
+ * Slice updater accepts either a partial slice (merged shallowly) or a functional updater
+ * that receives the previous slice and returns the next. Functional callers always see the
+ * latest slice value, eliminating stale-closure races on rapid taps.
+ */
+type SliceUpdater<T> = (update: Partial<T> | ((prev: T) => T)) => void
+
+/** App metadata + readyStatus + immutable defaultSettings. Updates rarely. */
+export interface BotMetaContextValue {
+    readyStatus: boolean
+    setReadyStatus: (readyStatus: boolean) => void
+    defaultSettings: Settings
+    appName: string
+    setAppName: (appName: string) => void
+    appVersion: string
+    setAppVersion: (appVersion: string) => void
+}
+
+export interface RacingContextValue {
+    racing: Settings["racing"]
+    updateRacing: SliceUpdater<Settings["racing"]>
+}
+
+export interface SkillsContextValue {
+    skills: Settings["skills"]
+    updateSkills: SliceUpdater<Settings["skills"]>
+}
+
+export interface TrainingContextValue {
+    training: Settings["training"]
+    trainingStatTarget: Settings["trainingStatTarget"]
+    updateTraining: SliceUpdater<Settings["training"]>
+    updateTrainingStatTarget: SliceUpdater<Settings["trainingStatTarget"]>
+}
+
+export interface TrainingEventContextValue {
+    trainingEvent: Settings["trainingEvent"]
+    updateTrainingEvent: SliceUpdater<Settings["trainingEvent"]>
+}
+
+export interface GeneralMiscContextValue {
+    general: Settings["general"]
+    misc: Settings["misc"]
+    updateGeneral: SliceUpdater<Settings["general"]>
+    updateMisc: SliceUpdater<Settings["misc"]>
+}
+
+export interface DebugContextValue {
+    debug: Settings["debug"]
+    updateDebug: SliceUpdater<Settings["debug"]>
+}
+
+export interface DiscordContextValue {
+    discord: Settings["discord"]
+    updateDiscord: SliceUpdater<Settings["discord"]>
+}
+
+export interface ChatContextValue {
+    chat: Settings["chat"]
+    updateChat: SliceUpdater<Settings["chat"]>
+}
+
+export interface ScenarioOverridesContextValue {
+    scenarioOverrides: Settings["scenarioOverrides"]
+    updateScenarioOverrides: SliceUpdater<Settings["scenarioOverrides"]>
+}
+
+export const BotMetaContext = createContext<BotMetaContextValue>({} as BotMetaContextValue)
+export const RacingContext = createContext<RacingContextValue>({} as RacingContextValue)
+export const SkillsContext = createContext<SkillsContextValue>({} as SkillsContextValue)
+export const TrainingContext = createContext<TrainingContextValue>({} as TrainingContextValue)
+export const TrainingEventContext = createContext<TrainingEventContextValue>({} as TrainingEventContextValue)
+export const GeneralMiscContext = createContext<GeneralMiscContextValue>({} as GeneralMiscContextValue)
+export const DebugContext = createContext<DebugContextValue>({} as DebugContextValue)
+export const DiscordContext = createContext<DiscordContextValue>({} as DiscordContextValue)
+export const ChatContext = createContext<ChatContextValue>({} as ChatContextValue)
+export const ScenarioOverridesContext = createContext<ScenarioOverridesContextValue>({} as ScenarioOverridesContextValue)
 
 /**
  * Provider component for the BotState context.
@@ -519,7 +601,35 @@ export const BotStateProvider = ({ children }: any): React.ReactElement => {
         }
     }, [])
 
-    // Memoize the provider value to prevent cascading re-renders.
+    // Build a slice-aware updater. Accepts either `Partial<Slice>` (shallow-merged) or
+    // `(prev) => next`. Functional updaters always read the freshest slice, avoiding
+    // stale-closure races when multiple toggles fire in the same React batch.
+    const makeSliceUpdater = useCallback(
+        <K extends keyof Settings>(key: K): SliceUpdater<Settings[K]> =>
+            (update) => {
+                setSettingsWithLogging((prev) => {
+                    const prevSlice = prev[key]
+                    const nextSlice = typeof update === "function" ? (update as (p: Settings[K]) => Settings[K])(prevSlice) : ({ ...prevSlice, ...update } as Settings[K])
+                    if (nextSlice === prevSlice) return prev
+                    return { ...prev, [key]: nextSlice }
+                })
+            },
+        [setSettingsWithLogging]
+    )
+
+    const updateRacing = useMemo(() => makeSliceUpdater("racing"), [makeSliceUpdater])
+    const updateSkills = useMemo(() => makeSliceUpdater("skills"), [makeSliceUpdater])
+    const updateTraining = useMemo(() => makeSliceUpdater("training"), [makeSliceUpdater])
+    const updateTrainingStatTarget = useMemo(() => makeSliceUpdater("trainingStatTarget"), [makeSliceUpdater])
+    const updateTrainingEvent = useMemo(() => makeSliceUpdater("trainingEvent"), [makeSliceUpdater])
+    const updateGeneral = useMemo(() => makeSliceUpdater("general"), [makeSliceUpdater])
+    const updateMisc = useMemo(() => makeSliceUpdater("misc"), [makeSliceUpdater])
+    const updateDebug = useMemo(() => makeSliceUpdater("debug"), [makeSliceUpdater])
+    const updateDiscord = useMemo(() => makeSliceUpdater("discord"), [makeSliceUpdater])
+    const updateChat = useMemo(() => makeSliceUpdater("chat"), [makeSliceUpdater])
+    const updateScenarioOverrides = useMemo(() => makeSliceUpdater("scenarioOverrides"), [makeSliceUpdater])
+
+    // Aggregate (legacy) context value — only the three full-settings consumers should subscribe.
     const providerValues = useMemo<BotStateProviderProps>(
         () => ({
             readyStatus,
@@ -535,5 +645,53 @@ export const BotStateProvider = ({ children }: any): React.ReactElement => {
         [readyStatus, settings, appName, appVersion, setSettingsWithLogging]
     )
 
-    return <BotStateContext.Provider value={providerValues}>{children}</BotStateContext.Provider>
+    // Per-slice values memoized on their own slice reference. An untouched slice keeps a
+    // stable identity across renders, so consumers of that slice's context skip re-rendering
+    // when an unrelated domain mutates.
+    const metaValue = useMemo<BotMetaContextValue>(
+        () => ({ readyStatus, setReadyStatus, defaultSettings, appName, setAppName, appVersion, setAppVersion }),
+        [readyStatus, appName, appVersion]
+    )
+    const racingValue = useMemo<RacingContextValue>(() => ({ racing: settings.racing, updateRacing }), [settings.racing, updateRacing])
+    const skillsValue = useMemo<SkillsContextValue>(() => ({ skills: settings.skills, updateSkills }), [settings.skills, updateSkills])
+    const trainingValue = useMemo<TrainingContextValue>(
+        () => ({ training: settings.training, trainingStatTarget: settings.trainingStatTarget, updateTraining, updateTrainingStatTarget }),
+        [settings.training, settings.trainingStatTarget, updateTraining, updateTrainingStatTarget]
+    )
+    const trainingEventValue = useMemo<TrainingEventContextValue>(() => ({ trainingEvent: settings.trainingEvent, updateTrainingEvent }), [settings.trainingEvent, updateTrainingEvent])
+    const generalMiscValue = useMemo<GeneralMiscContextValue>(
+        () => ({ general: settings.general, misc: settings.misc, updateGeneral, updateMisc }),
+        [settings.general, settings.misc, updateGeneral, updateMisc]
+    )
+    const debugValue = useMemo<DebugContextValue>(() => ({ debug: settings.debug, updateDebug }), [settings.debug, updateDebug])
+    const discordValue = useMemo<DiscordContextValue>(() => ({ discord: settings.discord, updateDiscord }), [settings.discord, updateDiscord])
+    const chatValue = useMemo<ChatContextValue>(() => ({ chat: settings.chat, updateChat }), [settings.chat, updateChat])
+    const scenarioOverridesValue = useMemo<ScenarioOverridesContextValue>(
+        () => ({ scenarioOverrides: settings.scenarioOverrides, updateScenarioOverrides }),
+        [settings.scenarioOverrides, updateScenarioOverrides]
+    )
+
+    return (
+        <BotStateContext.Provider value={providerValues}>
+            <BotMetaContext.Provider value={metaValue}>
+                <GeneralMiscContext.Provider value={generalMiscValue}>
+                    <RacingContext.Provider value={racingValue}>
+                        <SkillsContext.Provider value={skillsValue}>
+                            <TrainingContext.Provider value={trainingValue}>
+                                <TrainingEventContext.Provider value={trainingEventValue}>
+                                    <DebugContext.Provider value={debugValue}>
+                                        <DiscordContext.Provider value={discordValue}>
+                                            <ChatContext.Provider value={chatValue}>
+                                                <ScenarioOverridesContext.Provider value={scenarioOverridesValue}>{children}</ScenarioOverridesContext.Provider>
+                                            </ChatContext.Provider>
+                                        </DiscordContext.Provider>
+                                    </DebugContext.Provider>
+                                </TrainingEventContext.Provider>
+                            </TrainingContext.Provider>
+                        </SkillsContext.Provider>
+                    </RacingContext.Provider>
+                </GeneralMiscContext.Provider>
+            </BotMetaContext.Provider>
+        </BotStateContext.Provider>
+    )
 }

--- a/src/context/BotStateContext.tsx
+++ b/src/context/BotStateContext.tsx
@@ -1,7 +1,25 @@
 import { createContext, useState, useMemo, useCallback } from "react"
 import { startTiming } from "../lib/performanceLogger"
-import racesData from "../data/races.json"
 import { skillPlanSettingsPages } from "../pages/SkillPlanSettings/config"
+
+// Defer parsing the races.json bundle until the racing-plan defaults are first read.
+// This keeps the cold-start path off the main thread until something actually consumes it.
+let _racingDefaultsCache: { plan: string; data: string } | null = null
+const _getRacingDefaults = (): { plan: string; data: string } => {
+    if (_racingDefaultsCache) return _racingDefaultsCache
+    const racesData = require("../data/races.json")
+    _racingDefaultsCache = {
+        plan: JSON.stringify(
+            Object.values(racesData as Record<string, { name: string; date: string }>).map((race, index) => ({
+                raceName: race.name,
+                date: race.date,
+                priority: index,
+            }))
+        ),
+        data: JSON.stringify(racesData),
+    }
+    return _racingDefaultsCache
+}
 
 /**
  * Configuration for an individual skill plan (e.g. preFinals, careerComplete).
@@ -240,14 +258,12 @@ export const defaultSettings: Settings = {
         customAgendaTitle: "",
         enableRacingPlan: false,
         enableMandatoryRacingPlan: false,
-        racingPlan: JSON.stringify(
-            Object.values(racesData).map((race, index) => ({
-                raceName: race.name,
-                date: race.date,
-                priority: index,
-            }))
-        ),
-        racingPlanData: JSON.stringify(racesData),
+        get racingPlan() {
+            return _getRacingDefaults().plan
+        },
+        get racingPlanData() {
+            return _getRacingDefaults().data
+        },
         minFansThreshold: 0,
         preferredTerrain: "Any",
         preferredGrades: ["G1", "G2", "G3"],

--- a/src/context/BotStateContext.tsx
+++ b/src/context/BotStateContext.tsx
@@ -500,6 +500,12 @@ export interface BotMetaContextValue {
     setAppName: (appName: string) => void
     appVersion: string
     setAppVersion: (appVersion: string) => void
+    /**
+     * Bulk settings setter. Exposed here (rather than only via the legacy `BotStateContext`)
+     * so cross-slice writers (e.g., profile overwrite) can mutate without subscribing to the
+     * full settings object, since `setSettings` is a stable callback identity.
+     */
+    setSettings: (settings: Settings | ((prev: Settings) => Settings)) => void
 }
 
 export interface RacingContextValue {
@@ -649,8 +655,8 @@ export const BotStateProvider = ({ children }: any): React.ReactElement => {
     // stable identity across renders, so consumers of that slice's context skip re-rendering
     // when an unrelated domain mutates.
     const metaValue = useMemo<BotMetaContextValue>(
-        () => ({ readyStatus, setReadyStatus, defaultSettings, appName, setAppName, appVersion, setAppVersion }),
-        [readyStatus, appName, appVersion]
+        () => ({ readyStatus, setReadyStatus, defaultSettings, appName, setAppName, appVersion, setAppVersion, setSettings: setSettingsWithLogging }),
+        [readyStatus, appName, appVersion, setSettingsWithLogging]
     )
     const racingValue = useMemo<RacingContextValue>(() => ({ racing: settings.racing, updateRacing }), [settings.racing, updateRacing])
     const skillsValue = useMemo<SkillsContextValue>(() => ({ skills: settings.skills, updateSkills }), [settings.skills, updateSkills])

--- a/src/hooks/useBootstrap.tsx
+++ b/src/hooks/useBootstrap.tsx
@@ -1,6 +1,6 @@
 import { useContext, useEffect, useState, useRef } from "react"
 import { DeviceEventEmitter, AppState, InteractionManager } from "react-native"
-import { BotStateContext, BotStateProviderProps } from "../context/BotStateContext"
+import { BotMetaContext, GeneralMiscContext } from "../context/BotStateContext"
 import { MessageLogContext, MessageLogProviderProps } from "../context/MessageLogContext"
 import { useSettings } from "../context/SettingsContext"
 import { logWithTimestamp, logErrorWithTimestamp } from "../lib/logger"
@@ -15,7 +15,8 @@ export const useBootstrap = () => {
     const [isReady, setIsReady] = useState<boolean>(false)
     const isSavingRef = useRef<boolean>(false)
 
-    const bsc = useContext(BotStateContext) as BotStateProviderProps
+    const { setReadyStatus } = useContext(BotMetaContext)
+    const { general } = useContext(GeneralMiscContext)
     const mlc = useContext(MessageLogContext) as MessageLogProviderProps
 
     // Hook for managing settings persistence.
@@ -212,8 +213,8 @@ export const useBootstrap = () => {
     // Update ready status whenever settings change or app becomes ready.
     useEffect(() => {
         if (isReady) {
-            const scenario = bsc.settings.general.scenario
-            bsc.setReadyStatus(scenario !== "")
+            const scenario = general.scenario
+            setReadyStatus(scenario !== "")
         }
-    }, [isReady, bsc.settings.general.scenario])
+    }, [isReady, general.scenario])
 }

--- a/src/hooks/useBootstrap.tsx
+++ b/src/hooks/useBootstrap.tsx
@@ -1,15 +1,10 @@
 import { useContext, useEffect, useState, useRef } from "react"
-import { DeviceEventEmitter, AppState } from "react-native"
+import { DeviceEventEmitter, AppState, InteractionManager } from "react-native"
 import { BotStateContext, BotStateProviderProps } from "../context/BotStateContext"
 import { MessageLogContext, MessageLogProviderProps } from "../context/MessageLogContext"
 import { useSettings } from "../context/SettingsContext"
 import { logWithTimestamp, logErrorWithTimestamp } from "../lib/logger"
 import { databaseManager, DatabaseRace, DatabaseSkill } from "../lib/database"
-import racesData from "../data/races.json"
-import skillsData from "../data/skills.json"
-import charactersData from "../data/characters.json"
-import supportsData from "../data/supports.json"
-import scenariosData from "../data/scenarios.json"
 
 /**
  * Manages app initialization, settings persistence, and message handling.
@@ -35,7 +30,7 @@ export const useBootstrap = () => {
         return () => messageLogSubscription.remove()
     }, [])
 
-    // Initialize database and populate races data on mount.
+    // Initialize database and populate data after the first paint so the splash can render.
     useEffect(() => {
         const initializeApp = async () => {
             try {
@@ -59,8 +54,21 @@ export const useBootstrap = () => {
             }
         }
 
-        initializeApp()
+        // Defer the heavy JSON parses + DB writes until after the first frame paints.
+        const handle = InteractionManager.runAfterInteractions(() => {
+            initializeApp()
+        })
+        return () => handle.cancel()
     }, [])
+
+    /**
+     * Yield to the UI thread so any pending frame can paint before the next heavy step.
+     * @returns A promise that resolves once interactions are idle.
+     */
+    const yieldToFrame = (): Promise<void> =>
+        new Promise((resolve) => {
+            InteractionManager.runAfterInteractions(() => resolve())
+        })
 
     /**
      * Populate race event data from racing.json into SQLite.
@@ -70,8 +78,11 @@ export const useBootstrap = () => {
         try {
             logWithTimestamp("[Bootstrap] Starting races data population...")
 
+            const racesData = require("../data/races.json")
+            await yieldToFrame()
+
             // Convert races.json data to database format.
-            const races: Array<Omit<DatabaseRace, "id">> = Object.entries(racesData).map(([key, race]) => ({
+            const races: Array<Omit<DatabaseRace, "id">> = Object.entries(racesData).map(([key, race]: [string, any]) => ({
                 key,
                 name: race.name,
                 date: race.date,
@@ -108,8 +119,11 @@ export const useBootstrap = () => {
         try {
             logWithTimestamp("[Bootstrap] Starting skills data population...")
 
+            const skillsData = require("../data/skills.json")
+            await yieldToFrame()
+
             // Convert skills.json data to database format.
-            const skills: Array<Omit<DatabaseSkill, "id">> = Object.entries(skillsData).map(([key, skill]) => ({
+            const skills: Array<Omit<DatabaseSkill, "id">> = Object.entries(skillsData).map(([key, skill]: [string, any]) => ({
                 key,
                 skill_id: skill.id,
                 gene_id: skill.gene_id,
@@ -150,15 +164,22 @@ export const useBootstrap = () => {
         try {
             logWithTimestamp("[Bootstrap] Starting event data population...")
 
-            // Save character event data to SQLite.
+            // Lazy-require each large bundled JSON between yields so each parse and write
+            // happens on its own frame instead of all in one main-thread block.
+            const charactersData = require("../data/characters.json")
+            await yieldToFrame()
             await databaseManager.saveSetting("trainingEvent", "characterEventData", charactersData, true)
             logWithTimestamp(`[Bootstrap] Successfully saved character event data (${Object.keys(charactersData).length} characters) to SQLite`)
+            await yieldToFrame()
 
-            // Save support event data to SQLite.
+            const supportsData = require("../data/supports.json")
+            await yieldToFrame()
             await databaseManager.saveSetting("trainingEvent", "supportEventData", supportsData, true)
             logWithTimestamp(`[Bootstrap] Successfully saved support event data (${Object.keys(supportsData).length} supports) to SQLite`)
+            await yieldToFrame()
 
-            // Save scenario-specific event data to SQLite.
+            const scenariosData = require("../data/scenarios.json")
+            await yieldToFrame()
             await databaseManager.saveSetting("trainingEvent", "scenarioEventData", scenariosData, true)
             logWithTimestamp(`[Bootstrap] Successfully saved scenario-specific event data (${Object.keys(scenariosData).length} scenarios) to SQLite`)
 

--- a/src/hooks/usePerformanceLogging.ts
+++ b/src/hooks/usePerformanceLogging.ts
@@ -3,10 +3,14 @@ import { startTiming, markNavigationEnd } from "../lib/performanceLogger"
 
 /**
  * A custom hook that logs component lifecycle events (mount, unmount, re-render).
- * All logs are gated by `PerformanceLogger.ENABLED`.
+ * All logs are gated by `PerformanceLogger.ENABLED`. In release builds the hook is a no-op
+ * because `__DEV__` is a compile-time constant — the early return makes the rest dead code
+ * for the release bundle, eliminating the per-render `useRef`/`useEffect` overhead.
  * @param componentName - The name of the component to track.
  */
 export const usePerformanceLogging = (componentName: string) => {
+    if (!__DEV__) return
+
     const renderCount = useRef(1)
 
     useEffect(() => {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,19 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
     return twMerge(clsx(inputs))
 }
+
+/**
+ * Shallow element-wise comparison for primitive arrays. Cheaper than the JSON.stringify diff pattern.
+ * @param a First array.
+ * @param b Second array.
+ * @returns True when both arrays have identical lengths and equal elements at each index.
+ */
+export function shallowArrayEqual<T>(a: readonly T[] | undefined | null, b: readonly T[] | undefined | null): boolean {
+    if (a === b) return true
+    if (!a || !b) return false
+    if (a.length !== b.length) return false
+    for (let i = 0; i < a.length; i++) {
+        if (a[i] !== b[i]) return false
+    }
+    return true
+}

--- a/src/pages/DebugSettings/index.tsx
+++ b/src/pages/DebugSettings/index.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useContext, useRef, useState, useEffect } from "react"
 import { View, Text, ScrollView, StyleSheet, NativeModules, Linking, AppState, AppStateStatus } from "react-native"
 import { useTheme } from "../../context/ThemeContext"
-import { BotStateContext } from "../../context/BotStateContext"
+import { DebugContext, BotMetaContext } from "../../context/BotStateContext"
 import CustomSlider from "../../components/CustomSlider"
 import CustomCheckbox from "../../components/CustomCheckbox"
 import CustomTitle from "../../components/CustomTitle"
@@ -22,10 +22,11 @@ import { usePerformanceLogging } from "../../hooks/usePerformanceLogging"
 const DebugSettings = () => {
     usePerformanceLogging("DebugSettings")
     const { colors } = useTheme()
-    const bsc = useContext(BotStateContext)
+    const { debug, updateDebug } = useContext(DebugContext)
+    const { defaultSettings } = useContext(BotMetaContext)
     const scrollViewRef = useRef<ScrollView>(null)
 
-    /** List of all diagnostic debug test property names in bsc.settings.debug. */
+    /** List of all diagnostic debug test property names in debug. */
     const debugTestKeys = [
         "debugMode_startTemplateMatchingTest",
         "debugMode_startSingleTrainingOCRTest",
@@ -54,19 +55,9 @@ const DebugSettings = () => {
                 return acc
             }, {} as any)
 
-            bsc.setSettings({
-                ...bsc.settings,
-                debug: {
-                    ...bsc.settings.debug,
-                    ...updates,
-                },
-            })
+            updateDebug(updates)
         } else {
-            // Just disable the one test.
-            bsc.setSettings({
-                ...bsc.settings,
-                debug: { ...bsc.settings.debug, [key]: false },
-            })
+            updateDebug({ [key]: false } as any)
         }
     }
 
@@ -101,12 +92,12 @@ const DebugSettings = () => {
     }
 
     useEffect(() => {
-        if (bsc.settings.debug.enableRemoteLogViewer) {
+        if (debug.enableRemoteLogViewer) {
             NativeModules.StartModule.getDeviceIpAddress()
                 .then((ip: string) => setDeviceIp(ip))
                 .catch(() => setDeviceIp("<phone-ip>"))
         }
-    }, [bsc.settings.debug.enableRemoteLogViewer])
+    }, [debug.enableRemoteLogViewer])
 
     useEffect(() => {
         checkAccessibilityStatus()
@@ -166,37 +157,28 @@ const DebugSettings = () => {
                             {/* Enable Debug Mode Checkbox */}
                             <CustomCheckbox
                                 searchId="enable-debug-mode"
-                                checked={bsc.settings.debug.enableDebugMode}
+                                checked={debug.enableDebugMode}
                                 onCheckedChange={(checked) => {
-                                    bsc.setSettings({
-                                        ...bsc.settings,
-                                        debug: { ...bsc.settings.debug, enableDebugMode: checked },
-                                    })
+                                    updateDebug({ enableDebugMode: checked })
                                 }}
                                 label="Enable Debug Mode"
                                 description="Allows debugging messages in the log and test images to be created in the /temp/ folder."
                             />
 
-                            {bsc.settings.debug.enableDebugMode && (
+                            {debug.enableDebugMode && (
                                 <WarningContainer style={{ marginTop: 8 }}>⚠️ Significantly extends the average runtime of the bot due to increased IO operations.</WarningContainer>
                             )}
 
                             {/* Template Match Confidence Slider */}
                             <CustomSlider
                                 searchId="template-match-confidence"
-                                value={bsc.settings.debug.templateMatchConfidence}
-                                placeholder={bsc.defaultSettings.debug.templateMatchConfidence}
+                                value={debug.templateMatchConfidence}
+                                placeholder={defaultSettings.debug.templateMatchConfidence}
                                 onValueChange={(value) => {
-                                    bsc.setSettings({
-                                        ...bsc.settings,
-                                        debug: { ...bsc.settings.debug, templateMatchConfidence: value },
-                                    })
+                                    updateDebug({ templateMatchConfidence: value })
                                 }}
                                 onSlidingComplete={(value) => {
-                                    bsc.setSettings({
-                                        ...bsc.settings,
-                                        debug: { ...bsc.settings.debug, templateMatchConfidence: value },
-                                    })
+                                    updateDebug({ templateMatchConfidence: value })
                                 }}
                                 min={0.5}
                                 max={1.0}
@@ -211,19 +193,13 @@ const DebugSettings = () => {
                             {/* Template Match Custom Scale Slider */}
                             <CustomSlider
                                 searchId="template-match-custom-scale"
-                                value={bsc.settings.debug.templateMatchCustomScale}
-                                placeholder={bsc.defaultSettings.debug.templateMatchCustomScale}
+                                value={debug.templateMatchCustomScale}
+                                placeholder={defaultSettings.debug.templateMatchCustomScale}
                                 onValueChange={(value) => {
-                                    bsc.setSettings({
-                                        ...bsc.settings,
-                                        debug: { ...bsc.settings.debug, templateMatchCustomScale: value },
-                                    })
+                                    updateDebug({ templateMatchCustomScale: value })
                                 }}
                                 onSlidingComplete={(value) => {
-                                    bsc.setSettings({
-                                        ...bsc.settings,
-                                        debug: { ...bsc.settings.debug, templateMatchCustomScale: value },
-                                    })
+                                    updateDebug({ templateMatchCustomScale: value })
                                 }}
                                 min={0.5}
                                 max={3.0}
@@ -238,19 +214,13 @@ const DebugSettings = () => {
                             {/* OCR Threshold Slider */}
                             <CustomSlider
                                 searchId="ocr-threshold"
-                                value={bsc.settings.debug.ocrThreshold}
-                                placeholder={bsc.defaultSettings.debug.ocrThreshold}
+                                value={debug.ocrThreshold}
+                                placeholder={defaultSettings.debug.ocrThreshold}
                                 onValueChange={(value: number) => {
-                                    bsc.setSettings({
-                                        ...bsc.settings,
-                                        debug: { ...bsc.settings.debug, ocrThreshold: value },
-                                    })
+                                    updateDebug({ ocrThreshold: value })
                                 }}
                                 onSlidingComplete={(value: number) => {
-                                    bsc.setSettings({
-                                        ...bsc.settings,
-                                        debug: { ...bsc.settings.debug, ocrThreshold: value },
-                                    })
+                                    updateDebug({ ocrThreshold: value })
                                 }}
                                 min={100}
                                 max={255}
@@ -268,35 +238,26 @@ const DebugSettings = () => {
 
                             <CustomCheckbox
                                 searchId="settings-enable-remote-log-viewer"
-                                checked={bsc.settings.debug.enableRemoteLogViewer}
+                                checked={debug.enableRemoteLogViewer}
                                 onCheckedChange={(checked) => {
-                                    bsc.setSettings({
-                                        ...bsc.settings,
-                                        debug: { ...bsc.settings.debug, enableRemoteLogViewer: checked },
-                                    })
+                                    updateDebug({ enableRemoteLogViewer: checked })
                                 }}
                                 label="Enable Remote Log Viewer"
                                 description="Starts an HTTP server on this device when the bot runs. Open the URL shown below in a browser on your computer to view logs in real-time."
                             />
 
-                            <View style={bsc.settings.debug.enableRemoteLogViewer ? {} : { display: "none" }}>
+                            <View style={debug.enableRemoteLogViewer ? {} : { display: "none" }}>
                                 <CustomSlider
                                     searchId="settings-remote-log-viewer-port"
-                                    searchCondition={bsc.settings.debug.enableRemoteLogViewer}
+                                    searchCondition={debug.enableRemoteLogViewer}
                                     parentId="settings-enable-remote-log-viewer"
-                                    value={bsc.settings.debug.remoteLogViewerPort}
-                                    placeholder={bsc.defaultSettings.debug.remoteLogViewerPort}
+                                    value={debug.remoteLogViewerPort}
+                                    placeholder={defaultSettings.debug.remoteLogViewerPort}
                                     onValueChange={(value) => {
-                                        bsc.setSettings({
-                                            ...bsc.settings,
-                                            debug: { ...bsc.settings.debug, remoteLogViewerPort: value },
-                                        })
+                                        updateDebug({ remoteLogViewerPort: value })
                                     }}
                                     onSlidingComplete={(value) => {
-                                        bsc.setSettings({
-                                            ...bsc.settings,
-                                            debug: { ...bsc.settings.debug, remoteLogViewerPort: value },
-                                        })
+                                        updateDebug({ remoteLogViewerPort: value })
                                     }}
                                     min={1024}
                                     max={65535}
@@ -312,9 +273,9 @@ const DebugSettings = () => {
                                         <Text style={styles.infoDescription}>📡 When the bot is running, open this URL in a browser:</Text>
                                         <Text
                                             style={[styles.infoLabel, { marginTop: 8, textDecorationLine: "underline" }]}
-                                            onPress={() => Linking.openURL(`http://${deviceIp === "10.0.2.15" ? "localhost" : deviceIp}:${bsc.settings.debug.remoteLogViewerPort}`)}
+                                            onPress={() => Linking.openURL(`http://${deviceIp === "10.0.2.15" ? "localhost" : deviceIp}:${debug.remoteLogViewerPort}`)}
                                         >
-                                            http://{deviceIp === "10.0.2.15" ? "localhost" : deviceIp}:{bsc.settings.debug.remoteLogViewerPort}
+                                            http://{deviceIp === "10.0.2.15" ? "localhost" : deviceIp}:{debug.remoteLogViewerPort}
                                         </Text>
                                         <Text style={[styles.infoDescription, { marginTop: 8 }]}>Both devices must be on the same WiFi network.</Text>
                                         <Text style={[styles.infoDescription, { marginTop: 8 }]}>
@@ -351,7 +312,7 @@ const DebugSettings = () => {
                                             <Text style={styles.infoDescription}>Run these commands on your computer (port may vary) to use your emulator's localhost URL:</Text>
                                             <Text style={[styles.infoLabel, { marginTop: 8 }]}>
                                                 adb connect localhost:5555{"\n"}
-                                                adb forward tcp:{bsc.settings.debug.remoteLogViewerPort} tcp:{bsc.settings.debug.remoteLogViewerPort}
+                                                adb forward tcp:{debug.remoteLogViewerPort} tcp:{debug.remoteLogViewerPort}
                                             </Text>
                                         </View>
                                     </View>
@@ -365,12 +326,9 @@ const DebugSettings = () => {
                             {/* Enable Screen Recording Checkbox */}
                             <CustomCheckbox
                                 searchId="enable-screen-recording"
-                                checked={bsc.settings.debug.enableScreenRecording}
+                                checked={debug.enableScreenRecording}
                                 onCheckedChange={(checked) => {
-                                    bsc.setSettings({
-                                        ...bsc.settings,
-                                        debug: { ...bsc.settings.debug, enableScreenRecording: checked },
-                                    })
+                                    updateDebug({ enableScreenRecording: checked })
                                 }}
                                 label="Enable Screen Recording"
                                 description="Records the screen while the bot is running. The mp4 file will be saved to the /recordings folder of the app's data directory. Note that performance and battery life may be impacted while recording."
@@ -379,21 +337,15 @@ const DebugSettings = () => {
                             {/* Recording Bit Rate Slider */}
                             <CustomSlider
                                 searchId="recording-bit-rate"
-                                searchCondition={bsc.settings.debug.enableScreenRecording}
+                                searchCondition={debug.enableScreenRecording}
                                 parentId="enable-screen-recording"
-                                value={bsc.settings.debug.recordingBitRate}
-                                placeholder={bsc.defaultSettings.debug.recordingBitRate}
+                                value={debug.recordingBitRate}
+                                placeholder={defaultSettings.debug.recordingBitRate}
                                 onValueChange={(value) => {
-                                    bsc.setSettings({
-                                        ...bsc.settings,
-                                        debug: { ...bsc.settings.debug, recordingBitRate: value },
-                                    })
+                                    updateDebug({ recordingBitRate: value })
                                 }}
                                 onSlidingComplete={(value) => {
-                                    bsc.setSettings({
-                                        ...bsc.settings,
-                                        debug: { ...bsc.settings.debug, recordingBitRate: value },
-                                    })
+                                    updateDebug({ recordingBitRate: value })
                                 }}
                                 min={1}
                                 max={20}
@@ -408,19 +360,16 @@ const DebugSettings = () => {
                             {/* Recording Frame Rate Select */}
                             <CustomSelect
                                 searchId="recording-frame-rate"
-                                searchCondition={bsc.settings.debug.enableScreenRecording}
+                                searchCondition={debug.enableScreenRecording}
                                 parentId="enable-screen-recording"
-                                value={bsc.settings.debug.recordingFrameRate.toString()}
+                                value={debug.recordingFrameRate.toString()}
                                 options={[
                                     { value: "30", label: "30 FPS" },
                                     { value: "60", label: "60 FPS" },
                                 ]}
                                 onValueChange={(value) => {
                                     if (value) {
-                                        bsc.setSettings({
-                                            ...bsc.settings,
-                                            debug: { ...bsc.settings.debug, recordingFrameRate: parseInt(value, 10) },
-                                        })
+                                        updateDebug({ recordingFrameRate: parseInt(value, 10) })
                                     }
                                 }}
                                 label="Recording Frame Rate"
@@ -432,21 +381,15 @@ const DebugSettings = () => {
                             {/* Recording Resolution Scale Slider */}
                             <CustomSlider
                                 searchId="recording-resolution-scale"
-                                searchCondition={bsc.settings.debug.enableScreenRecording}
+                                searchCondition={debug.enableScreenRecording}
                                 parentId="enable-screen-recording"
-                                value={bsc.settings.debug.recordingResolutionScale}
-                                placeholder={bsc.defaultSettings.debug.recordingResolutionScale}
+                                value={debug.recordingResolutionScale}
+                                placeholder={defaultSettings.debug.recordingResolutionScale}
                                 onValueChange={(value) => {
-                                    bsc.setSettings({
-                                        ...bsc.settings,
-                                        debug: { ...bsc.settings.debug, recordingResolutionScale: value },
-                                    })
+                                    updateDebug({ recordingResolutionScale: value })
                                 }}
                                 onSlidingComplete={(value) => {
-                                    bsc.setSettings({
-                                        ...bsc.settings,
-                                        debug: { ...bsc.settings.debug, recordingResolutionScale: value },
-                                    })
+                                    updateDebug({ recordingResolutionScale: value })
                                 }}
                                 min={0.25}
                                 max={1.0}
@@ -510,7 +453,7 @@ const DebugSettings = () => {
                             {/* Checkboxes for enabling Debug Tests */}
                             <CustomCheckbox
                                 searchId="debug-template-matching-test"
-                                checked={bsc.settings.debug.debugMode_startTemplateMatchingTest}
+                                checked={debug.debugMode_startTemplateMatchingTest}
                                 onCheckedChange={(checked) => handleDebugTestToggle("debugMode_startTemplateMatchingTest", checked)}
                                 label="Start Basic Template Matching Test"
                                 description="Disables normal bot operations and starts the template match test. Only on the Home screen and will check if it can find certain essential buttons on the screen. It will also output what scale it had the most success with."
@@ -519,7 +462,7 @@ const DebugSettings = () => {
 
                             <CustomCheckbox
                                 searchId="debug-single-training-ocr-test"
-                                checked={bsc.settings.debug.debugMode_startSingleTrainingOCRTest}
+                                checked={debug.debugMode_startSingleTrainingOCRTest}
                                 onCheckedChange={(checked) => handleDebugTestToggle("debugMode_startSingleTrainingOCRTest", checked)}
                                 label="Start Single Training OCR Test"
                                 description="Disables normal bot operations and starts the single training OCR test. Only on the Training screen and tests the current training on display for stat gains and failure chances."
@@ -528,7 +471,7 @@ const DebugSettings = () => {
 
                             <CustomCheckbox
                                 searchId="debug-comprehensive-training-ocr-test"
-                                checked={bsc.settings.debug.debugMode_startComprehensiveTrainingOCRTest}
+                                checked={debug.debugMode_startComprehensiveTrainingOCRTest}
                                 onCheckedChange={(checked) => handleDebugTestToggle("debugMode_startComprehensiveTrainingOCRTest", checked)}
                                 label="Start Comprehensive Training OCR Test"
                                 description="Disables normal bot operations and starts the comprehensive training OCR test. Only on the Training screen and tests all 5 trainings for their stat gains and failure chances."
@@ -537,7 +480,7 @@ const DebugSettings = () => {
 
                             <CustomCheckbox
                                 searchId="debug-race-list-detection-test"
-                                checked={bsc.settings.debug.debugMode_startRaceListDetectionTest}
+                                checked={debug.debugMode_startRaceListDetectionTest}
                                 onCheckedChange={(checked) => handleDebugTestToggle("debugMode_startRaceListDetectionTest", checked)}
                                 label="Start Race List Detection Test"
                                 description="Disables normal bot operations and starts the Race List detection test. Only on the Race List screen and tests detecting the races with double star predictions currently on display."
@@ -546,7 +489,7 @@ const DebugSettings = () => {
 
                             <CustomCheckbox
                                 searchId="debug-main-screen-update-test"
-                                checked={bsc.settings.debug.debugMode_startMainScreenUpdateTest}
+                                checked={debug.debugMode_startMainScreenUpdateTest}
                                 onCheckedChange={(checked) => handleDebugTestToggle("debugMode_startMainScreenUpdateTest", checked)}
                                 label="Start Main Screen Update Test"
                                 description="Disables normal bot operations and starts the Main Screen update test. This test will go through all Main Screen updates and then print the Trainee information."
@@ -555,7 +498,7 @@ const DebugSettings = () => {
 
                             <CustomCheckbox
                                 searchId="debug-skill-list-buy-test"
-                                checked={bsc.settings.debug.debugMode_startSkillListBuyTest}
+                                checked={debug.debugMode_startSkillListBuyTest}
                                 onCheckedChange={(checked) => handleDebugTestToggle("debugMode_startSkillListBuyTest", checked)}
                                 label="Start Skill List Buy Test"
                                 description="Processes the list of skills in the Skills screen, reads all skills in the list, logs a summary and then logs another summary of which skills it will buy to bring down the current Skill Points as close to zero as possible and then it will stop there without actually doing the buying."
@@ -564,7 +507,7 @@ const DebugSettings = () => {
 
                             <CustomCheckbox
                                 searchId="debug-scrollbar-detection-test"
-                                checked={bsc.settings.debug.debugMode_startScrollBarDetectionTest}
+                                checked={debug.debugMode_startScrollBarDetectionTest}
                                 onCheckedChange={(checked) => handleDebugTestToggle("debugMode_startScrollBarDetectionTest", checked)}
                                 label="Start Scrollbar Detection Test"
                                 description="Disables normal bot operations and starts the Scrollbar detection test. Detects the scrollbar on the current screen and attempts to scroll it up and down to verify functionality."
@@ -573,7 +516,7 @@ const DebugSettings = () => {
 
                             <CustomCheckbox
                                 searchId="debug-trackblazer-race-selection-test"
-                                checked={bsc.settings.debug.debugMode_startTrackblazerRaceSelectionTest}
+                                checked={debug.debugMode_startTrackblazerRaceSelectionTest}
                                 onCheckedChange={(checked) => handleDebugTestToggle("debugMode_startTrackblazerRaceSelectionTest", checked)}
                                 label="Start Trackblazer Race Selection Test"
                                 description="Disables normal bot operations and starts the Trackblazer race selection test. Navigates to the Race List if on the Main Screen and identifies the best race to run, including Rivals."
@@ -582,7 +525,7 @@ const DebugSettings = () => {
 
                             <CustomCheckbox
                                 searchId="debug-trackblazer-inventory-sync-test"
-                                checked={bsc.settings.debug.debugMode_startTrackblazerInventorySyncTest}
+                                checked={debug.debugMode_startTrackblazerInventorySyncTest}
                                 onCheckedChange={(checked) => handleDebugTestToggle("debugMode_startTrackblazerInventorySyncTest", checked)}
                                 label="Start Trackblazer Inventory Sync Test"
                                 description="Disables normal bot operations and starts the Trackblazer inventory sync test. Opens the Training Items dialog if on the Main Screen and logs inventory contents and quick-use intentions."
@@ -591,7 +534,7 @@ const DebugSettings = () => {
 
                             <CustomCheckbox
                                 searchId="debug-trackblazer-buy-items-test"
-                                checked={bsc.settings.debug.debugMode_startTrackblazerBuyItemsTest}
+                                checked={debug.debugMode_startTrackblazerBuyItemsTest}
                                 onCheckedChange={(checked) => handleDebugTestToggle("debugMode_startTrackblazerBuyItemsTest", checked)}
                                 label="Start Trackblazer Buy Items Test"
                                 description="Disables normal bot operations and starts the Trackblazer buy items test. Opens the Shop if on the Main Screen and logs shop contents and purchase intentions without actually buying anything."

--- a/src/pages/DiscordSettings/index.tsx
+++ b/src/pages/DiscordSettings/index.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useContext, useRef, useState, useCallback } from "react"
 import { View, ScrollView, StyleSheet, TextInput, Text } from "react-native"
 import { useTheme } from "../../context/ThemeContext"
-import { BotStateContext, defaultSettings } from "../../context/BotStateContext"
+import { DiscordContext, defaultSettings, Settings } from "../../context/BotStateContext"
 import { SearchPageProvider } from "../../context/SearchPageContext"
 import CustomCheckbox from "../../components/CustomCheckbox"
 import CustomButton from "../../components/CustomButton"
@@ -20,17 +20,15 @@ import { NativeModules } from "react-native"
 const DiscordSettings = () => {
     usePerformanceLogging("DiscordSettings")
     const { colors, isDark } = useTheme()
-    const bsc = useContext(BotStateContext)
+    const { discord, updateDiscord } = useContext(DiscordContext)
     const scrollViewRef = useRef<ScrollView>(null)
 
     // Test connection state.
     const [isTesting, setIsTesting] = useState(false)
     const [testResult, setTestResult] = useState<{ success: boolean; message: string } | null>(null)
 
-    const { settings, setSettings } = bsc
-
     // Merge current Discord settings with defaults to handle missing properties.
-    const discordSettings = { ...defaultSettings.discord, ...settings.discord }
+    const discordSettings = { ...defaultSettings.discord, ...discord }
     const { enableDiscordNotifications, discordToken } = discordSettings
     // Coerce to string since SQLite may store numeric IDs as numbers.
     const discordUserID = String(discordSettings.discordUserID || "")
@@ -42,16 +40,10 @@ const DiscordSettings = () => {
      * @param value The new value for the setting.
      */
     const updateDiscordSetting = useCallback(
-        (key: keyof typeof settings.discord, value: any) => {
-            setSettings({
-                ...bsc.settings,
-                discord: {
-                    ...bsc.settings.discord,
-                    [key]: value,
-                },
-            })
+        (key: keyof Settings["discord"], value: any) => {
+            updateDiscord({ [key]: value } as Partial<Settings["discord"]>)
         },
-        [bsc.settings, setSettings]
+        [updateDiscord]
     )
 
     /**

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -1,7 +1,7 @@
 import * as Application from "expo-application"
 import MessageLog from "../../components/MessageLog"
 import { useContext, useEffect, useRef, useState, useMemo } from "react"
-import { BotStateContext } from "../../context/BotStateContext"
+import { BotMetaContext, GeneralMiscContext } from "../../context/BotStateContext"
 import { useSettings } from "../../context/SettingsContext"
 import { logWithTimestamp, logErrorWithTimestamp } from "../../lib/logger"
 import { Animated, DeviceEventEmitter, StyleSheet, View, NativeModules } from "react-native"
@@ -76,7 +76,8 @@ const Home = () => {
 
     const navigation = useNavigation()
 
-    const bsc = useContext(BotStateContext)
+    const { readyStatus, setReadyStatus, setAppName, setAppVersion } = useContext(BotMetaContext)
+    const { general, updateGeneral } = useContext(GeneralMiscContext)
     const mlc = useContext(MessageLogContext)
     const { saveSettings } = useSettings()
 
@@ -135,8 +136,8 @@ const Home = () => {
      * Checks if the currently selected scenario exists in the available scenarios data.
      */
     const isScenarioValid: boolean = useMemo(() => {
-        return scenarios.some((it) => it.value === bsc.settings.general.scenario)
-    }, [bsc.settings.general.scenario])
+        return scenarios.some((it) => it.value === general.scenario)
+    }, [general.scenario])
 
     /**
      * Fetch device metrics from NativeModule.
@@ -168,8 +169,8 @@ const Home = () => {
         var version = Application.nativeApplicationVersion || "0.0.0"
         version += " (" + (Application.nativeBuildVersion || "0") + ")"
         logWithTimestamp(`Android app ${appName} version is ${version}`)
-        bsc.setAppName(appName)
-        bsc.setAppVersion(version)
+        setAppName(appName)
+        setAppVersion(version)
     }
 
     /**
@@ -178,7 +179,7 @@ const Home = () => {
     const handleButtonPress = async () => {
         if (isRunning) {
             StartModule.stop()
-        } else if (bsc.readyStatus) {
+        } else if (readyStatus) {
             // Check accessibility status first.
             try {
                 const status = await StartModule.getAccessibilityStatus()
@@ -273,7 +274,7 @@ where width and height of the screen is in pixels, and diagonal is the diagonal 
             )
         }
 
-        if (!bsc.readyStatus && !isRunning) {
+        if (!readyStatus && !isRunning) {
             return (
                 <Tooltip delayDuration={150}>
                     <TooltipTrigger>
@@ -314,11 +315,11 @@ where width and height of the screen is in pixels, and diagonal is the diagonal 
                         iconName={getSelectButtonIconName()}
                         options={scenarios}
                         placeholder={deviceMetrics ? "Select a Scenario" : "Not Ready"}
-                        value={bsc.settings.general.scenario}
+                        value={general.scenario}
                         onValueChange={(value) => {
                             const newScenario = value || ""
-                            bsc.setSettings({ ...bsc.settings, general: { ...bsc.settings.general, scenario: newScenario } })
-                            bsc.setReadyStatus(newScenario !== "")
+                            updateGeneral({ scenario: newScenario })
+                            setReadyStatus(newScenario !== "")
                         }}
                         onPress={handleButtonPress}
                     />

--- a/src/pages/LLMSettings/index.tsx
+++ b/src/pages/LLMSettings/index.tsx
@@ -2,7 +2,7 @@ import { useCallback, useContext, useEffect, useMemo, useState } from "react"
 import { View, ScrollView, StyleSheet, Text, TextInput, NativeModules, NativeEventEmitter, Alert, Linking, Pressable } from "react-native"
 import { Check, Trash2 } from "lucide-react-native"
 import { useTheme } from "../../context/ThemeContext"
-import { BotStateContext } from "../../context/BotStateContext"
+import { ChatContext } from "../../context/BotStateContext"
 import CustomButton from "../../components/CustomButton"
 import CustomCheckbox from "../../components/CustomCheckbox"
 import CustomSlider from "../../components/CustomSlider"
@@ -102,8 +102,8 @@ interface DownloadedModel {
  */
 const LLMSettings = () => {
     const { colors } = useTheme()
-    const bsc = useContext(BotStateContext)
-    const enableAskTheDocs = bsc.settings.chat?.enableAskTheDocs ?? false
+    const { chat, updateChat } = useContext(ChatContext)
+    const enableAskTheDocs = chat?.enableAskTheDocs ?? false
     const [downloadState, setDownloadState] = useState<DownloadState | null>(null)
     const [embedderState, setEmbedderState] = useState<DownloadState | null>(null)
     const [embedderReady, setEmbedderReady] = useState(false)
@@ -496,7 +496,7 @@ const LLMSettings = () => {
                 <View style={styles.section}>
                     <CustomCheckbox
                         checked={enableAskTheDocs}
-                        onCheckedChange={(checked) => bsc.setSettings({ ...bsc.settings, chat: { ...bsc.settings.chat, enableAskTheDocs: checked } })}
+                        onCheckedChange={(checked) => updateChat({ enableAskTheDocs: checked })}
                         label="Enable Ask the Docs feature"
                         description="Show the Ask the Docs page in the navigation drawer and reveal the rest of these LLM options. Off by default."
                         searchId="llm-enable-ask-the-docs"

--- a/src/pages/RacingPlanSettings/index.tsx
+++ b/src/pages/RacingPlanSettings/index.tsx
@@ -2,7 +2,7 @@ import { useMemo, useContext, useState, useEffect, useRef } from "react"
 import { View, Text, ScrollView, StyleSheet, TouchableOpacity } from "react-native"
 import { Divider } from "react-native-paper"
 import { useTheme } from "../../context/ThemeContext"
-import { BotStateContext, defaultSettings } from "../../context/BotStateContext"
+import { RacingContext, defaultSettings } from "../../context/BotStateContext"
 import { SearchPageProvider } from "../../context/SearchPageContext"
 import CustomCheckbox from "../../components/CustomCheckbox"
 import CustomButton from "../../components/CustomButton"
@@ -57,13 +57,11 @@ interface PlannedRace {
 const RacingPlanSettings = () => {
     usePerformanceLogging("RacingPlanSettings")
     const { colors } = useTheme()
-    const bsc = useContext(BotStateContext)
+    const { racing, updateRacing } = useContext(RacingContext)
     const scrollViewRef = useRef<ScrollView>(null)
 
-    const { settings, setSettings } = bsc
-
     // Merge current racing settings with defaults to handle missing properties.
-    const racingSettings = { ...defaultSettings.racing, ...settings.racing }
+    const racingSettings = { ...defaultSettings.racing, ...racing }
     const {
         enableRacingPlan,
         enableMandatoryRacingPlan,
@@ -127,25 +125,16 @@ const RacingPlanSettings = () => {
      */
     const updateRacingSetting = (key: string, value: any) => {
         if (key === "enableRacingPlan" && value) {
-            setSettings({
-                ...bsc.settings,
-                racing: {
-                    // The following settings need to be set due to being two distinct racing systems.
-                    ...bsc.settings.racing,
-                    enableFarmingFans: true,
-                    enableForceRacing: false,
-                    enableUserInGameRaceAgenda: false,
-                    enableRacingPlan: true,
-                },
-            })
+            updateRacing((prev) => ({
+                // The following settings need to be set due to being two distinct racing systems.
+                ...prev,
+                enableFarmingFans: true,
+                enableForceRacing: false,
+                enableUserInGameRaceAgenda: false,
+                enableRacingPlan: true,
+            }))
         } else {
-            setSettings({
-                ...bsc.settings,
-                racing: {
-                    ...bsc.settings.racing,
-                    [key]: value,
-                },
-            })
+            updateRacing({ [key]: value } as any)
         }
     }
 

--- a/src/pages/RacingPlanSettings/index.tsx
+++ b/src/pages/RacingPlanSettings/index.tsx
@@ -9,7 +9,6 @@ import CustomButton from "../../components/CustomButton"
 import CustomScrollView from "../../components/CustomScrollView"
 import { Input } from "../../components/ui/input"
 import { CircleCheckBig, Plus, Trash2 } from "lucide-react-native"
-import racesData from "../../data/races.json"
 import PageHeader from "../../components/PageHeader"
 import { usePerformanceLogging } from "../../hooks/usePerformanceLogging"
 import SearchableItem from "../../components/SearchableItem"
@@ -104,8 +103,8 @@ const RacingPlanSettings = () => {
         return racingPlan && racingPlan !== "[]" && typeof racingPlan === "string" ? JSON.parse(racingPlan) : []
     }, [racingPlan])
 
-    // Convert races.json to array.
-    const allRaces: Race[] = useMemo(() => Object.values(racesData), [])
+    // Convert races.json to array. Lazy-required so the parse only happens when this page mounts.
+    const allRaces: Race[] = useMemo(() => Object.values(require("../../data/races.json")) as Race[], [])
 
     // Filter races based on search and preferences.
     const filteredRaces = useMemo(() => {

--- a/src/pages/RacingSettings/index.tsx
+++ b/src/pages/RacingSettings/index.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useContext, useRef } from "react"
+import { useMemo, useContext, useRef, useCallback } from "react"
 import { View, Text, TextInput, ScrollView, StyleSheet } from "react-native"
 import { useNavigation } from "@react-navigation/native"
 import { useTheme } from "../../context/ThemeContext"
@@ -56,28 +56,31 @@ const RacingSettings = () => {
      * @param key The key of the setting to update.
      * @param value The value to set the setting to.
      */
-    const updateRacingSetting = (key: keyof typeof settings.racing, value: any) => {
-        if (key === "enableUserInGameRaceAgenda" && value) {
-            setSettings({
-                ...bsc.settings,
-                racing: {
-                    // Disable the Farming Fans and Racing Plan settings when User In Game Race Agenda is enabled.
-                    ...bsc.settings.racing,
-                    enableFarmingFans: false,
-                    enableUserInGameRaceAgenda: true,
-                    enableRacingPlan: false,
-                },
-            })
-        } else {
-            setSettings({
-                ...bsc.settings,
-                racing: {
-                    ...bsc.settings.racing,
-                    [key]: value,
-                },
-            })
-        }
-    }
+    const updateRacingSetting = useCallback(
+        (key: keyof typeof settings.racing, value: any) => {
+            if (key === "enableUserInGameRaceAgenda" && value) {
+                setSettings((prev) => ({
+                    ...prev,
+                    racing: {
+                        // Disable the Farming Fans and Racing Plan settings when User In Game Race Agenda is enabled.
+                        ...prev.racing,
+                        enableFarmingFans: false,
+                        enableUserInGameRaceAgenda: true,
+                        enableRacingPlan: false,
+                    },
+                }))
+            } else {
+                setSettings((prev) => ({
+                    ...prev,
+                    racing: {
+                        ...prev.racing,
+                        [key]: value,
+                    },
+                }))
+            }
+        },
+        [setSettings]
+    )
 
     const styles = useMemo(
         () =>

--- a/src/pages/RacingSettings/index.tsx
+++ b/src/pages/RacingSettings/index.tsx
@@ -2,7 +2,7 @@ import { useMemo, useContext, useRef, useCallback } from "react"
 import { View, Text, TextInput, ScrollView, StyleSheet } from "react-native"
 import { useNavigation } from "@react-navigation/native"
 import { useTheme } from "../../context/ThemeContext"
-import { BotStateContext, defaultSettings } from "../../context/BotStateContext"
+import { RacingContext, defaultSettings, Settings } from "../../context/BotStateContext"
 import { SearchPageProvider } from "../../context/SearchPageContext"
 import CustomCheckbox from "../../components/CustomCheckbox"
 import CustomSelect from "../../components/CustomSelect"
@@ -23,12 +23,11 @@ const RacingSettings = () => {
     usePerformanceLogging("RacingSettings")
     const { colors } = useTheme()
     const navigation = useNavigation()
-    const bsc = useContext(BotStateContext)
+    const { racing, updateRacing } = useContext(RacingContext)
     const scrollViewRef = useRef<ScrollView>(null)
 
-    const { settings, setSettings } = bsc
     // Merge current racing settings with defaults to handle missing properties.
-    const racingSettings = { ...defaultSettings.racing, ...settings.racing }
+    const racingSettings = { ...defaultSettings.racing, ...racing }
     const {
         enableFarmingFans,
         ignoreConsecutiveRaceWarning,
@@ -57,29 +56,20 @@ const RacingSettings = () => {
      * @param value The value to set the setting to.
      */
     const updateRacingSetting = useCallback(
-        (key: keyof typeof settings.racing, value: any) => {
+        (key: keyof Settings["racing"], value: any) => {
             if (key === "enableUserInGameRaceAgenda" && value) {
-                setSettings((prev) => ({
+                updateRacing((prev) => ({
+                    // Disable Farming Fans and Racing Plan when User In Game Race Agenda is enabled.
                     ...prev,
-                    racing: {
-                        // Disable the Farming Fans and Racing Plan settings when User In Game Race Agenda is enabled.
-                        ...prev.racing,
-                        enableFarmingFans: false,
-                        enableUserInGameRaceAgenda: true,
-                        enableRacingPlan: false,
-                    },
+                    enableFarmingFans: false,
+                    enableUserInGameRaceAgenda: true,
+                    enableRacingPlan: false,
                 }))
             } else {
-                setSettings((prev) => ({
-                    ...prev,
-                    racing: {
-                        ...prev.racing,
-                        [key]: value,
-                    },
-                }))
+                updateRacing({ [key]: value } as Partial<Settings["racing"]>)
             }
         },
-        [setSettings]
+        [updateRacing]
     )
 
     const styles = useMemo(

--- a/src/pages/ScenarioOverridesSettings/index.tsx
+++ b/src/pages/ScenarioOverridesSettings/index.tsx
@@ -2,7 +2,7 @@ import { useMemo, useContext, useRef, useState, useCallback } from "react"
 import { View, Text, ScrollView, StyleSheet, Image, TouchableOpacity } from "react-native"
 import { Divider } from "react-native-paper"
 import { useTheme } from "../../context/ThemeContext"
-import { BotStateContext } from "../../context/BotStateContext"
+import { ScenarioOverridesContext, BotMetaContext, Settings } from "../../context/BotStateContext"
 import { SearchPageProvider } from "../../context/SearchPageContext"
 import CustomSlider from "../../components/CustomSlider"
 import CustomCheckbox from "../../components/CustomCheckbox"
@@ -21,11 +21,9 @@ import trackblazerIcons from "./icons"
 const ScenarioOverridesSettings = () => {
     usePerformanceLogging("ScenarioOverridesSettings")
     const { colors } = useTheme()
-    const bsc = useContext(BotStateContext)
+    const { scenarioOverrides, updateScenarioOverrides } = useContext(ScenarioOverridesContext)
+    const { defaultSettings } = useContext(BotMetaContext)
     const scrollViewRef = useRef<ScrollView>(null)
-
-    const { settings, setSettings } = bsc
-    const { scenarioOverrides } = settings
 
     const [searchQuery, setSearchQuery] = useState("")
 
@@ -43,16 +41,10 @@ const ScenarioOverridesSettings = () => {
      * @param value The value to set the setting to.
      */
     const updateOverrideSetting = useCallback(
-        (key: keyof typeof scenarioOverrides, value: any) => {
-            setSettings((prev) => ({
-                ...prev,
-                scenarioOverrides: {
-                    ...prev.scenarioOverrides,
-                    [key]: value,
-                },
-            }))
+        (key: keyof Settings["scenarioOverrides"], value: any) => {
+            updateScenarioOverrides({ [key]: value } as Partial<Settings["scenarioOverrides"]>)
         },
-        [setSettings]
+        [updateScenarioOverrides]
     )
 
     /**
@@ -113,7 +105,7 @@ const ScenarioOverridesSettings = () => {
                             <CustomSlider
                                 searchId="trackblazer-consecutive-races-limit"
                                 value={scenarioOverrides.trackblazerConsecutiveRacesLimit}
-                                placeholder={bsc.defaultSettings.scenarioOverrides.trackblazerConsecutiveRacesLimit}
+                                placeholder={defaultSettings.scenarioOverrides.trackblazerConsecutiveRacesLimit}
                                 onValueChange={(value) => updateOverrideSetting("trackblazerConsecutiveRacesLimit", value)}
                                 onSlidingComplete={(value) => updateOverrideSetting("trackblazerConsecutiveRacesLimit", value)}
                                 min={3}
@@ -131,7 +123,7 @@ const ScenarioOverridesSettings = () => {
                             <CustomSlider
                                 searchId="trackblazer-energy-threshold"
                                 value={scenarioOverrides.trackblazerEnergyThreshold}
-                                placeholder={bsc.defaultSettings.scenarioOverrides.trackblazerEnergyThreshold}
+                                placeholder={defaultSettings.scenarioOverrides.trackblazerEnergyThreshold}
                                 onValueChange={(value) => updateOverrideSetting("trackblazerEnergyThreshold", value)}
                                 onSlidingComplete={(value) => updateOverrideSetting("trackblazerEnergyThreshold", value)}
                                 min={0}
@@ -149,7 +141,7 @@ const ScenarioOverridesSettings = () => {
                             <CustomSlider
                                 searchId="trackblazer-max-retries-per-race"
                                 value={scenarioOverrides.trackblazerMaxRetriesPerRace}
-                                placeholder={bsc.defaultSettings.scenarioOverrides.trackblazerMaxRetriesPerRace}
+                                placeholder={defaultSettings.scenarioOverrides.trackblazerMaxRetriesPerRace}
                                 onValueChange={(value) => updateOverrideSetting("trackblazerMaxRetriesPerRace", value)}
                                 onSlidingComplete={(value) => updateOverrideSetting("trackblazerMaxRetriesPerRace", value)}
                                 min={0}
@@ -167,7 +159,7 @@ const ScenarioOverridesSettings = () => {
                             <CustomSlider
                                 searchId="trackblazer-min-stat-gain-for-charm"
                                 value={scenarioOverrides.trackblazerMinStatGainForCharm}
-                                placeholder={bsc.defaultSettings.scenarioOverrides.trackblazerMinStatGainForCharm}
+                                placeholder={defaultSettings.scenarioOverrides.trackblazerMinStatGainForCharm}
                                 onValueChange={(value) => updateOverrideSetting("trackblazerMinStatGainForCharm", value)}
                                 onSlidingComplete={(value) => updateOverrideSetting("trackblazerMinStatGainForCharm", value)}
                                 min={20}
@@ -196,7 +188,7 @@ const ScenarioOverridesSettings = () => {
                                 <CustomSlider
                                     searchId="trackblazer-irregular-training-min-stat-gain"
                                     value={scenarioOverrides.trackblazerIrregularTrainingMinStatGain}
-                                    placeholder={bsc.defaultSettings.scenarioOverrides.trackblazerIrregularTrainingMinStatGain}
+                                    placeholder={defaultSettings.scenarioOverrides.trackblazerIrregularTrainingMinStatGain}
                                     onValueChange={(value) => updateOverrideSetting("trackblazerIrregularTrainingMinStatGain", value)}
                                     onSlidingComplete={(value) => updateOverrideSetting("trackblazerIrregularTrainingMinStatGain", value)}
                                     min={20}
@@ -225,7 +217,7 @@ const ScenarioOverridesSettings = () => {
                             <CustomSlider
                                 searchId="trackblazer-shop-check-frequency"
                                 value={scenarioOverrides.trackblazerShopCheckFrequency}
-                                placeholder={bsc.defaultSettings.scenarioOverrides.trackblazerShopCheckFrequency}
+                                placeholder={defaultSettings.scenarioOverrides.trackblazerShopCheckFrequency}
                                 onValueChange={(value) => updateOverrideSetting("trackblazerShopCheckFrequency", value)}
                                 onSlidingComplete={(value) => updateOverrideSetting("trackblazerShopCheckFrequency", value)}
                                 min={1}

--- a/src/pages/Settings/index.tsx
+++ b/src/pages/Settings/index.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useContext, useEffect, useState, useRef, useCallback } from "react"
 import { SearchPageProvider } from "../../context/SearchPageContext"
-import { BotStateContext } from "../../context/BotStateContext"
+import { BotMetaContext, GeneralMiscContext } from "../../context/BotStateContext"
 import { ScrollView, StyleSheet, Text, View } from "react-native"
 import { Snackbar } from "react-native-paper"
 import { useNavigation } from "@react-navigation/native"
@@ -31,7 +31,8 @@ const Settings = () => {
     const [snackbarOpen, setSnackbarOpen] = useState<boolean>(false)
     const scrollViewRef = useRef<ScrollView>(null)
 
-    const bsc = useContext(BotStateContext)
+    const { readyStatus, defaultSettings } = useContext(BotMetaContext)
+    const { general, misc, updateGeneral, updateMisc } = useContext(GeneralMiscContext)
     const { colors } = useTheme()
     const navigation = useNavigation()
 
@@ -60,7 +61,7 @@ const Settings = () => {
         // Manually set this flag to false as the snackbar autohiding does not set this to false automatically.
         setSnackbarOpen(true)
         setTimeout(() => setSnackbarOpen(false), 2500)
-    }, [bsc.readyStatus])
+    }, [readyStatus])
 
     /**
      * Reset the settings to their default values.
@@ -105,7 +106,7 @@ const Settings = () => {
 
     const handleStopAtDateChange = useCallback(
         (index: number, part: "year" | "month" | "phase", value: string) => {
-            const dates = [...bsc.settings.general.stopAtDates]
+            const dates = [...general.stopAtDates]
             const currentParts = dates[index].split(" ")
             let newYear = currentParts[0] || "Senior"
             let newMonth = currentParts[1] || "January"
@@ -116,30 +117,21 @@ const Settings = () => {
             if (part === "phase") newPhase = value
 
             dates[index] = `${newYear} ${newMonth} ${newPhase}`
-            bsc.setSettings({
-                ...bsc.settings,
-                general: { ...bsc.settings.general, stopAtDates: dates },
-            })
+            updateGeneral({ stopAtDates: dates })
         },
-        [bsc]
+        [general]
     )
 
     const handleAddStopAtDate = useCallback(() => {
-        bsc.setSettings({
-            ...bsc.settings,
-            general: { ...bsc.settings.general, stopAtDates: [...bsc.settings.general.stopAtDates, "Senior January Early"] },
-        })
-    }, [bsc])
+        updateGeneral({ stopAtDates: [...general.stopAtDates, "Senior January Early"] })
+    }, [general])
 
     const handleRemoveStopAtDate = useCallback(
         (index: number) => {
-            const dates = bsc.settings.general.stopAtDates.filter((_, i) => i !== index)
-            bsc.setSettings({
-                ...bsc.settings,
-                general: { ...bsc.settings.general, stopAtDates: dates.length > 0 ? dates : ["Senior January Early"] },
-            })
+            const dates = general.stopAtDates.filter((_, i) => i !== index)
+            updateGeneral({ stopAtDates: dates.length > 0 ? dates : ["Senior January Early"] })
         },
-        [bsc]
+        [general]
     )
 
     const renderTrainingLink = () => {
@@ -225,12 +217,9 @@ const Settings = () => {
 
                 <CustomCheckbox
                     searchId="settings-popup-check"
-                    checked={bsc.settings.general.enablePopupCheck}
+                    checked={general.enablePopupCheck}
                     onCheckedChange={(checked) => {
-                        bsc.setSettings({
-                            ...bsc.settings,
-                            general: { ...bsc.settings.general, enablePopupCheck: checked },
-                        })
+                        updateGeneral({ enablePopupCheck: checked })
                     }}
                     label="Stop on Unexpected Popups"
                     description="Stops the bot when an unexpected popup with a Cancel button is detected (e.g. lack of fans or trophies). You will need to dismiss the popup and restart the bot manually."
@@ -239,12 +228,9 @@ const Settings = () => {
 
                 <CustomCheckbox
                     searchId="settings-stop-before-finals"
-                    checked={bsc.settings.general.enableStopBeforeFinals}
+                    checked={general.enableStopBeforeFinals}
                     onCheckedChange={(checked) => {
-                        bsc.setSettings({
-                            ...bsc.settings,
-                            general: { ...bsc.settings.general, enableStopBeforeFinals: checked },
-                        })
+                        updateGeneral({ enableStopBeforeFinals: checked })
                     }}
                     label="Stop before Finals"
                     description="Stops the bot on turn 72 so you can purchase skills before the final races."
@@ -253,27 +239,24 @@ const Settings = () => {
 
                 <CustomCheckbox
                     searchId="settings-stop-at-date"
-                    checked={bsc.settings.general.enableStopAtDate}
+                    checked={general.enableStopAtDate}
                     onCheckedChange={(checked) => {
-                        bsc.setSettings({
-                            ...bsc.settings,
-                            general: { ...bsc.settings.general, enableStopAtDate: checked },
-                        })
+                        updateGeneral({ enableStopAtDate: checked })
                     }}
                     label="Stop at Date"
                     description="Stops the bot on one or more specified dates. The bot will stop at the earliest matching date it reaches."
                     className="mt-4"
                 />
 
-                {bsc.settings.general.enableStopAtDate && (
+                {general.enableStopAtDate && (
                     <SearchableItem id="settings-stop-at-date" title="Target Dates" description="Stops the bot on the specified dates." style={{ marginLeft: 16, marginTop: 8 }}>
-                        {bsc.settings.general.stopAtDates.map((dateStr, index) => {
+                        {general.stopAtDates.map((dateStr, index) => {
                             const parts = dateStr.split(" ")
                             return (
-                                <View key={index} style={{ marginBottom: index < bsc.settings.general.stopAtDates.length - 1 ? 12 : 0 }}>
+                                <View key={index} style={{ marginBottom: index < general.stopAtDates.length - 1 ? 12 : 0 }}>
                                     <View style={{ flexDirection: "row", alignItems: "center", justifyContent: "space-between", marginBottom: 4 }}>
                                         <Text style={{ fontSize: 14, fontWeight: "600", color: colors.foreground }}>Date {index + 1}</Text>
-                                        {bsc.settings.general.stopAtDates.length > 1 && (
+                                        {general.stopAtDates.length > 1 && (
                                             <CustomButton onPress={() => handleRemoveStopAtDate(index)} variant="destructive" size="sm" fontSize={12}>
                                                 Remove
                                             </CustomButton>
@@ -319,12 +302,9 @@ const Settings = () => {
 
                 <CustomCheckbox
                     searchId="settings-crane-game-attempt"
-                    checked={bsc.settings.general.enableCraneGameAttempt}
+                    checked={general.enableCraneGameAttempt}
                     onCheckedChange={(checked) => {
-                        bsc.setSettings({
-                            ...bsc.settings,
-                            general: { ...bsc.settings.general, enableCraneGameAttempt: checked },
-                        })
+                        updateGeneral({ enableCraneGameAttempt: checked })
                     }}
                     label="Enable Crane Game Attempt"
                     description="When enabled, the bot will attempt to complete the crane game. By default, the bot will stop when it is detected."
@@ -333,12 +313,9 @@ const Settings = () => {
 
                 <CustomCheckbox
                     searchId="settings-enable-settings-display"
-                    checked={bsc.settings.misc.enableSettingsDisplay}
+                    checked={misc.enableSettingsDisplay}
                     onCheckedChange={(checked) => {
-                        bsc.setSettings({
-                            ...bsc.settings,
-                            misc: { ...bsc.settings.misc, enableSettingsDisplay: checked },
-                        })
+                        updateMisc({ enableSettingsDisplay: checked })
                     }}
                     label="Enable Settings Display in Message Log"
                     description="Shows current bot configuration settings at the top of the message log."
@@ -347,12 +324,9 @@ const Settings = () => {
 
                 <CustomCheckbox
                     searchId="settings-enable-message-id-display"
-                    checked={bsc.settings.misc.enableMessageIdDisplay}
+                    checked={misc.enableMessageIdDisplay}
                     onCheckedChange={(checked) => {
-                        bsc.setSettings({
-                            ...bsc.settings,
-                            misc: { ...bsc.settings.misc, enableMessageIdDisplay: checked },
-                        })
+                        updateMisc({ enableMessageIdDisplay: checked })
                     }}
                     label="Enable Message ID Display"
                     description="Shows message IDs in the message log to help with debugging."
@@ -361,13 +335,13 @@ const Settings = () => {
 
                 <CustomSlider
                     searchId="settings-wait-delay"
-                    value={bsc.settings.general.waitDelay}
-                    placeholder={bsc.defaultSettings.general.waitDelay}
+                    value={general.waitDelay}
+                    placeholder={defaultSettings.general.waitDelay}
                     onValueChange={(value) => {
-                        bsc.setSettings({ ...bsc.settings, general: { ...bsc.settings.general, waitDelay: value } })
+                        updateGeneral({ waitDelay: value })
                     }}
                     onSlidingComplete={(value) => {
-                        bsc.setSettings({ ...bsc.settings, general: { ...bsc.settings.general, waitDelay: value } })
+                        updateGeneral({ waitDelay: value })
                     }}
                     min={0.0}
                     max={1.0}
@@ -381,13 +355,13 @@ const Settings = () => {
 
                 <CustomSlider
                     searchId="settings-dialog-wait-delay"
-                    value={bsc.settings.general.dialogWaitDelay}
-                    placeholder={bsc.defaultSettings.general.dialogWaitDelay}
+                    value={general.dialogWaitDelay}
+                    placeholder={defaultSettings.general.dialogWaitDelay}
                     onValueChange={(value) => {
-                        bsc.setSettings({ ...bsc.settings, general: { ...bsc.settings.general, dialogWaitDelay: value } })
+                        updateGeneral({ dialogWaitDelay: value })
                     }}
                     onSlidingComplete={(value) => {
-                        bsc.setSettings({ ...bsc.settings, general: { ...bsc.settings.general, dialogWaitDelay: value } })
+                        updateGeneral({ dialogWaitDelay: value })
                     }}
                     min={0.0}
                     max={1.0}
@@ -401,13 +375,13 @@ const Settings = () => {
 
                 <CustomSlider
                     searchId="settings-overlay-button-size"
-                    value={bsc.settings.misc.overlayButtonSizeDP}
-                    placeholder={bsc.defaultSettings.misc.overlayButtonSizeDP}
+                    value={misc.overlayButtonSizeDP}
+                    placeholder={defaultSettings.misc.overlayButtonSizeDP}
                     onValueChange={(value) => {
-                        bsc.setSettings({ ...bsc.settings, misc: { ...bsc.settings.misc, overlayButtonSizeDP: value } })
+                        updateMisc({ overlayButtonSizeDP: value })
                     }}
                     onSlidingComplete={(value) => {
-                        bsc.setSettings({ ...bsc.settings, misc: { ...bsc.settings.misc, overlayButtonSizeDP: value } })
+                        updateMisc({ overlayButtonSizeDP: value })
                     }}
                     min={30}
                     max={60}
@@ -487,9 +461,9 @@ const Settings = () => {
                         setSnackbarOpen(false)
                     },
                 }}
-                style={{ backgroundColor: bsc.readyStatus ? "green" : "red", borderRadius: 10 }}
+                style={{ backgroundColor: readyStatus ? "green" : "red", borderRadius: 10 }}
             >
-                {bsc.readyStatus ? "Bot is ready!" : "Bot is not ready!"}
+                {readyStatus ? "Bot is ready!" : "Bot is not ready!"}
             </Snackbar>
 
             {/* Restart Dialog */}

--- a/src/pages/SkillPlanSettings/index.tsx
+++ b/src/pages/SkillPlanSettings/index.tsx
@@ -2,7 +2,7 @@ import React, { useMemo, useContext, useState, useRef, FC, useCallback } from "r
 import { View, Text, ScrollView, StyleSheet, TouchableOpacity, Image } from "react-native"
 import { Divider } from "react-native-paper"
 import { useTheme } from "../../context/ThemeContext"
-import { BotStateContext, defaultSettings } from "../../context/BotStateContext"
+import { SkillsContext, defaultSettings } from "../../context/BotStateContext"
 import { SkillPlanSettingsProps } from "./config"
 import CustomSelect from "../../components/CustomSelect"
 import CustomCheckbox from "../../components/CustomCheckbox"
@@ -70,12 +70,10 @@ const skillData: Skill[] = Object.values(skillsData)
 const SkillPlanSettings: FC<SkillPlanSettingsProps> = ({ planKey, name, title, description }) => {
     usePerformanceLogging(name)
     const { colors } = useTheme()
-    const bsc = useContext(BotStateContext)
-
-    const { settings, setSettings } = bsc
+    const { skills, updateSkills } = useContext(SkillsContext)
 
     // Merge current skills settings with defaults to handle missing properties.
-    const combinedConfig = { ...defaultSettings.skills.plans, ...settings.skills.plans }
+    const combinedConfig = { ...defaultSettings.skills.plans, ...skills.plans }
 
     const { enabled, strategy, enableBuyInheritedUniqueSkills, enableBuyNegativeSkills, plan } = combinedConfig[planKey]
 
@@ -108,21 +106,15 @@ const SkillPlanSettings: FC<SkillPlanSettingsProps> = ({ planKey, name, title, d
      */
     const updateSkillsSetting = useCallback(
         (key: string, value: any) => {
-            setSettings({
-                ...bsc.settings,
-                skills: {
-                    ...bsc.settings.skills,
-                    plans: {
-                        ...bsc.settings.skills.plans,
-                        [planKey]: {
-                            ...bsc.settings.skills.plans[planKey],
-                            [key]: value,
-                        },
-                    },
+            updateSkills((prev) => ({
+                ...prev,
+                plans: {
+                    ...prev.plans,
+                    [planKey]: { ...prev.plans[planKey], [key]: value },
                 },
-            })
+            }))
         },
-        [bsc.settings, planKey, setSettings]
+        [planKey, updateSkills]
     )
 
     /**

--- a/src/pages/SkillSettings/index.tsx
+++ b/src/pages/SkillSettings/index.tsx
@@ -9,7 +9,7 @@ import CustomCheckbox from "../../components/CustomCheckbox"
 import CustomSlider from "../../components/CustomSlider"
 import CustomTitle from "../../components/CustomTitle"
 import PageHeader from "../../components/PageHeader"
-import { BotStateContext, defaultSettings } from "../../context/BotStateContext"
+import { SkillsContext, defaultSettings } from "../../context/BotStateContext"
 import { SearchPageProvider } from "../../context/SearchPageContext"
 import { skillPlanSettingsPages } from "../SkillPlanSettings/config"
 import InfoContainer from "../../components/InfoContainer"
@@ -25,26 +25,18 @@ const SkillSettings = () => {
     usePerformanceLogging("SkillSettings")
     const { colors } = useTheme()
     const navigation = useNavigation()
-    const bsc = useContext(BotStateContext)
+    const { skills, updateSkills } = useContext(SkillsContext)
     const scrollViewRef = useRef<ScrollView>(null)
 
-    const { settings, setSettings } = bsc
-
     // Merge current skills settings with defaults to handle missing properties.
-    const skillSettings = { ...defaultSettings.skills, ...settings.skills }
+    const skillSettings = { ...defaultSettings.skills, ...skills }
     const { preferredRunningStyle, preferredTrackDistance, preferredTrackSurface } = skillSettings
 
     useEffect(() => {
-        if (bsc.settings.skills.plans.skillPointCheck.enabled) {
-            bsc.setSettings({
-                ...bsc.settings,
-                skills: {
-                    ...bsc.settings.skills,
-                    enableSkillPointCheck: true,
-                },
-            })
+        if (skills.plans.skillPointCheck.enabled) {
+            updateSkills({ enableSkillPointCheck: true })
         }
-    }, [bsc.settings.skills.plans.skillPointCheck.enabled])
+    }, [skills.plans.skillPointCheck.enabled])
 
     /**
      * Update a skill setting.
@@ -52,13 +44,7 @@ const SkillSettings = () => {
      * @param value The value to set the setting to.
      */
     const updateSkillsSetting = (key: string, value: any) => {
-        setSettings({
-            ...bsc.settings,
-            skills: {
-                ...bsc.settings.skills,
-                [key]: value,
-            },
-        })
+        updateSkills({ [key]: value } as any)
     }
 
     const styles = useMemo(
@@ -125,35 +111,26 @@ const SkillSettings = () => {
                         <Divider style={{ marginBottom: 16 }} />
                         <CustomCheckbox
                             searchId="enable-skill-point-check"
-                            checked={bsc.settings.skills.enableSkillPointCheck}
+                            checked={skills.enableSkillPointCheck}
                             onCheckedChange={(checked) => {
-                                bsc.setSettings({
-                                    ...bsc.settings,
-                                    skills: { ...bsc.settings.skills, enableSkillPointCheck: checked },
-                                })
+                                updateSkills({ enableSkillPointCheck: checked })
                             }}
                             label="Enable Skill Point Check"
                             description="Enables check for a certain skill point threshold. When the threshold is reached, the bot is stopped. This can be changed to allow the selected Skill Plan to spend those points instead of stopping the bot."
                         />
 
-                        <View style={bsc.settings.skills.enableSkillPointCheck ? { marginTop: 8 } : { display: "none" }}>
+                        <View style={skills.enableSkillPointCheck ? { marginTop: 8 } : { display: "none" }}>
                             <CustomSlider
                                 searchId="skill-point-check"
-                                searchCondition={bsc.settings.skills.enableSkillPointCheck}
+                                searchCondition={skills.enableSkillPointCheck}
                                 parentId="enable-skill-point-check"
-                                value={bsc.settings.skills.skillPointCheck}
-                                placeholder={bsc.defaultSettings.skills.skillPointCheck}
+                                value={skills.skillPointCheck}
+                                placeholder={defaultSettings.skills.skillPointCheck}
                                 onValueChange={(value) => {
-                                    bsc.setSettings({
-                                        ...bsc.settings,
-                                        skills: { ...bsc.settings.skills, skillPointCheck: value },
-                                    })
+                                    updateSkills({ skillPointCheck: value })
                                 }}
                                 onSlidingComplete={(value) => {
-                                    bsc.setSettings({
-                                        ...bsc.settings,
-                                        skills: { ...bsc.settings.skills, skillPointCheck: value },
-                                    })
+                                    updateSkills({ skillPointCheck: value })
                                 }}
                                 min={100}
                                 max={2000}
@@ -166,23 +143,17 @@ const SkillSettings = () => {
                             />
                             <CustomCheckbox
                                 searchId="skill-point-check-plan"
-                                searchCondition={bsc.settings.skills.enableSkillPointCheck}
+                                searchCondition={skills.enableSkillPointCheck}
                                 parentId="enable-skill-point-check"
-                                checked={bsc.settings.skills.plans.skillPointCheck.enabled}
+                                checked={skills.plans.skillPointCheck.enabled}
                                 onCheckedChange={(checked) => {
-                                    bsc.setSettings({
-                                        ...bsc.settings,
-                                        skills: {
-                                            ...bsc.settings.skills,
-                                            plans: {
-                                                ...bsc.settings.skills.plans,
-                                                skillPointCheck: {
-                                                    ...bsc.settings.skills.plans.skillPointCheck,
-                                                    enabled: checked,
-                                                },
-                                            },
+                                    updateSkills((prev) => ({
+                                        ...prev,
+                                        plans: {
+                                            ...prev.plans,
+                                            skillPointCheck: { ...prev.plans.skillPointCheck, enabled: checked },
                                         },
-                                    })
+                                    }))
                                 }}
                                 label="Enable Skill Plan Upon Meeting Threshold"
                                 description="Instead of stopping the bot, this will run the Skill Plan to spend the skill points when the threshold is met."

--- a/src/pages/TrainingEventSettings/index.tsx
+++ b/src/pages/TrainingEventSettings/index.tsx
@@ -2,7 +2,7 @@ import { useContext, useState, useMemo, useCallback, useRef } from "react"
 import { View, Text, ScrollView, StyleSheet, TouchableOpacity, Modal, TextInput, Dimensions } from "react-native"
 import { FlashList } from "@shopify/flash-list"
 import { useTheme } from "../../context/ThemeContext"
-import { BotStateContext, defaultSettings } from "../../context/BotStateContext"
+import { TrainingEventContext, defaultSettings } from "../../context/BotStateContext"
 import { SearchPageProvider } from "../../context/SearchPageContext"
 import CustomAccordion from "../../components/CustomAccordion"
 import CustomCheckbox from "../../components/CustomCheckbox"
@@ -51,10 +51,9 @@ const excludedEventNames = new Set([
 const TrainingEventSettings = () => {
     usePerformanceLogging("TrainingEventSettings")
     const { colors } = useTheme()
-    const bsc = useContext(BotStateContext)
+    const { trainingEvent, updateTrainingEvent } = useContext(TrainingEventContext)
     const scrollViewRef = useRef<ScrollView>(null)
 
-    const { settings, setSettings } = bsc
     // Merge current training event settings with defaults to handle missing properties.
     const {
         enablePrioritizeEnergyOptions,
@@ -65,7 +64,7 @@ const TrainingEventSettings = () => {
         characterEventOverrides,
         supportEventOverrides,
         scenarioEventOverrides,
-    } = { ...defaultSettings.trainingEvent, ...settings.trainingEvent }
+    } = { ...defaultSettings.trainingEvent, ...trainingEvent }
 
     const [eventOverrideModalVisible, setEventOverrideModalVisible] = useState(false)
     const [eventOverrideSearchQuery, setEventOverrideSearchQuery] = useState("")
@@ -137,14 +136,8 @@ const TrainingEventSettings = () => {
      * @param key The key of the setting to update.
      * @param value The value to set the setting to.
      */
-    const updateTrainingEventSetting = (key: keyof typeof settings.trainingEvent, value: any) => {
-        setSettings({
-            ...bsc.settings,
-            trainingEvent: {
-                ...bsc.settings.trainingEvent,
-                [key]: value,
-            },
-        })
+    const updateTrainingEventSetting = (key: keyof typeof trainingEvent, value: any) => {
+        updateTrainingEvent({ [key]: value } as any)
     }
 
     /**
@@ -154,19 +147,16 @@ const TrainingEventSettings = () => {
      * @param value The new value for the field.
      */
     const updateSpecialEventOverride = (eventName: string, field: "selectedOption" | "requiresConfirmation" | "enableEnergyBasedSelection", value: any) => {
-        setSettings({
-            ...bsc.settings,
-            trainingEvent: {
-                ...bsc.settings.trainingEvent,
-                specialEventOverrides: {
-                    ...bsc.settings.trainingEvent.specialEventOverrides,
-                    [eventName]: {
-                        ...bsc.settings.trainingEvent.specialEventOverrides[eventName],
-                        [field]: value,
-                    },
+        updateTrainingEvent((prev) => ({
+            ...prev,
+            specialEventOverrides: {
+                ...prev.specialEventOverrides,
+                [eventName]: {
+                    ...prev.specialEventOverrides[eventName],
+                    [field]: value,
                 },
             },
-        })
+        }))
     }
 
     /**
@@ -274,38 +264,20 @@ const TrainingEventSettings = () => {
         const eventType = allEvents.find((e) => e.key === eventKey)?.type
 
         if (eventType === "character") {
-            setSettings({
-                ...bsc.settings,
-                trainingEvent: {
-                    ...bsc.settings.trainingEvent,
-                    characterEventOverrides: {
-                        ...(bsc.settings.trainingEvent.characterEventOverrides || {}),
-                        [eventKey]: optionIndex,
-                    },
-                },
-            })
+            updateTrainingEvent((prev) => ({
+                ...prev,
+                characterEventOverrides: { ...(prev.characterEventOverrides || {}), [eventKey]: optionIndex },
+            }))
         } else if (eventType === "support") {
-            setSettings({
-                ...bsc.settings,
-                trainingEvent: {
-                    ...bsc.settings.trainingEvent,
-                    supportEventOverrides: {
-                        ...(bsc.settings.trainingEvent.supportEventOverrides || {}),
-                        [eventKey]: optionIndex,
-                    },
-                },
-            })
+            updateTrainingEvent((prev) => ({
+                ...prev,
+                supportEventOverrides: { ...(prev.supportEventOverrides || {}), [eventKey]: optionIndex },
+            }))
         } else if (eventType === "scenario") {
-            setSettings({
-                ...bsc.settings,
-                trainingEvent: {
-                    ...bsc.settings.trainingEvent,
-                    scenarioEventOverrides: {
-                        ...(bsc.settings.trainingEvent.scenarioEventOverrides || {}),
-                        [eventKey]: optionIndex,
-                    },
-                },
-            })
+            updateTrainingEvent((prev) => ({
+                ...prev,
+                scenarioEventOverrides: { ...(prev.scenarioEventOverrides || {}), [eventKey]: optionIndex },
+            }))
         }
         // Close the option selection modal.
         setOptionSelectionModalVisible(false)
@@ -320,34 +292,22 @@ const TrainingEventSettings = () => {
         const eventType = allEvents.find((e) => e.key === eventKey)?.type
 
         if (eventType === "character") {
-            const newOverrides = { ...(bsc.settings.trainingEvent.characterEventOverrides || {}) }
-            delete newOverrides[eventKey]
-            setSettings({
-                ...bsc.settings,
-                trainingEvent: {
-                    ...bsc.settings.trainingEvent,
-                    characterEventOverrides: newOverrides,
-                },
+            updateTrainingEvent((prev) => {
+                const next = { ...(prev.characterEventOverrides || {}) }
+                delete next[eventKey]
+                return { ...prev, characterEventOverrides: next }
             })
         } else if (eventType === "support") {
-            const newOverrides = { ...(bsc.settings.trainingEvent.supportEventOverrides || {}) }
-            delete newOverrides[eventKey]
-            setSettings({
-                ...bsc.settings,
-                trainingEvent: {
-                    ...bsc.settings.trainingEvent,
-                    supportEventOverrides: newOverrides,
-                },
+            updateTrainingEvent((prev) => {
+                const next = { ...(prev.supportEventOverrides || {}) }
+                delete next[eventKey]
+                return { ...prev, supportEventOverrides: next }
             })
         } else if (eventType === "scenario") {
-            const newOverrides = { ...(bsc.settings.trainingEvent.scenarioEventOverrides || {}) }
-            delete newOverrides[eventKey]
-            setSettings({
-                ...bsc.settings,
-                trainingEvent: {
-                    ...bsc.settings.trainingEvent,
-                    scenarioEventOverrides: newOverrides,
-                },
+            updateTrainingEvent((prev) => {
+                const next = { ...(prev.scenarioEventOverrides || {}) }
+                delete next[eventKey]
+                return { ...prev, scenarioEventOverrides: next }
             })
         }
     }

--- a/src/pages/TrainingSettings/index.tsx
+++ b/src/pages/TrainingSettings/index.tsx
@@ -46,9 +46,7 @@ const TrainingSettings = () => {
     const [statPrioritizationItems, setStatPrioritizationItems] = useState<string[]>(() =>
         training?.statPrioritization !== undefined ? training.statPrioritization : defaultSettings.training.statPrioritization
     )
-    const [blacklistItems, setBlacklistItems] = useState<string[]>(() =>
-        training?.trainingBlacklist !== undefined ? training.trainingBlacklist : defaultSettings.training.trainingBlacklist
-    )
+    const [blacklistItems, setBlacklistItems] = useState<string[]>(() => (training?.trainingBlacklist !== undefined ? training.trainingBlacklist : defaultSettings.training.trainingBlacklist))
     const [sparkStatTargetItems, setSparkStatTargetItems] = useState<string[]>(() => {
         const value = training?.focusOnSparkStatTarget
         // Ensure we always have an array (migration should handle this, but be safe).

--- a/src/pages/TrainingSettings/index.tsx
+++ b/src/pages/TrainingSettings/index.tsx
@@ -2,7 +2,7 @@ import React, { useMemo, useContext, useEffect, useState, useRef, useCallback } 
 import { View, Text, ScrollView, StyleSheet, Modal, TouchableOpacity, Dimensions } from "react-native"
 import { Snackbar } from "react-native-paper"
 import { useTheme } from "../../context/ThemeContext"
-import { BotStateContext, defaultSettings, Settings } from "../../context/BotStateContext"
+import { TrainingContext, GeneralMiscContext, BotMetaContext, defaultSettings, Settings } from "../../context/BotStateContext"
 import CustomButton from "../../components/CustomButton"
 import CustomSlider from "../../components/CustomSlider"
 import CustomCheckbox from "../../components/CustomCheckbox"
@@ -30,7 +30,9 @@ import WarningContainer from "../../components/WarningContainer"
 const TrainingSettings = () => {
     usePerformanceLogging("TrainingSettings")
     const { colors } = useTheme()
-    const bsc = useContext(BotStateContext)
+    const { training, trainingStatTarget, updateTraining, updateTrainingStatTarget: updateStatTargetSlice } = useContext(TrainingContext)
+    const { misc, updateMisc } = useContext(GeneralMiscContext)
+    const { setSettings } = useContext(BotMetaContext)
     const scrollViewRef = useRef<ScrollView>(null)
     const { saveSettingsImmediate } = useSettings()
     const { currentProfileName } = useProfileManager()
@@ -40,17 +42,15 @@ const TrainingSettings = () => {
     const [snackbarVisible, setSnackbarVisible] = useState(false)
     const [snackbarMessage, setSnackbarMessage] = useState("")
 
-    const { settings, setSettings } = bsc
-
     // Initialize local state from settings, with fallback to defaults.
     const [statPrioritizationItems, setStatPrioritizationItems] = useState<string[]>(() =>
-        settings.training?.statPrioritization !== undefined ? settings.training.statPrioritization : defaultSettings.training.statPrioritization
+        training?.statPrioritization !== undefined ? training.statPrioritization : defaultSettings.training.statPrioritization
     )
     const [blacklistItems, setBlacklistItems] = useState<string[]>(() =>
-        settings.training?.trainingBlacklist !== undefined ? settings.training.trainingBlacklist : defaultSettings.training.trainingBlacklist
+        training?.trainingBlacklist !== undefined ? training.trainingBlacklist : defaultSettings.training.trainingBlacklist
     )
     const [sparkStatTargetItems, setSparkStatTargetItems] = useState<string[]>(() => {
-        const value = settings.training?.focusOnSparkStatTarget
+        const value = training?.focusOnSparkStatTarget
         // Ensure we always have an array (migration should handle this, but be safe).
         if (Array.isArray(value)) {
             return value
@@ -66,15 +66,15 @@ const TrainingSettings = () => {
     const trainingSettings = useMemo(
         () => ({
             ...defaultSettings.training,
-            ...settings.training,
+            ...training,
             trainingBlacklist: blacklistItems,
             statPrioritization: statPrioritizationItems,
             focusOnSparkStatTarget: sparkStatTargetItems,
         }),
-        [settings.training, blacklistItems, statPrioritizationItems, sparkStatTargetItems]
+        [training, blacklistItems, statPrioritizationItems, sparkStatTargetItems]
     )
 
-    const trainingStatTargetSettings = useMemo(() => ({ ...defaultSettings.trainingStatTarget, ...settings.trainingStatTarget }), [settings.trainingStatTarget])
+    const trainingStatTargetSettings = useMemo(() => ({ ...defaultSettings.trainingStatTarget, ...trainingStatTarget }), [trainingStatTarget])
 
     const {
         maximumFailureChance,
@@ -95,7 +95,7 @@ const TrainingSettings = () => {
     // We also verify that the values are actually different before triggering an update.
     useEffect(() => {
         if (isMounted.current) {
-            if (!shallowArrayEqual(settings.training?.statPrioritization, statPrioritizationItems)) {
+            if (!shallowArrayEqual(training?.statPrioritization, statPrioritizationItems)) {
                 updateTrainingSetting("statPrioritization", statPrioritizationItems)
             }
         }
@@ -103,7 +103,7 @@ const TrainingSettings = () => {
 
     useEffect(() => {
         if (isMounted.current) {
-            if (!shallowArrayEqual(settings.training?.trainingBlacklist, blacklistItems)) {
+            if (!shallowArrayEqual(training?.trainingBlacklist, blacklistItems)) {
                 updateTrainingSetting("trainingBlacklist", blacklistItems)
             }
         }
@@ -111,7 +111,7 @@ const TrainingSettings = () => {
 
     useEffect(() => {
         if (isMounted.current) {
-            if (!shallowArrayEqual(settings.training?.focusOnSparkStatTarget, sparkStatTargetItems)) {
+            if (!shallowArrayEqual(training?.focusOnSparkStatTarget, sparkStatTargetItems)) {
                 updateTrainingSetting("focusOnSparkStatTarget", sparkStatTargetItems)
             }
         }
@@ -124,39 +124,33 @@ const TrainingSettings = () => {
 
     // Sync local state when settings change (e.g., when switching profiles).
     useEffect(() => {
-        const newVal = settings.training?.trainingBlacklist
+        const newVal = training?.trainingBlacklist
         if (newVal !== undefined && !shallowArrayEqual(newVal, blacklistItems)) {
             setBlacklistItems(newVal)
         }
-    }, [settings.training?.trainingBlacklist])
+    }, [training?.trainingBlacklist])
 
     useEffect(() => {
-        const newVal = settings.training?.statPrioritization
+        const newVal = training?.statPrioritization
         if (newVal !== undefined && !shallowArrayEqual(newVal, statPrioritizationItems)) {
             setStatPrioritizationItems(newVal)
         }
-    }, [settings.training?.statPrioritization])
+    }, [training?.statPrioritization])
 
     useEffect(() => {
-        const newVal = settings.training?.focusOnSparkStatTarget
+        const newVal = training?.focusOnSparkStatTarget
         if (newVal !== undefined && Array.isArray(newVal) && !shallowArrayEqual(newVal, sparkStatTargetItems)) {
             setSparkStatTargetItems(newVal)
         }
-    }, [settings.training?.focusOnSparkStatTarget])
+    }, [training?.focusOnSparkStatTarget])
 
     // Sync currentProfileName from profile manager to settings context.
     // This is now purely for the BotStateContext as the ProfileContext is the source of truth for the UI.
     useEffect(() => {
         const syncProfileName = async () => {
             const profileName = currentProfileName || ""
-            if (settings.misc.currentProfileName !== profileName) {
-                setSettings((prev) => ({
-                    ...prev,
-                    misc: {
-                        ...prev.misc,
-                        currentProfileName: profileName,
-                    },
-                }))
+            if (misc.currentProfileName !== profileName) {
+                updateMisc({ currentProfileName: profileName })
             }
         }
         syncProfileName()
@@ -168,16 +162,10 @@ const TrainingSettings = () => {
      * @param value The value to set the setting to.
      */
     const updateTrainingSetting = useCallback(
-        (key: keyof typeof settings.training, value: any) => {
-            setSettings((prev) => ({
-                ...prev,
-                training: {
-                    ...prev.training,
-                    [key]: value,
-                },
-            }))
+        (key: keyof Settings["training"], value: any) => {
+            updateTraining({ [key]: value } as Partial<Settings["training"]>)
         },
-        [setSettings]
+        [updateTraining]
     )
 
     /**
@@ -222,20 +210,15 @@ const TrainingSettings = () => {
 
     /**
      * Update a training stat target setting in the global bot state.
+     * Wraps the slice updater so call sites can pass `(key, value)` rather than a partial object.
      * @param key The key of the stat target setting to update.
      * @param value The value to set the target to.
      */
     const updateTrainingStatTarget = useCallback(
-        (key: keyof typeof settings.trainingStatTarget, value: any) => {
-            setSettings((prev) => ({
-                ...prev,
-                trainingStatTarget: {
-                    ...prev.trainingStatTarget,
-                    [key]: value,
-                },
-            }))
+        (key: keyof Settings["trainingStatTarget"], value: any) => {
+            updateStatTargetSlice({ [key]: value } as Partial<Settings["trainingStatTarget"]>)
         },
-        [setSettings]
+        [updateStatTargetSlice]
     )
 
     const styles = useMemo(

--- a/src/pages/TrainingSettings/index.tsx
+++ b/src/pages/TrainingSettings/index.tsx
@@ -19,6 +19,7 @@ import PageHeader from "../../components/PageHeader"
 import { SearchPageProvider } from "../../context/SearchPageContext"
 import SearchableItem from "../../components/SearchableItem"
 import { usePerformanceLogging } from "../../hooks/usePerformanceLogging"
+import { shallowArrayEqual } from "../../lib/utils"
 import WarningContainer from "../../components/WarningContainer"
 
 /**
@@ -94,8 +95,7 @@ const TrainingSettings = () => {
     // We also verify that the values are actually different before triggering an update.
     useEffect(() => {
         if (isMounted.current) {
-            const currentVal = settings.training?.statPrioritization
-            if (JSON.stringify(currentVal) !== JSON.stringify(statPrioritizationItems)) {
+            if (!shallowArrayEqual(settings.training?.statPrioritization, statPrioritizationItems)) {
                 updateTrainingSetting("statPrioritization", statPrioritizationItems)
             }
         }
@@ -103,8 +103,7 @@ const TrainingSettings = () => {
 
     useEffect(() => {
         if (isMounted.current) {
-            const currentVal = settings.training?.trainingBlacklist
-            if (JSON.stringify(currentVal) !== JSON.stringify(blacklistItems)) {
+            if (!shallowArrayEqual(settings.training?.trainingBlacklist, blacklistItems)) {
                 updateTrainingSetting("trainingBlacklist", blacklistItems)
             }
         }
@@ -112,8 +111,7 @@ const TrainingSettings = () => {
 
     useEffect(() => {
         if (isMounted.current) {
-            const currentVal = settings.training?.focusOnSparkStatTarget
-            if (JSON.stringify(currentVal) !== JSON.stringify(sparkStatTargetItems)) {
+            if (!shallowArrayEqual(settings.training?.focusOnSparkStatTarget, sparkStatTargetItems)) {
                 updateTrainingSetting("focusOnSparkStatTarget", sparkStatTargetItems)
             }
         }
@@ -127,21 +125,21 @@ const TrainingSettings = () => {
     // Sync local state when settings change (e.g., when switching profiles).
     useEffect(() => {
         const newVal = settings.training?.trainingBlacklist
-        if (newVal !== undefined && JSON.stringify(newVal) !== JSON.stringify(blacklistItems)) {
+        if (newVal !== undefined && !shallowArrayEqual(newVal, blacklistItems)) {
             setBlacklistItems(newVal)
         }
     }, [settings.training?.trainingBlacklist])
 
     useEffect(() => {
         const newVal = settings.training?.statPrioritization
-        if (newVal !== undefined && JSON.stringify(newVal) !== JSON.stringify(statPrioritizationItems)) {
+        if (newVal !== undefined && !shallowArrayEqual(newVal, statPrioritizationItems)) {
             setStatPrioritizationItems(newVal)
         }
     }, [settings.training?.statPrioritization])
 
     useEffect(() => {
         const newVal = settings.training?.focusOnSparkStatTarget
-        if (newVal !== undefined && Array.isArray(newVal) && JSON.stringify(newVal) !== JSON.stringify(sparkStatTargetItems)) {
+        if (newVal !== undefined && Array.isArray(newVal) && !shallowArrayEqual(newVal, sparkStatTargetItems)) {
             setSparkStatTargetItems(newVal)
         }
     }, [settings.training?.focusOnSparkStatTarget])


### PR DESCRIPTION
## Description

- This PR fixes a performance bug where toggling any checkbox in the settings pages felt sluggish once settings are imported, even though factory defaults stayed snappy.

- **Root cause:** `MessageLogContext` had a `useMemo` that rebuilt the entire welcome-banner string (`formattedSettingsString`) on every settings change. Inside that memo, the code interpolated dozens of fields and called `JSON.parse(settings.racing.racingPlan)` plus `Object.keys(...).length` on each event-override map. With factory defaults these structures are tiny (empty racing plan, no overrides) so the memo finished in ~1ms. After importing settings - 50+ planned races, dozens of character/support/scenario overrides - the same memo took ~10-30ms. The new string then triggered downstream memos (`introMessage`, `processedMessages`, `filteredMessages`) and a FlashList re-key, all on the synchronous render commit, blocking the visual feedback for the toggle that just fired.

- **Fix:** converted `formattedSettingsString` from a synchronous `useMemo` keyed on `[bsc.settings]` into a `useState` updated by a debounced `useEffect`. The pure builder function is extracted as `buildFormattedSettings()` (a `useCallback`). When settings change, a 250ms timer is scheduled - only after the user stops toggling does the heavy template rebuild run. Until then, the existing string stays in state, downstream memos bail out via `Object.is`, and the toggle's render commits immediately.

## Measured improvement

Tested on an emulator with the Samsung S25 Ultra preset connected via ADB, release builds, app launched fresh with imported settings. Toggle measurements are on the `Disable Training on Maxed Stats` checkbox in Training Settings. Each value is the median of 5 runs.

### Toggle latency (visual feedback after tap)

Captured by taking a pre-tap screenshot, recording the wall-clock millisecond when the tap fires, then taking 8 successive screenshots while logging elapsed-ms after each. The "last unchanged" and "first changed" timestamps bracket when the pixels actually flipped.

| Metric | Master | This PR | Improvement |
|---|---|---|---|
| Last screenshot still showing old state | 573 ms | 231 ms | −342 ms |
| First screenshot showing new state | 750 ms | 412 ms | −338 ms |
| Midpoint estimate of perceived lag | ~662 ms | ~322 ms | **−340 ms (~51% faster)** |

Per-run timestamps (ms):

| Run | Master last-same | Master first-changed | This PR last-same | This PR first-changed |
|---|---|---|---|---|
| 1 | 579 | 746 | 235 | 422 |
| 2 | 563 | 743 | 228 | 406 |
| 3 | 555 | 725 | 237 | 421 |
| 4 | 570 | 756 | 227 | 403 |
| 5 | 599 | 781 | 229 | 407 |

### Frame quality during toggling

Captured via `adb shell dumpsys gfxinfo com.steve1316.uma_android_automation framestats` after 5 rapid checkbox toggles.

| Metric | Master | This PR |
|---|---|---|
| Total frames rendered | 5 | 5 |
| Modern janky frames | 0 / 5 (0%) | 0 / 5 (0%) |
| **Legacy janky frames (>16.7ms input-to-display)** | **4 / 5 (80%)** | **0 / 5 (0%)** |
| 50th percentile frame time | 5 ms | 5 ms |
| 90th percentile frame time | 6 ms | 5 ms |
| 99th percentile frame time | 6 ms | 5 ms |
| Missed vsyncs | 0 | 0 |
| Slow UI thread | 0 | 0 |

The modern "Janky frames" metric counts frames the GPU pipeline missed. The legacy janky-frames metric counts frames where the full input-to-display path (including JS work) overran 16.7ms; this is what catches the lag, and the fix reduces it from 80% to 0%.