### PR TITLE
Separate stat priority for event choices, regular training, and summer training

### DIFF
--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Training.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Training.kt
@@ -87,6 +87,18 @@ open class Training(protected val game: Game, protected val campaign: Campaign) 
     /** The final stat prioritization list. */
     internal val statPrioritization: List<StatName> = statPrioritizationRaw.ifEmpty { StatName.entries }
 
+    /** The raw stat prioritization list for in-game event choices, sourced from user settings. */
+    private val eventChoiceStatPriorityRaw: List<StatName> = SettingsHelper.getStringArraySetting("training", "eventChoiceStatPriority").map { StatName.fromName(it)!! }
+
+    /** The final stat prioritization list applied to event choice scoring. Falls back to [statPrioritization] if unset. */
+    internal val eventChoiceStatPriority: List<StatName> = eventChoiceStatPriorityRaw.ifEmpty { statPrioritization }
+
+    /** The raw stat prioritization list for Summer Training, sourced from user settings. */
+    private val summerTrainingStatPriorityRaw: List<StatName> = SettingsHelper.getStringArraySetting("training", "summerTrainingStatPriority").map { StatName.fromName(it)!! }
+
+    /** The final stat prioritization list applied during Summer Training. Falls back to [statPrioritization] if unset. */
+    internal val summerTrainingStatPriority: List<StatName> = summerTrainingStatPriorityRaw.ifEmpty { statPrioritization }
+
     /** The maximum allowed failure chance for training. */
     private val maximumFailureChance: Int = SettingsHelper.getIntSetting("training", "maximumFailureChance")
 
@@ -245,7 +257,9 @@ open class Training(protected val game: Game, protected val campaign: Campaign) 
      * Store configuration for training scoring calculations.
      *
      * @property currentStats Map of current character stats.
-     * @property statPrioritization Ordered list of stat priorities.
+     * @property statPrioritization Ordered list of stat priorities for regular training.
+     * @property eventChoiceStatPriority Ordered list of stat priorities used when scoring in-game event choices.
+     * @property summerTrainingStatPriority Ordered list of stat priorities applied during Summer Training.
      * @property statTargets Map of target values for each stat.
      * @property currentDate The current in-game date.
      * @property scenario The current training scenario name.
@@ -262,6 +276,8 @@ open class Training(protected val game: Game, protected val campaign: Campaign) 
         // Global configuration.
         val currentStats: Map<StatName, Int>,
         val statPrioritization: List<StatName>,
+        val eventChoiceStatPriority: List<StatName>,
+        val summerTrainingStatPriority: List<StatName>,
         val statTargets: Map<StatName, Int>,
         val currentDate: GameDate,
         val scenario: String,
@@ -282,6 +298,8 @@ open class Training(protected val game: Game, protected val campaign: Campaign) 
 
             if (currentStats != other.currentStats) return false
             if (statPrioritization != other.statPrioritization) return false
+            if (eventChoiceStatPriority != other.eventChoiceStatPriority) return false
+            if (summerTrainingStatPriority != other.summerTrainingStatPriority) return false
             if (statTargets != other.statTargets) return false
             if (currentDate != other.currentDate) return false
             if (scenario != other.scenario) return false
@@ -300,6 +318,8 @@ open class Training(protected val game: Game, protected val campaign: Campaign) 
         override fun hashCode(): Int {
             var result = currentStats.hashCode()
             result = 31 * result + statPrioritization.hashCode()
+            result = 31 * result + eventChoiceStatPriority.hashCode()
+            result = 31 * result + summerTrainingStatPriority.hashCode()
             result = 31 * result + statTargets.hashCode()
             result = 31 * result + currentDate.hashCode()
             result = 31 * result + scenario.hashCode()
@@ -587,13 +607,16 @@ open class Training(protected val game: Game, protected val campaign: Campaign) 
         fun calculateStatEfficiencyScore(config: TrainingConfig, training: TrainingOption): Double {
             var score = 0.0
 
+            // Use the Summer-specific priority list during Summer Training; otherwise use the regular list.
+            val activePriority = if (config.currentDate.isSummer()) config.summerTrainingStatPriority else config.statPrioritization
+
             for (statName in StatName.entries) {
                 val currentStat = config.currentStats[statName] ?: 0
                 val targetStat = config.statTargets[statName] ?: 0
                 val statGain = training.statGains[statName] ?: 0
 
                 if (statGain > 0 && targetStat > 0) {
-                    val priorityIndex = config.statPrioritization.indexOf(statName)
+                    val priorityIndex = activePriority.indexOf(statName)
 
                     // Calculate completion percentage (how far along this stat is toward its target).
                     val completionPercent = (currentStat.toDouble() / targetStat) * 100.0
@@ -624,7 +647,7 @@ open class Training(protected val game: Game, protected val campaign: Campaign) 
 
                     // Priority-based tiebreaker (only applies when completion is similar).
                     // Find the completion percentage of the highest priority stat for comparison.
-                    val highestPriorityStat: StatName? = config.statPrioritization.firstOrNull()
+                    val highestPriorityStat: StatName? = activePriority.firstOrNull()
                     val highestPriorityCompletion =
                         if (highestPriorityStat != null) {
                             val hpCurrent = config.currentStats[highestPriorityStat] ?: 0
@@ -637,7 +660,7 @@ open class Training(protected val game: Game, protected val campaign: Campaign) 
                     // Only apply priority bonus if this stat's completion is within 10% of highest priority stat.
                     val priorityMultiplier =
                         if (priorityIndex != -1 && kotlin.math.abs(completionPercent - highestPriorityCompletion) <= 10.0) {
-                            1.0 + (0.1 * (config.statPrioritization.size - priorityIndex))
+                            1.0 + (0.1 * (activePriority.size - priorityIndex))
                         } else {
                             1.0
                         }
@@ -1882,6 +1905,8 @@ open class Training(protected val game: Game, protected val campaign: Campaign) 
             TrainingConfig(
                 currentStats = campaign.trainee.stats.asMap(),
                 statPrioritization = statPrioritization,
+                eventChoiceStatPriority = eventChoiceStatPriority,
+                summerTrainingStatPriority = summerTrainingStatPriority,
                 statTargets = campaign.trainee.getPhaseStatTargets(campaign.date.year),
                 currentDate = campaign.date,
                 scenario = game.scenario,

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/TrainingEvent.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/TrainingEvent.kt
@@ -621,7 +621,7 @@ class TrainingEvent(private val game: Game, private val campaign: Campaign) {
                                 selectionWeight[rewardIndex] += finalSkillPoints
                             } else {
                                 // Apply inflated weights to the prioritized stats based on their order.
-                                campaign.training.statPrioritization.forEachIndexed { index, stat ->
+                                campaign.training.eventChoiceStatPriority.forEachIndexed { index, stat ->
                                     if (line.lowercase().contains(stat.name.lowercase())) {
                                         // Calculate weight bonus based on position (higher priority = higher bonus).
                                         val priorityBonus =

--- a/src/components/MessageLog/index.tsx
+++ b/src/components/MessageLog/index.tsx
@@ -285,6 +285,16 @@ const MessageLog = () => {
 📊 Stat Prioritization: ${
             settings.training.statPrioritization.length === 0 ? "Using Default Stat Prioritization: Speed, Stamina, Power, Wit, Guts" : `${settings.training.statPrioritization.join(", ")}`
         }
+🎴 Event Choice Stat Priority: ${
+            settings.training.eventChoiceStatPriority.length === 0
+                ? "Using Default Event Choice Stat Priority: Speed, Stamina, Power, Wit, Guts"
+                : `${settings.training.eventChoiceStatPriority.join(", ")}`
+        }
+☀️ Summer Training Stat Priority: ${
+            settings.training.summerTrainingStatPriority.length === 0
+                ? "Using Default Summer Training Stat Priority: Speed, Stamina, Power, Wit, Guts"
+                : `${settings.training.summerTrainingStatPriority.join(", ")}`
+        }
 🔍 Maximum Failure Chance Allowed: ${settings.training.maximumFailureChance}%
 ⚠️ Enable Riskier Training: ${settings.training.enableRiskyTraining ? "✅" : "❌"}${
             settings.training.enableRiskyTraining

--- a/src/components/ProfileCreationModal/index.tsx
+++ b/src/components/ProfileCreationModal/index.tsx
@@ -151,6 +151,8 @@ const ProfileCreationModal: React.FC<ProfileCreationModalProps> = ({ visible, on
         const settings: string[] = []
         settings.push(`Blacklist: ${currentTrainingSettings.trainingBlacklist.length > 0 ? currentTrainingSettings.trainingBlacklist.join(", ") : "None"}`)
         settings.push(`Prioritization: ${currentTrainingSettings.statPrioritization.length > 0 ? currentTrainingSettings.statPrioritization.join(", ") : "None"}`)
+        settings.push(`Event Choice Priority: ${currentTrainingSettings.eventChoiceStatPriority.length > 0 ? currentTrainingSettings.eventChoiceStatPriority.join(", ") : "None"}`)
+        settings.push(`Summer Training Priority: ${currentTrainingSettings.summerTrainingStatPriority.length > 0 ? currentTrainingSettings.summerTrainingStatPriority.join(", ") : "None"}`)
         settings.push(`Max Failure Chance: ${currentTrainingSettings.maximumFailureChance}%`)
         settings.push(`Disable on Maxed: ${currentTrainingSettings.disableTrainingOnMaxedStat ? "Yes" : "No"}`)
         settings.push(`Focus on Sparks: ${currentTrainingSettings.focusOnSparkStatTarget ? "Yes" : "No"}`)

--- a/src/context/BotStateContext.tsx
+++ b/src/context/BotStateContext.tsx
@@ -127,6 +127,8 @@ export interface Settings {
     training: {
         trainingBlacklist: string[]
         statPrioritization: string[]
+        eventChoiceStatPriority: string[]
+        summerTrainingStatPriority: string[]
         maximumFailureChance: number
         disableTrainingOnMaxedStat: boolean
         focusOnSparkStatTarget: string[]
@@ -368,6 +370,8 @@ export const defaultSettings: Settings = {
     training: {
         trainingBlacklist: [],
         statPrioritization: ["Speed", "Stamina", "Power", "Wit", "Guts"],
+        eventChoiceStatPriority: ["Speed", "Stamina", "Power", "Wit", "Guts"],
+        summerTrainingStatPriority: ["Speed", "Stamina", "Power", "Wit", "Guts"],
         maximumFailureChance: 20,
         disableTrainingOnMaxedStat: true,
         focusOnSparkStatTarget: ["Speed", "Stamina", "Power"],

--- a/src/data/searchConfig.ts
+++ b/src/data/searchConfig.ts
@@ -87,6 +87,18 @@ const searchConfig: SearchOption[] = [
         page: "TrainingSettings",
     },
     {
+        id: "event-choice-stat-priority",
+        title: "Event Choice Prioritization",
+        description: "Select the priority order of stats used when scoring in-game event choices. Events typically grant flat stat gains, so a different ordering than regular training may be optimal.",
+        page: "TrainingSettings",
+    },
+    {
+        id: "summer-training-stat-priority",
+        title: "Summer Training Prioritization",
+        description: "Select the priority order of stats used during Summer Training. Facility levels are maxed during summer with no facility progression, so a different ordering than regular training may be optimal.",
+        page: "TrainingSettings",
+    },
+    {
         id: "disable-training-on-maxed-stats",
         title: "Disable Training on Maxed Stats",
         description: "When enabled, training will be skipped for stats that have reached their maximum value.",

--- a/src/hooks/useSettingsManager.tsx
+++ b/src/hooks/useSettingsManager.tsx
@@ -143,8 +143,10 @@ export const useSettingsManager = () => {
 
             // Load from SQLite database.
             let newSettings: Settings = JSON.parse(JSON.stringify(defaultSettings))
+            let rawDbSettings: any = undefined
             try {
                 const dbSettings = await databaseManager.loadAllSettings()
+                rawDbSettings = dbSettings
                 // Use deep merge to preserve nested default values.
                 newSettings = deepMerge(defaultSettings, dbSettings as Partial<Settings>)
                 logWithTimestamp(`[SettingsManager] Settings loaded from SQLite database ${context}.`)
@@ -154,7 +156,7 @@ export const useSettingsManager = () => {
             }
 
             // Apply all migrations to the settings.
-            const { settings: migratedSettings, anyMigrated } = applyMigrations(newSettings)
+            const { settings: migratedSettings, anyMigrated } = applyMigrations(newSettings, rawDbSettings)
             newSettings = migratedSettings
 
             // If any migration occurred, save the migrated settings back to the database.
@@ -214,7 +216,7 @@ export const useSettingsManager = () => {
     const fixSettings = (decoded: Settings): Settings => {
         const merged = deepMerge(defaultSettings, decoded as Partial<Settings>)
         // Apply all migrations to the settings.
-        const { settings } = applyMigrations(merged)
+        const { settings } = applyMigrations(merged, decoded)
         return settings
     }
 

--- a/src/lib/settingsUtils.ts
+++ b/src/lib/settingsUtils.ts
@@ -37,10 +37,12 @@ export const convertSettingsToBatch = (settings: Record<string, any>) => {
 
 /**
  * Applies all registered migrations to the Settings object.
- * @param settings - The Settings object to apply migrations to.
+ * @param settings - The Settings object to apply migrations to (already merged with defaults).
+ * @param rawSettings - Optional raw settings (pre-merge) used to detect fields that were absent in the persisted store.
+ *   Required by migrations that need to distinguish "user never set this" from "user set this to the default value".
  * @returns An object containing the migrated Settings object and a boolean indicating whether any migrations were applied.
  */
-export const applyMigrations = (settings: any): { settings: any; anyMigrated: boolean } => {
+export const applyMigrations = (settings: any, rawSettings?: any): { settings: any; anyMigrated: boolean } => {
     let anyMigrated = false
     let migratedSettings = settings
 
@@ -79,6 +81,24 @@ export const applyMigrations = (settings: any): { settings: any; anyMigrated: bo
     // After moving all OCR settings, delete the empty ocr object.
     if (migratedSettings && (migratedSettings as any).ocr && Object.keys((migratedSettings as any).ocr).length === 0) {
         delete (migratedSettings as any).ocr
+    }
+
+    // Migration: Mirror statPrioritization into eventChoiceStatPriority and summerTrainingStatPriority for users
+    // upgrading from a version that only had a single stat priority list. The new keys are absent in the persisted
+    // settings, so deepMerge fills them with the canonical default — but we want them to match the user's main list.
+    const rawTraining = rawSettings?.training as any
+    const training = migratedSettings.training as any
+    if (training && rawTraining) {
+        if (rawTraining.eventChoiceStatPriority === undefined && Array.isArray(training.statPrioritization)) {
+            training.eventChoiceStatPriority = [...training.statPrioritization]
+            anyMigrated = true
+            logWithTimestamp("[SettingsManager] Mirrored statPrioritization into eventChoiceStatPriority for upgrade.")
+        }
+        if (rawTraining.summerTrainingStatPriority === undefined && Array.isArray(training.statPrioritization)) {
+            training.summerTrainingStatPriority = [...training.statPrioritization]
+            anyMigrated = true
+            logWithTimestamp("[SettingsManager] Mirrored statPrioritization into summerTrainingStatPriority for upgrade.")
+        }
     }
 
     // Migration: Convert single stopAtDate string to stopAtDates array.

--- a/src/pages/TrainingSettings/index.tsx
+++ b/src/pages/TrainingSettings/index.tsx
@@ -38,6 +38,8 @@ const TrainingSettings = () => {
     const { currentProfileName } = useProfileManager()
     const [blacklistModalVisible, setBlacklistModalVisible] = useState(false)
     const [prioritizationModalVisible, setPrioritizationModalVisible] = useState(false)
+    const [eventChoicePrioritizationModalVisible, setEventChoicePrioritizationModalVisible] = useState(false)
+    const [summerTrainingPrioritizationModalVisible, setSummerTrainingPrioritizationModalVisible] = useState(false)
     const [sparkStatTargetModalVisible, setSparkStatTargetModalVisible] = useState(false)
     const [snackbarVisible, setSnackbarVisible] = useState(false)
     const [snackbarMessage, setSnackbarMessage] = useState("")
@@ -45,6 +47,12 @@ const TrainingSettings = () => {
     // Initialize local state from settings, with fallback to defaults.
     const [statPrioritizationItems, setStatPrioritizationItems] = useState<string[]>(() =>
         training?.statPrioritization !== undefined ? training.statPrioritization : defaultSettings.training.statPrioritization
+    )
+    const [eventChoiceStatPriorityItems, setEventChoiceStatPriorityItems] = useState<string[]>(() =>
+        training?.eventChoiceStatPriority !== undefined ? training.eventChoiceStatPriority : defaultSettings.training.eventChoiceStatPriority
+    )
+    const [summerTrainingStatPriorityItems, setSummerTrainingStatPriorityItems] = useState<string[]>(() =>
+        training?.summerTrainingStatPriority !== undefined ? training.summerTrainingStatPriority : defaultSettings.training.summerTrainingStatPriority
     )
     const [blacklistItems, setBlacklistItems] = useState<string[]>(() => (training?.trainingBlacklist !== undefined ? training.trainingBlacklist : defaultSettings.training.trainingBlacklist))
     const [sparkStatTargetItems, setSparkStatTargetItems] = useState<string[]>(() => {
@@ -67,9 +75,11 @@ const TrainingSettings = () => {
             ...training,
             trainingBlacklist: blacklistItems,
             statPrioritization: statPrioritizationItems,
+            eventChoiceStatPriority: eventChoiceStatPriorityItems,
+            summerTrainingStatPriority: summerTrainingStatPriorityItems,
             focusOnSparkStatTarget: sparkStatTargetItems,
         }),
-        [training, blacklistItems, statPrioritizationItems, sparkStatTargetItems]
+        [training, blacklistItems, statPrioritizationItems, eventChoiceStatPriorityItems, summerTrainingStatPriorityItems, sparkStatTargetItems]
     )
 
     const trainingStatTargetSettings = useMemo(() => ({ ...defaultSettings.trainingStatTarget, ...trainingStatTarget }), [trainingStatTarget])
@@ -98,6 +108,22 @@ const TrainingSettings = () => {
             }
         }
     }, [statPrioritizationItems])
+
+    useEffect(() => {
+        if (isMounted.current) {
+            if (!shallowArrayEqual(training?.eventChoiceStatPriority, eventChoiceStatPriorityItems)) {
+                updateTrainingSetting("eventChoiceStatPriority", eventChoiceStatPriorityItems)
+            }
+        }
+    }, [eventChoiceStatPriorityItems])
+
+    useEffect(() => {
+        if (isMounted.current) {
+            if (!shallowArrayEqual(training?.summerTrainingStatPriority, summerTrainingStatPriorityItems)) {
+                updateTrainingSetting("summerTrainingStatPriority", summerTrainingStatPriorityItems)
+            }
+        }
+    }, [summerTrainingStatPriorityItems])
 
     useEffect(() => {
         if (isMounted.current) {
@@ -134,6 +160,20 @@ const TrainingSettings = () => {
             setStatPrioritizationItems(newVal)
         }
     }, [training?.statPrioritization])
+
+    useEffect(() => {
+        const newVal = training?.eventChoiceStatPriority
+        if (newVal !== undefined && !shallowArrayEqual(newVal, eventChoiceStatPriorityItems)) {
+            setEventChoiceStatPriorityItems(newVal)
+        }
+    }, [training?.eventChoiceStatPriority])
+
+    useEffect(() => {
+        const newVal = training?.summerTrainingStatPriority
+        if (newVal !== undefined && !shallowArrayEqual(newVal, summerTrainingStatPriorityItems)) {
+            setSummerTrainingStatPriorityItems(newVal)
+        }
+    }, [training?.summerTrainingStatPriority])
 
     useEffect(() => {
         const newVal = training?.focusOnSparkStatTarget
@@ -185,7 +225,7 @@ const TrainingSettings = () => {
             } as Settings
 
             // Apply migrations to the merged settings.
-            const { settings: migratedSettings } = applyMigrations(mergedSettings)
+            const { settings: migratedSettings } = applyMigrations(mergedSettings, profileSettings)
 
             // Create the updated settings object with the migrated profile settings.
             const updatedSettings = {
@@ -475,6 +515,28 @@ const TrainingSettings = () => {
                             "Select the priority order of the stats. The stats will be trained in the order they are selected. If none are selected, then the default order will be used.",
                             "priority",
                             "training-prioritization"
+                        )}
+
+                        {renderStatSelector(
+                            "Event Choice Prioritization",
+                            eventChoiceStatPriorityItems,
+                            (value) => setEventChoiceStatPriorityItems(value),
+                            eventChoicePrioritizationModalVisible,
+                            setEventChoicePrioritizationModalVisible,
+                            "Select the priority order of stats used when scoring in-game event choices. Events typically grant flat stat gains, so a different ordering than regular training may be optimal.",
+                            "priority",
+                            "event-choice-stat-priority"
+                        )}
+
+                        {renderStatSelector(
+                            "Summer Training Prioritization",
+                            summerTrainingStatPriorityItems,
+                            (value) => setSummerTrainingStatPriorityItems(value),
+                            summerTrainingPrioritizationModalVisible,
+                            setSummerTrainingPrioritizationModalVisible,
+                            "Select the priority order of stats used during Summer Training. Facility levels are maxed during summer with no facility progression, so a different ordering than regular training may be optimal.",
+                            "priority",
+                            "summer-training-stat-priority"
                         )}
 
                         <View style={styles.section}>


### PR DESCRIPTION
## Description

- This PR resolves #295 by adding two new stat priority lists — `eventChoiceStatPriority` and `summerTrainingStatPriority` — alongside the existing `statPrioritization`, so users can score in-game event choices, regular training, and Summer Training with independent stat orderings. Event choice scoring in `TrainingEvent.kt` now consults `eventChoiceStatPriority`, and `calculateStatEfficiencyScore()` switches to `summerTrainingStatPriority` when `config.currentDate.isSummer()`.
- Existing users are migrated silently: `applyMigrations()` mirrors their current `statPrioritization` into both new lists when the keys are absent in the persisted settings, so behavior is unchanged until they reorder. The new lists are wired into `TrainingSettings`, `searchConfig`, the `MessageLog` banner, and the `ProfileCreationModal` preview.
