### PR TITLE
Reduce page nav latency, toggle blocking, and re-rendering impacting the performance

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
         "test:watch": "jest --watch",
         "test:coverage": "jest --coverage",
         "test:kt": "cd android && ./gradlew test",
-        "build:doc-index": "tsx scripts/build-doc-index.ts"
+        "build:doc-index": "tsx scripts/build-doc-index.ts",
+        "perf:nav": "tsx scripts/perf-nav-test.ts"
     },
     "dependencies": {
         "@expo/vector-icons": "^15.0.3",

--- a/scripts/perf-nav-test.ts
+++ b/scripts/perf-nav-test.ts
@@ -1,0 +1,294 @@
+#!/usr/bin/env tsx
+/**
+ * Scripted navigation-latency check. Drives the connected emulator over `adb`, taps a sequence
+ * of drawer links, then captures the resulting `[PERF]` and `[BLOCK]` logcat lines and asserts
+ * each navigation phase finishes under a configured budget.
+ *
+ * Run via: `yarn perf:nav` (see package.json) or `tsx scripts/perf-nav-test.ts`.
+ *
+ * The script is intentionally narrow:
+ *   1. Force-stop and relaunch the app so we measure cold mounts of each page.
+ *   2. For each scenario, open the drawer (swipe-from-left), tap the named row, wait, capture logs.
+ *   3. Parse `[PERF] UI - navigation_to_<route>_<phase>: <ms>ms` lines and the cumulative
+ *      `navigation_to_<route>: <ms>ms` line. Print a summary and exit non-zero if any number
+ *      exceeds the budget below.
+ *
+ * The script is *not* a substitute for a manual perception check — but it gives a stable number
+ * we can put on regressions.
+ */
+
+import { execSync } from "child_process"
+
+const DEVICE = process.env.ANDROID_DEVICE ?? "192.168.0.102:5555"
+const PACKAGE = "com.steve1316.uma_android_automation"
+const ACTIVITY = "com.steve1316.uma_android_automation/.MainActivity"
+
+// Tap coordinates for drawer-row labels. Calibrated via `adb shell uiautomator dump` on the
+// user's emulator (1080x1920 portrait, drawer width 280dp). Each (tapX, tapY) is the *centre of
+// the row's text label* — RN's TouchableOpacity rows aren't reported as clickable to
+// `uiautomator`, so we can't auto-discover them; recapture with the helper at the bottom of
+// this file if the layout shifts.
+//
+// `expandTapX/Y`, when set, performs a pre-tap (the chevron next to the parent row) before the
+// main row tap. Used for nested routes (Smart Race Solver lives under Racing Settings — tapping
+// the Racing label navigates instead of expanding, so we tap the chevron at its right edge).
+interface NavScenario {
+    name: string
+    route: string
+    tapX: number
+    tapY: number
+    expandTapX?: number
+    expandTapY?: number
+    /**
+     * Coordinate of a known checkbox-style toggle on the destination page. When set, the harness
+     * waits for the page to settle, taps the toggle, and measures `[BLOCK]` events for
+     * [TOGGLE_CAPTURE_MS] to surface re-render fan-out cost on already-mounted pages.
+     */
+    toggleTapX?: number
+    toggleTapY?: number
+}
+
+const SCENARIOS: NavScenario[] = [
+    { name: "Settings", route: "Settings", tapX: 213, tapY: 479, toggleTapX: 200, toggleTapY: 1670 },
+    { name: "Training Settings", route: "TrainingSettings", tapX: 255, tapY: 565 },
+    { name: "Racing Settings", route: "RacingSettings", tapX: 229, tapY: 744 },
+    // Smart Race Solver lives on the `smart-race-solver` feature branch only. Add a scenario
+    // here once that branch lands on master.
+]
+
+// Per-phase budget (ms). Soft thresholds — we report breaches but don't fail the run unless the
+// total exceeds [TOTAL_BUDGET_MS]. Tighten as we improve.
+const PHASE_BUDGETS_MS: Record<string, number> = {
+    drawer_closed: 100,
+    dispatch: 250,
+    first_commit: 800,
+}
+const TOTAL_BUDGET_MS = 1500
+
+// How long after a toggle tap to keep listening for `[BLOCK]` / `[SLOW-COMMIT]` events. The
+// reported blocked-time is the sum of every `[BLOCK]` line that fires inside this window.
+const TOGGLE_CAPTURE_MS = 3500
+const TOGGLE_BUDGET_MS = 100
+
+// Cold-start budget: from `am force-stop` + `am start` to the first `Home_mount` log.
+const COLD_START_BUDGET_MS = 3000
+
+interface PhaseSample {
+    route: string
+    phase: string
+    ms: number
+}
+
+const sh = (cmd: string, opts: { check?: boolean; timeoutMs?: number } = {}): string => {
+    try {
+        return execSync(cmd, { encoding: "utf8", timeout: opts.timeoutMs ?? 15000, stdio: ["ignore", "pipe", "pipe"] })
+    } catch (e) {
+        if (opts.check === false) return ""
+        throw e
+    }
+}
+
+const adb = (args: string, timeoutMs = 15000): string => sh(`adb -s ${DEVICE} ${args}`, { timeoutMs })
+
+const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms))
+
+/**
+ * Capture `adb logcat` for [windowMs] milliseconds and return the collected lines. Uses
+ * `adb logcat -c` then sleeps then `adb logcat -d` (one-shot) — simpler and less prone to
+ * hung child processes than streaming `spawn`.
+ *
+ * @param windowMs Capture duration in milliseconds.
+ * @returns The combined stdout of `adb logcat -d` over the window.
+ */
+const captureLogcat = async (windowMs: number): Promise<string> => {
+    adb("logcat -c", 10000)
+    await sleep(windowMs)
+    return adb('logcat -d -v brief ReactNativeJS:V "*:S"', 15000)
+}
+
+const PHASE_RE = /\[PERF\] UI - navigation_to_([A-Za-z]+)_([a-z_]+): ([\d.]+)ms/
+const TOTAL_RE = /\[PERF\] UI - navigation_to_([A-Za-z]+): ([\d.]+)ms/
+const BLOCK_RE = /\[BLOCK\] JS thread blocked for (\d+)ms/
+const SLOW_COMMIT_RE = /\[SLOW-COMMIT\] (\S+) commit took (\d+)ms/
+
+interface Sample {
+    phases: PhaseSample[]
+    totals: Map<string, number>
+    blocks: number[]
+    slowCommits: Array<{ component: string; ms: number }>
+}
+
+const parseSamples = (logs: string): Sample => {
+    const phases: PhaseSample[] = []
+    const totals = new Map<string, number>()
+    const blocks: number[] = []
+    const slowCommits: Array<{ component: string; ms: number }> = []
+    for (const line of logs.split("\n")) {
+        const p = PHASE_RE.exec(line)
+        if (p) {
+            phases.push({ route: p[1], phase: p[2], ms: parseFloat(p[3]) })
+            continue
+        }
+        const t = TOTAL_RE.exec(line)
+        if (t) {
+            totals.set(t[1], parseFloat(t[2]))
+            continue
+        }
+        const b = BLOCK_RE.exec(line)
+        if (b) blocks.push(parseInt(b[1], 10))
+        const s = SLOW_COMMIT_RE.exec(line)
+        if (s) slowCommits.push({ component: s[1], ms: parseInt(s[2], 10) })
+    }
+    return { phases, totals, blocks, slowCommits }
+}
+
+const openDrawer = () => {
+    // Edge-swipe right from x=5 to x=600.
+    adb("shell input swipe 5 600 600 600 80")
+}
+
+const tapAt = (x: number, y: number) => {
+    adb(`shell input tap ${x} ${y}`)
+}
+
+interface ScenarioResult {
+    route: string
+    total: number
+    phases: PhaseSample[]
+    navBlocks: number[]
+    toggleBlockedMs: number | null
+    toggleBlocks: number[]
+    toggleSlowCommits: Array<{ component: string; ms: number }>
+}
+
+/**
+ * Cold-start phase: force-stop the app, relaunch via `am start -W` (which blocks until the
+ * launcher activity is displayed and reports `TotalTime`), then watch for the `Home_mount`
+ * log so we measure JS-side readiness instead of just the activity-display point.
+ *
+ * @returns Cold-start time in ms, or `-1` if the `Home_mount` log never landed in the window.
+ */
+const measureColdStart = async (): Promise<number> => {
+    console.log("\n=== Cold start ===")
+    adb(`shell am force-stop ${PACKAGE}`)
+    await sleep(500)
+    adb("logcat -c", 10000)
+    const t0 = Date.now()
+    // `am start -W` waits for the activity to be displayed and prints `TotalTime` in ms.
+    const startOut = adb(`shell am start -W -n ${ACTIVITY}`, 30000)
+    const totalTimeMatch = /TotalTime: (\d+)/.exec(startOut)
+    const activityDisplayMs = totalTimeMatch ? parseInt(totalTimeMatch[1], 10) : -1
+    // Wait until either Home_mount lands or we hit a 10 s ceiling.
+    let homeMountMs = -1
+    for (let i = 0; i < 20; i++) {
+        await sleep(500)
+        const logs = adb('logcat -d -v brief ReactNativeJS:V "*:S"', 10000)
+        if (/Home_mount/.test(logs)) {
+            homeMountMs = Date.now() - t0
+            break
+        }
+    }
+    console.log(`  activity_display: ${activityDisplayMs}ms`)
+    console.log(`  ${homeMountMs <= COLD_START_BUDGET_MS ? "✓" : "✗"} home_mount:      ${homeMountMs}ms (budget ${COLD_START_BUDGET_MS}ms)`)
+    return homeMountMs
+}
+
+const main = async () => {
+    console.log(`Targeting ${DEVICE} (${PACKAGE})`)
+    const coldStartMs = await measureColdStart()
+    // Give the post-mount cascade time to finish before we start probing nav.
+    await sleep(3500)
+
+    let anyBreach = coldStartMs < 0 || coldStartMs > COLD_START_BUDGET_MS
+    const summary: ScenarioResult[] = []
+
+    for (const sc of SCENARIOS) {
+        console.log(`\n=== ${sc.name} ===`)
+        // Re-open drawer fresh each time so the prior nav doesn't bleed into the next.
+        openDrawer()
+        await sleep(700)
+
+        // Some scenarios live behind a chevron expansion. Tap the chevron first and let the
+        // disclosure animation settle before the actual nav tap.
+        if (sc.expandTapX != null && sc.expandTapY != null) {
+            tapAt(sc.expandTapX, sc.expandTapY)
+            await sleep(700)
+        }
+
+        const logsPromise = captureLogcat(4000)
+        tapAt(sc.tapX, sc.tapY)
+        const navLogs = await logsPromise
+
+        const { phases, totals, blocks: navBlocks } = parseSamples(navLogs)
+        const total = totals.get(sc.route) ?? -1
+        const routePhases = phases.filter((p) => p.route === sc.route)
+
+        console.log(`  total: ${total}ms (budget ${TOTAL_BUDGET_MS}ms)`)
+        for (const p of routePhases) {
+            const budget = PHASE_BUDGETS_MS[p.phase]
+            const tag = budget != null && p.ms > budget ? "  ✗" : "  ✓"
+            console.log(`${tag} ${p.phase.padEnd(16)} ${p.ms.toFixed(0)}ms${budget != null ? ` (budget ${budget}ms)` : ""}`)
+            if (budget != null && p.ms > budget) anyBreach = true
+        }
+        if (navBlocks.length > 0) {
+            console.log(`  nav blocks: ${navBlocks.join("ms, ")}ms`)
+        }
+        if (total > TOTAL_BUDGET_MS) anyBreach = true
+
+        // Toggle phase. Wait for the deferred-render cascade to settle, then tap the known
+        // checkbox and re-capture. Sum every `[BLOCK]` event that lands in the window.
+        let toggleBlockedMs: number | null = null
+        let toggleBlocks: number[] = []
+        let toggleSlowCommits: Array<{ component: string; ms: number }> = []
+        if (sc.toggleTapX != null && sc.toggleTapY != null) {
+            // Let any deferred-render cascade settle so its blocks don't get attributed to the
+            // toggle.
+            await sleep(2500)
+            const tLogsPromise = captureLogcat(TOGGLE_CAPTURE_MS)
+            tapAt(sc.toggleTapX, sc.toggleTapY)
+            const tLogs = await tLogsPromise
+            const tParsed = parseSamples(tLogs)
+            toggleBlocks = tParsed.blocks
+            toggleSlowCommits = tParsed.slowCommits
+            toggleBlockedMs = toggleBlocks.reduce((a, b) => a + b, 0)
+            const tag = toggleBlockedMs <= TOGGLE_BUDGET_MS ? "  ✓" : "  ✗"
+            console.log(`${tag} toggle blocked   ${toggleBlockedMs}ms (budget ${TOGGLE_BUDGET_MS}ms)`)
+            if (toggleBlocks.length > 0) console.log(`    block events: ${toggleBlocks.join("ms, ")}ms`)
+            if (toggleSlowCommits.length > 0) {
+                const top = toggleSlowCommits.sort((a, b) => b.ms - a.ms).slice(0, 5)
+                console.log(`    slow commits: ${top.map((c) => `${c.component}=${c.ms}ms`).join(", ")}`)
+            }
+            if (toggleBlockedMs > TOGGLE_BUDGET_MS) anyBreach = true
+            // Toggle it back so subsequent runs don't drift the user's settings forever.
+            tapAt(sc.toggleTapX, sc.toggleTapY)
+            await sleep(800)
+        }
+
+        summary.push({ route: sc.route, total, phases: routePhases, navBlocks, toggleBlockedMs, toggleBlocks, toggleSlowCommits })
+
+        // Reset to a known state by re-launching the activity rather than relying on BACK
+        // semantics (which differ for drawer-level vs stack-level screens). singleTask + the
+        // launcher intent brings the existing task to front at its root (Home).
+        adb(`shell am start -W -n ${ACTIVITY} -a android.intent.action.MAIN -c android.intent.category.LAUNCHER`, 15000)
+        await sleep(1500)
+    }
+
+    console.log("\n=== Summary ===")
+    console.log(`  cold_start ${coldStartMs}ms`)
+    for (const s of summary) {
+        const phasePart = s.phases.map((p) => `${p.phase}=${p.ms.toFixed(0)}`).join(" ")
+        const togglePart = s.toggleBlockedMs != null ? ` toggle_blocked=${s.toggleBlockedMs}ms` : ""
+        console.log(`  ${s.route.padEnd(28)} total=${s.total}ms ${phasePart}${togglePart}`)
+    }
+
+    if (anyBreach) {
+        console.log("\nFAIL: at least one phase exceeded its budget.")
+        process.exit(1)
+    }
+    console.log("\nPASS")
+}
+
+void main().catch((e) => {
+    console.error(e)
+    process.exit(1)
+})

--- a/scripts/perf-nav-test.ts
+++ b/scripts/perf-nav-test.ts
@@ -48,12 +48,25 @@ interface NavScenario {
     toggleTapY?: number
 }
 
+// Coordinates calibrated 2026-05-01 with `enableAskTheDocs=true` (Chat row inserted between
+// Home and Settings; pushes everything below it down ~91 px). If that toggle is later disabled,
+// re-dump and shift these up.
 const SCENARIOS: NavScenario[] = [
     { name: "Settings", route: "Settings", tapX: 213, tapY: 479, toggleTapX: 200, toggleTapY: 1670 },
+    // Settings expands by default; nested rows start at y=565 with a vertical stride of ~89 px.
     { name: "Training Settings", route: "TrainingSettings", tapX: 255, tapY: 565 },
+    { name: "Training Event Settings", route: "TrainingEventSettings", tapX: 280, tapY: 652 },
     { name: "Racing Settings", route: "RacingSettings", tapX: 229, tapY: 744 },
+    { name: "Skill Settings", route: "SkillSettings", tapX: 220, tapY: 826 },
+    { name: "Event Log Visualizer", route: "EventLogVisualizer", tapX: 250, tapY: 904 },
+    { name: "Discord Settings", route: "DiscordSettings", tapX: 220, tapY: 978 },
+    { name: "Scenario Overrides Settings", route: "ScenarioOverridesSettings", tapX: 290, tapY: 1065 },
+    { name: "Debug Settings", route: "DebugSettings", tapX: 220, tapY: 1153 },
+    { name: "LLM Settings", route: "LLMSettings", tapX: 220, tapY: 1227 },
     // Smart Race Solver lives on the `smart-race-solver` feature branch only. Add a scenario
     // here once that branch lands on master.
+    // RacingPlanSettings / SkillPlanSettings are sub-nested and need a multi-tap nav (expand
+    // chevron then tap row) — not scripted yet.
 ]
 
 // Per-phase budget (ms). Soft thresholds — we report breaches but don't fail the run unless the

--- a/scripts/perf-nav-test.ts
+++ b/scripts/perf-nav-test.ts
@@ -1,4 +1,3 @@
-#!/usr/bin/env tsx
 /**
  * Scripted navigation-latency check. Drives the connected emulator over `adb`, taps a sequence
  * of drawer links, then captures the resulting `[PERF]` and `[BLOCK]` logcat lines and asserts
@@ -32,23 +31,33 @@ const ACTIVITY = "com.steve1316.uma_android_automation/.MainActivity"
 // `expandTapX/Y`, when set, performs a pre-tap (the chevron next to the parent row) before the
 // main row tap. Used for nested routes (Smart Race Solver lives under Racing Settings — tapping
 // the Racing label navigates instead of expanding, so we tap the chevron at its right edge).
+/**
+ * One drawer-driven navigation scenario for the harness to exercise.
+ */
 interface NavScenario {
+    /** Human-readable label printed in the harness summary. */
     name: string
+    /** Route name as it appears in `[PERF] UI - navigation_to_<route>` log lines. */
     route: string
+    /** X-coordinate (px) for the drawer-row tap that triggers navigation. */
     tapX: number
+    /** Y-coordinate (px) for the drawer-row tap that triggers navigation. */
     tapY: number
+    /** Optional X-coordinate of a chevron tap to expand a parent row before navigating. */
     expandTapX?: number
+    /** Optional Y-coordinate of a chevron tap to expand a parent row before navigating. */
     expandTapY?: number
     /**
-     * Coordinate of a known checkbox-style toggle on the destination page. When set, the harness
-     * waits for the page to settle, taps the toggle, and measures `[BLOCK]` events for
-     * [TOGGLE_CAPTURE_MS] to surface re-render fan-out cost on already-mounted pages.
+     * Coordinate of a known checkbox on the destination page. When set, the harness
+     * waits for the page to settle, taps the checkbox, and measures `[BLOCK]` events for
+     * `TOGGLE_CAPTURE_MS` to surface re-render fan-out cost on already-mounted pages.
      */
     toggleTapX?: number
+    /** Companion Y-coordinate to `toggleTapX`. */
     toggleTapY?: number
 }
 
-// Coordinates calibrated 2026-05-01 with `enableAskTheDocs=true` (Chat row inserted between
+// Coordinates calibrated with `enableAskTheDocs=true` (Chat row inserted between
 // Home and Settings; pushes everything below it down ~91 px). If that toggle is later disabled,
 // re-dump and shift these up.
 const SCENARIOS: NavScenario[] = [
@@ -63,8 +72,6 @@ const SCENARIOS: NavScenario[] = [
     { name: "Scenario Overrides Settings", route: "ScenarioOverridesSettings", tapX: 290, tapY: 1065 },
     { name: "Debug Settings", route: "DebugSettings", tapX: 220, tapY: 1153 },
     { name: "LLM Settings", route: "LLMSettings", tapX: 220, tapY: 1227 },
-    // Smart Race Solver lives on the `smart-race-solver` feature branch only. Add a scenario
-    // here once that branch lands on master.
     // RacingPlanSettings / SkillPlanSettings are sub-nested and need a multi-tap nav (expand
     // chevron then tap row) — not scripted yet.
 ]
@@ -86,12 +93,24 @@ const TOGGLE_BUDGET_MS = 100
 // Cold-start budget: from `am force-stop` + `am start` to the first `Home_mount` log.
 const COLD_START_BUDGET_MS = 3000
 
+/**
+ * One parsed `[PERF] UI - navigation_to_<route>_<phase>` sample.
+ */
 interface PhaseSample {
+    /** Route name extracted from the log line. */
     route: string
+    /** Phase name (e.g. `drawer_closed`, `dispatch`, `first_commit`). */
     phase: string
+    /** Phase duration in milliseconds. */
     ms: number
 }
 
+/**
+ * Run a shell command synchronously and return its stdout.
+ * @param cmd - The full command line to execute.
+ * @param opts - Options bag. `check` defaults to `true`; pass `false` to swallow non-zero exits and return an empty string. `timeoutMs` defaults to 15000.
+ * @returns The captured stdout as a UTF-8 string.
+ */
 const sh = (cmd: string, opts: { check?: boolean; timeoutMs?: number } = {}): string => {
     try {
         return execSync(cmd, { encoding: "utf8", timeout: opts.timeoutMs ?? 15000, stdio: ["ignore", "pipe", "pipe"] })
@@ -101,16 +120,27 @@ const sh = (cmd: string, opts: { check?: boolean; timeoutMs?: number } = {}): st
     }
 }
 
+/**
+ * Run an `adb -s <DEVICE> ...` command against the configured emulator/device.
+ * @param args - Arguments to pass to `adb` (everything after `-s <DEVICE>`).
+ * @param timeoutMs - Per-command timeout in milliseconds. Defaults to 15000.
+ * @returns The combined stdout of the command.
+ */
 const adb = (args: string, timeoutMs = 15000): string => sh(`adb -s ${DEVICE} ${args}`, { timeoutMs })
 
+/**
+ * Promise-based sleep helper.
+ * @param ms - Duration to sleep in milliseconds.
+ * @returns A promise that resolves once the duration has elapsed.
+ */
 const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms))
 
 /**
- * Capture `adb logcat` for [windowMs] milliseconds and return the collected lines. Uses
+ * Capture `adb logcat` for `windowMs` milliseconds and return the collected lines. Uses
  * `adb logcat -c` then sleeps then `adb logcat -d` (one-shot) — simpler and less prone to
  * hung child processes than streaming `spawn`.
  *
- * @param windowMs Capture duration in milliseconds.
+ * @param windowMs - Capture duration in milliseconds.
  * @returns The combined stdout of `adb logcat -d` over the window.
  */
 const captureLogcat = async (windowMs: number): Promise<string> => {
@@ -124,13 +154,25 @@ const TOTAL_RE = /\[PERF\] UI - navigation_to_([A-Za-z]+): ([\d.]+)ms/
 const BLOCK_RE = /\[BLOCK\] JS thread blocked for (\d+)ms/
 const SLOW_COMMIT_RE = /\[SLOW-COMMIT\] (\S+) commit took (\d+)ms/
 
+/**
+ * Aggregated parse result of one logcat capture window.
+ */
 interface Sample {
+    /** Per-phase navigation samples extracted from `[PERF] UI - navigation_to_<route>_<phase>` lines. */
     phases: PhaseSample[]
+    /** Cumulative `navigation_to_<route>` totals keyed by route. */
     totals: Map<string, number>
+    /** Every `[BLOCK] JS thread blocked for <n>ms` event observed in the window. */
     blocks: number[]
+    /** Every `[SLOW-COMMIT] <component> commit took <n>ms` event observed in the window. */
     slowCommits: Array<{ component: string; ms: number }>
 }
 
+/**
+ * Parse a logcat dump into the typed event buckets the harness reports on.
+ * @param logs - The raw stdout from `adb logcat -d`.
+ * @returns A `Sample` containing every phase, total, block, and slow-commit event.
+ */
 const parseSamples = (logs: string): Sample => {
     const phases: PhaseSample[] = []
     const totals = new Map<string, number>()
@@ -155,22 +197,42 @@ const parseSamples = (logs: string): Sample => {
     return { phases, totals, blocks, slowCommits }
 }
 
+/**
+ * Open the navigation drawer via an edge-swipe from `x=5` to `x=600`.
+ * @returns Nothing; the swipe event is fire-and-forget.
+ */
 const openDrawer = () => {
     // Edge-swipe right from x=5 to x=600.
     adb("shell input swipe 5 600 600 600 80")
 }
 
+/**
+ * Send a single `input tap` event to the device.
+ * @param x - X-coordinate (px) of the tap.
+ * @param y - Y-coordinate (px) of the tap.
+ * @returns Nothing; the tap event is fire-and-forget.
+ */
 const tapAt = (x: number, y: number) => {
     adb(`shell input tap ${x} ${y}`)
 }
 
+/**
+ * Aggregated metrics for one scenario run, used in the final summary table.
+ */
 interface ScenarioResult {
+    /** Route name (matches `NavScenario.route`). */
     route: string
+    /** Total `navigation_to_<route>` time in milliseconds, or `-1` if the log line never fired. */
     total: number
+    /** Per-phase samples for this scenario. */
     phases: PhaseSample[]
+    /** Every `[BLOCK]` event observed in the navigation window. */
     navBlocks: number[]
+    /** Sum of every `[BLOCK]` event in the toggle window, or `null` if no toggle was scripted. */
     toggleBlockedMs: number | null
+    /** Individual block events observed in the toggle window. */
     toggleBlocks: number[]
+    /** Every `[SLOW-COMMIT]` event observed in the toggle window. */
     toggleSlowCommits: Array<{ component: string; ms: number }>
 }
 
@@ -206,6 +268,12 @@ const measureColdStart = async (): Promise<number> => {
     return homeMountMs
 }
 
+/**
+ * Harness entrypoint. Runs the cold-start probe, then loops over every `NavScenario`,
+ * captures cold-nav and (where wired) toggle metrics, prints a summary table, and exits
+ * non-zero if any phase or toggle exceeds its configured budget.
+ * @returns A promise that resolves once the harness has finished printing its summary.
+ */
 const main = async () => {
     console.log(`Targeting ${DEVICE} (${PACKAGE})`)
     const coldStartMs = await measureColdStart()

--- a/scripts/perf-nav-test.ts
+++ b/scripts/perf-nav-test.ts
@@ -55,6 +55,20 @@ interface NavScenario {
     toggleTapX?: number
     /** Companion Y-coordinate to `toggleTapX`. */
     toggleTapY?: number
+    /**
+     * Sub-nested route name as it appears in `[PERF] UI - navigation_to_<subRoute>` log lines.
+     * When set, the harness performs a second navigation hop after the parent page settles:
+     * scroll the parent `subScrolls` times, tap `(subTapX, subTapY)` (the in-page link), and
+     * measure the sub-route's mount as if it were a fresh cold-nav. The parent's first nav
+     * still runs but its metrics are reported as warm-up for the sub-route's budget check.
+     */
+    subRoute?: string
+    /** Number of swipe-up gestures to perform on the parent page before tapping the sub-link. */
+    subScrolls?: number
+    /** X-coordinate (px) of the in-page link to the sub-nested route. */
+    subTapX?: number
+    /** Y-coordinate (px) of the in-page link to the sub-nested route. */
+    subTapY?: number
 }
 
 // Coordinates calibrated with `enableAskTheDocs=true` (Chat row inserted between
@@ -72,8 +86,39 @@ const SCENARIOS: NavScenario[] = [
     { name: "Scenario Overrides Settings", route: "ScenarioOverridesSettings", tapX: 290, tapY: 1065 },
     { name: "Debug Settings", route: "DebugSettings", tapX: 220, tapY: 1153 },
     { name: "LLM Settings", route: "LLMSettings", tapX: 220, tapY: 1227 },
-    // RacingPlanSettings / SkillPlanSettings are sub-nested and need a multi-tap nav (expand
-    // chevron then tap row) — not scripted yet.
+    // Sub-nested pages: navigate to the parent first, scroll to the in-page link, then tap. The
+    // sub-link y-coords are the on-screen position *after* the configured number of swipe-ups
+    // brings the link into view. Calibrated 2026-05-01 on the same emulator as the drawer rows.
+    //
+    // Order matters: navigating to a sub-route auto-expands the drawer to show that sub-route
+    // as a nested row, which shifts every drawer row *below* its parent down by ~89 px. Run
+    // Skill Plan first because Skill Settings (y=826) sits below Racing Settings (y=744) — the
+    // shift only affects rows below Skill Settings (none of which we touch later in the run).
+    // Reversing the order would shift Skill Settings out from under the Racing-Plan-iteration
+    // tap.
+    // The Skill Plan Settings page has 3 in-page entry links (Skill Point Check, Pre-Finals,
+    // Career Complete) that mount the same component under distinct route names — we measure
+    // the canonical "Skill Point Check" entry.
+    {
+        name: "Skill Plan Settings",
+        route: "SkillSettings",
+        tapX: 220,
+        tapY: 826,
+        subRoute: "SkillPlanSettingsSkillPointCheck",
+        subScrolls: 4,
+        subTapX: 540,
+        subTapY: 1474,
+    },
+    {
+        name: "Racing Plan Settings",
+        route: "RacingSettings",
+        tapX: 229,
+        tapY: 744,
+        subRoute: "RacingPlanSettings",
+        subScrolls: 3,
+        subTapX: 540,
+        subTapY: 1800,
+    },
 ]
 
 // Per-phase budget (ms). Soft thresholds — we report breaches but don't fail the run unless the
@@ -153,6 +198,12 @@ const PHASE_RE = /\[PERF\] UI - navigation_to_([A-Za-z]+)_([a-z_]+): ([\d.]+)ms/
 const TOTAL_RE = /\[PERF\] UI - navigation_to_([A-Za-z]+): ([\d.]+)ms/
 const BLOCK_RE = /\[BLOCK\] JS thread blocked for (\d+)ms/
 const SLOW_COMMIT_RE = /\[SLOW-COMMIT\] (\S+) commit took (\d+)ms/
+// Sub-routes are reached via in-page nav links rather than drawer rows, so they bypass
+// `markNavigationStart` and never get the `navigation_to_<route>` total. The destination's
+// `usePerformanceLogging` hook still fires `[PERF] UI - <component>_commit` on mount, and the
+// `Details` payload carries the real first-commit duration under `duration_ms` — we use that
+// as the sub-route's first-commit metric.
+const COMMIT_DURATION_RE = /\[PERF\] UI - ([A-Za-z]+)_commit: [\d.]+ms \| Details: \{[^}]*"duration_ms":([\d.]+)/
 
 /**
  * Aggregated parse result of one logcat capture window.
@@ -234,6 +285,12 @@ interface ScenarioResult {
     toggleBlocks: number[]
     /** Every `[SLOW-COMMIT]` event observed in the toggle window. */
     toggleSlowCommits: Array<{ component: string; ms: number }>
+    /** Sub-route name (matches `NavScenario.subRoute`), or `null` if this scenario has no sub-hop. */
+    subRoute: string | null
+    /** Total `navigation_to_<subRoute>` time in milliseconds, or `-1` if the log line never fired. */
+    subTotal: number
+    /** Per-phase samples for the sub-route's mount. */
+    subPhases: PhaseSample[]
 }
 
 /**
@@ -345,7 +402,60 @@ const main = async () => {
             await sleep(800)
         }
 
-        summary.push({ route: sc.route, total, phases: routePhases, navBlocks, toggleBlockedMs, toggleBlocks, toggleSlowCommits })
+        // Sub-route phase. Treat the parent page as already-warm: scroll its content the
+        // configured number of times to bring the in-page link into view, then tap it and
+        // measure the sub-route's commit-phase duration. In-page nav links bypass
+        // `markNavigationStart`, so we use the destination's `<Route>_commit` `duration_ms`
+        // as the first-commit metric (see `COMMIT_DURATION_RE`).
+        let subTotal = -1
+        let subPhases: PhaseSample[] = []
+        if (sc.subRoute && sc.subTapX != null && sc.subTapY != null) {
+            // Settle any deferred-render cascade on the parent page first.
+            await sleep(2500)
+            const scrolls = sc.subScrolls ?? 0
+            for (let i = 0; i < scrolls; i++) {
+                adb("shell input swipe 540 1500 540 200 100")
+                await sleep(400)
+            }
+            const subLogsPromise = captureLogcat(4000)
+            tapAt(sc.subTapX, sc.subTapY)
+            const subLogs = await subLogsPromise
+            for (const line of subLogs.split("\n")) {
+                const m = COMMIT_DURATION_RE.exec(line)
+                if (m && m[1] === sc.subRoute) {
+                    const ms = parseFloat(m[2])
+                    subTotal = ms
+                    subPhases = [{ route: sc.subRoute, phase: "first_commit", ms }]
+                    break
+                }
+            }
+            const firstCommitBudget = PHASE_BUDGETS_MS["first_commit"] ?? TOTAL_BUDGET_MS
+            const tag = subTotal > 0 && subTotal <= firstCommitBudget ? "  ✓" : "  ✗"
+            console.log(`${tag} sub_first_commit ${subTotal === -1 ? "no log" : `${subTotal.toFixed(0)}ms`} (${sc.subRoute}, budget ${firstCommitBudget}ms)`)
+            if (subTotal > firstCommitBudget || subTotal === -1) anyBreach = true
+            // The sub-route lives under a stack-pushed parent (Settings hub → RacingSettings →
+            // RacingPlanSettings). Inside a stack-pushed screen, edge-swipe is intercepted as
+            // stack-pop rather than drawer-open, so the next iteration's `openDrawer()` would
+            // silently fail. Pop twice to land back on the drawer-level Settings hub before
+            // the post-iteration `am start LAUNCHER` reset.
+            adb("shell input keyevent KEYCODE_BACK")
+            await sleep(500)
+            adb("shell input keyevent KEYCODE_BACK")
+            await sleep(500)
+        }
+
+        summary.push({
+            route: sc.route,
+            total,
+            phases: routePhases,
+            navBlocks,
+            toggleBlockedMs,
+            toggleBlocks,
+            toggleSlowCommits,
+            subRoute: sc.subRoute ?? null,
+            subTotal,
+            subPhases,
+        })
 
         // Reset to a known state by re-launching the activity rather than relying on BACK
         // semantics (which differ for drawer-level vs stack-level screens). singleTask + the
@@ -360,6 +470,10 @@ const main = async () => {
         const phasePart = s.phases.map((p) => `${p.phase}=${p.ms.toFixed(0)}`).join(" ")
         const togglePart = s.toggleBlockedMs != null ? ` toggle_blocked=${s.toggleBlockedMs}ms` : ""
         console.log(`  ${s.route.padEnd(28)} total=${s.total}ms ${phasePart}${togglePart}`)
+        if (s.subRoute) {
+            const subPhasePart = s.subPhases.map((p) => `${p.phase}=${p.ms.toFixed(0)}`).join(" ")
+            console.log(`    └─ ${s.subRoute.padEnd(24)} total=${s.subTotal}ms ${subPhasePart}`)
+        }
     }
 
     if (anyBreach) {

--- a/src/components/DrawerContent/index.tsx
+++ b/src/components/DrawerContent/index.tsx
@@ -4,7 +4,7 @@ import { DrawerContentScrollView, DrawerContentComponentProps, useDrawerStatus }
 import { CommonActions } from "@react-navigation/native"
 import { Ionicons } from "@expo/vector-icons"
 import { Avatar, AvatarImage } from "../ui/avatar"
-import { markNavigationStart } from "../../lib/performanceLogger"
+import { markNavigationStart, markNavigationPhase } from "../../lib/performanceLogger"
 import { useTheme } from "../../context/ThemeContext"
 import { ChatContext, BotMetaContext } from "../../context/BotStateContext"
 import { skillPlanSettingsPages } from "../../pages/SkillPlanSettings/config"
@@ -372,10 +372,12 @@ const DrawerContent: React.FC<DrawerContentComponentProps> = (props) => {
         // Close the drawer immediately to start the transition.
         // This achieves the effect of hiding the initial lag of mounting and rendering the target page while we are transitioning to it.
         navigation.closeDrawer()
+        markNavigationPhase(routeName, "drawer_closed")
 
         // Defer the heavy navigation until the drawer closing animation has been scheduled.
         // This prevents the target page's heavy mount/render from stuttering the drawer animation.
         setTimeout(() => {
+            markNavigationPhase(routeName, "dispatch")
             if (routeName === "Home") {
                 // Navigate to Home drawer screen.
                 navigation.dispatch(CommonActions.navigate({ name: "Home" }))

--- a/src/components/MessageLog/index.tsx
+++ b/src/components/MessageLog/index.tsx
@@ -1,6 +1,6 @@
 import { useContext, useState, useMemo, useCallback, memo, useEffect, useRef } from "react"
 import { MessageLogContext } from "../../context/MessageLogContext"
-import { BotStateContext } from "../../context/BotStateContext"
+import { BotMetaContext, Settings, useSettingsSnapshot } from "../../context/BotStateContext"
 import { useSettings } from "../../context/SettingsContext"
 import { databaseManager } from "../../lib/database"
 import { StyleSheet, Text, View, TextInput, TouchableOpacity, Animated } from "react-native"
@@ -192,7 +192,8 @@ const LogItem = memo(({ item, fontSize, onLongPress, enableMessageIdDisplay }: {
  */
 const MessageLog = () => {
     const mlc = useContext(MessageLogContext)
-    const bsc = useContext(BotStateContext)
+    const { appName, appVersion, setSettings } = useContext(BotMetaContext)
+    const settings = useSettingsSnapshot()
     const { saveSettingsImmediate } = useSettings()
     const [searchQuery, setSearchQuery] = useState("")
     const [showErrorDialog, setShowErrorDialog] = useState(false)
@@ -203,7 +204,7 @@ const MessageLog = () => {
     const [contentHeight, setContentHeight] = useState(0)
     const [viewportHeight, setViewportHeight] = useState(0)
 
-    const fontSize = bsc.settings.misc.messageLogFontSize
+    const fontSize = settings.misc.messageLogFontSize
     const maxFontSize = 24
     const minFontSize = 8
 
@@ -238,7 +239,7 @@ const MessageLog = () => {
     // Build the formatted settings welcome banner. Pure function of the settings snapshot;
     // the surrounding effect defers invocation so the heavy template-literal work stays off
     // the synchronous toggle path.
-    const buildFormattedSettings = useCallback((settings: typeof bsc.settings): string => {
+    const buildFormattedSettings = useCallback((settings: Settings): string => {
         // Training stat targets by distance.
         const sprintTargetsString = `Sprint: \n\t\tSpeed: ${settings.trainingStatTarget.trainingSprintStatTarget_speedStatTarget}\t\tStamina: ${settings.trainingStatTarget.trainingSprintStatTarget_staminaStatTarget}\t\tPower: ${settings.trainingStatTarget.trainingSprintStatTarget_powerStatTarget}\n\t\tGuts: ${settings.trainingStatTarget.trainingSprintStatTarget_gutsStatTarget}\t\t\tWit: ${settings.trainingStatTarget.trainingSprintStatTarget_witStatTarget}`
         const mileTargetsString = `Mile: \n\t\tSpeed: ${settings.trainingStatTarget.trainingMileStatTarget_speedStatTarget}\t\tStamina: ${settings.trainingStatTarget.trainingMileStatTarget_staminaStatTarget}\t\tPower: ${settings.trainingStatTarget.trainingMileStatTarget_powerStatTarget}\n\t\tGuts: ${settings.trainingStatTarget.trainingMileStatTarget_gutsStatTarget}\t\t\tWit: ${settings.trainingStatTarget.trainingMileStatTarget_witStatTarget}`
@@ -424,18 +425,18 @@ ${longTargetsString}
     // imported a populated settings file. We now compute it 250ms after the last settings
     // change, off the toggle's render commit. The intro/log path keeps using the previous
     // value until the new one lands; downstream memos bail out via `Object.is`.
-    const [formattedSettingsString, setFormattedSettingsString] = useState<string>(() => buildFormattedSettings(bsc.settings))
+    const [formattedSettingsString, setFormattedSettingsString] = useState<string>(() => buildFormattedSettings(settings))
     const formattedStringTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
     useEffect(() => {
         if (formattedStringTimerRef.current) clearTimeout(formattedStringTimerRef.current)
         formattedStringTimerRef.current = setTimeout(() => {
-            const next = buildFormattedSettings(bsc.settings)
+            const next = buildFormattedSettings(settings)
             setFormattedSettingsString((prev) => (prev === next ? prev : next))
         }, 250)
         return () => {
             if (formattedStringTimerRef.current) clearTimeout(formattedStringTimerRef.current)
         }
-    }, [bsc.settings, buildFormattedSettings])
+    }, [settings, buildFormattedSettings])
 
     // Persist the formatted string directly to SQLite. The Kotlin runtime is the only consumer
     // (via SettingsHelper.getStringSetting), so writing through `setSettings` would just trigger
@@ -457,7 +458,7 @@ ${longTargetsString}
      */
     const introMessage = useMemo(() => {
         const hasLogs = mlc.messageLog.length > 0
-        const baseMessage = `****************************************\nWelcome to ${bsc.appName} v${bsc.appVersion}\n****************************************`
+        const baseMessage = `****************************************\nWelcome to ${appName} v${appVersion}\n****************************************`
 
         // Don't add formattedSettingsString if logs are already present (Android already copied it).
         if (hasLogs) {
@@ -466,8 +467,8 @@ ${longTargetsString}
         }
 
         // Only include settings string if enabled and no logs exist yet.
-        return bsc.settings.misc.enableSettingsDisplay ? `${baseMessage}\n\n${formattedSettingsString}` : baseMessage
-    }, [bsc.appName, bsc.appVersion, bsc.settings.misc.enableSettingsDisplay, formattedSettingsString, mlc.messageLog.length])
+        return settings.misc.enableSettingsDisplay ? `${baseMessage}\n\n${formattedSettingsString}` : baseMessage
+    }, [appName, appVersion, settings.misc.enableSettingsDisplay, formattedSettingsString, mlc.messageLog.length])
 
     /**
      * Process log messages with color coding and virtualization while sorting them by timestamp.
@@ -724,12 +725,12 @@ ${longTargetsString}
     const increaseFontSize = useCallback(async () => {
         const newFontSize = Math.min(fontSize + 1, maxFontSize)
         const updatedSettings = {
-            ...bsc.settings,
-            misc: { ...bsc.settings.misc, messageLogFontSize: newFontSize },
+            ...settings,
+            misc: { ...settings.misc, messageLogFontSize: newFontSize },
         }
-        bsc.setSettings(updatedSettings)
+        setSettings(updatedSettings)
         await saveSettingsImmediate(updatedSettings)
-    }, [fontSize, bsc.settings, bsc.setSettings, saveSettingsImmediate])
+    }, [fontSize, settings, setSettings, saveSettingsImmediate])
 
     /**
      * Decrease font size and then save it to the settings.
@@ -737,12 +738,12 @@ ${longTargetsString}
     const decreaseFontSize = useCallback(async () => {
         const newFontSize = Math.max(fontSize - 1, minFontSize)
         const updatedSettings = {
-            ...bsc.settings,
-            misc: { ...bsc.settings.misc, messageLogFontSize: newFontSize },
+            ...settings,
+            misc: { ...settings.misc, messageLogFontSize: newFontSize },
         }
-        bsc.setSettings(updatedSettings)
+        setSettings(updatedSettings)
         await saveSettingsImmediate(updatedSettings)
-    }, [fontSize, bsc.settings, bsc.setSettings, saveSettingsImmediate])
+    }, [fontSize, settings, setSettings, saveSettingsImmediate])
 
     /**
      * Clear search query.
@@ -784,8 +785,8 @@ ${longTargetsString}
      * @returns The rendered log item.
      */
     const renderLogItem = useCallback(
-        ({ item }: { item: LogMessage }) => <LogItem item={item} fontSize={fontSize} onLongPress={handleLongPress} enableMessageIdDisplay={bsc.settings.misc.enableMessageIdDisplay} />,
-        [fontSize, handleLongPress, bsc.settings.misc.enableMessageIdDisplay]
+        ({ item }: { item: LogMessage }) => <LogItem item={item} fontSize={fontSize} onLongPress={handleLongPress} enableMessageIdDisplay={settings.misc.enableMessageIdDisplay} />,
+        [fontSize, handleLongPress, settings.misc.enableMessageIdDisplay]
     )
 
     /**

--- a/src/context/BotStateContext.tsx
+++ b/src/context/BotStateContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useState, useMemo, useCallback } from "react"
+import { createContext, useState, useMemo, useCallback, useContext } from "react"
 import { startTiming } from "../lib/performanceLogger"
 import { skillPlanSettingsPages } from "../pages/SkillPlanSettings/config"
 
@@ -458,37 +458,6 @@ export const defaultSettings: Settings = {
 }
 
 /**
- * Context value interface for the BotState provider.
- * Exposes application-wide state including readiness, settings, and app metadata.
- * Kept for the three full-settings consumers (`useSettingsManager`, `useSettingsFileManager`,
- * `MessageLog`'s formatted-string memo). Per-page consumers should subscribe to a slice
- * context (`RacingContext`, `TrainingContext`, ...) so a single-domain edit doesn't
- * re-render every page tree.
- */
-export interface BotStateProviderProps {
-    /** Whether the bot/app is ready (initialized and settings loaded). */
-    readyStatus: boolean
-    /** Setter for the ready status. */
-    setReadyStatus: (readyStatus: boolean) => void
-    /** The default settings used for reset and comparison. */
-    defaultSettings: Settings
-    /** The current application settings. */
-    settings: Settings
-    /** Setter for the application settings. */
-    setSettings: (settings: Settings | ((prev: Settings) => Settings)) => void
-    /** The application name. */
-    appName: string
-    /** Setter for the application name. */
-    setAppName: (appName: string) => void
-    /** The application version string. */
-    appVersion: string
-    /** Setter for the application version. */
-    setAppVersion: (appVersion: string) => void
-}
-
-export const BotStateContext = createContext<BotStateProviderProps>({} as BotStateProviderProps)
-
-/**
  * Slice updater accepts either a partial slice (merged shallowly) or a functional updater
  * that receives the previous slice and returns the next. Functional callers always see the
  * latest slice value, eliminating stale-closure races on rapid taps.
@@ -639,22 +608,6 @@ export const BotStateProvider = ({ children }: any): React.ReactElement => {
     const updateChat = useMemo(() => makeSliceUpdater("chat"), [makeSliceUpdater])
     const updateScenarioOverrides = useMemo(() => makeSliceUpdater("scenarioOverrides"), [makeSliceUpdater])
 
-    // Aggregate (legacy) context value — only the three full-settings consumers should subscribe.
-    const providerValues = useMemo<BotStateProviderProps>(
-        () => ({
-            readyStatus,
-            setReadyStatus,
-            defaultSettings,
-            settings,
-            setSettings: setSettingsWithLogging,
-            appName,
-            setAppName,
-            appVersion,
-            setAppVersion,
-        }),
-        [readyStatus, settings, appName, appVersion, setSettingsWithLogging]
-    )
-
     // Per-slice values memoized on their own slice reference. An untouched slice keeps a
     // stable identity across renders, so consumers of that slice's context skip re-rendering
     // when an unrelated domain mutates.
@@ -682,26 +635,49 @@ export const BotStateProvider = ({ children }: any): React.ReactElement => {
     )
 
     return (
-        <BotStateContext.Provider value={providerValues}>
-            <BotMetaContext.Provider value={metaValue}>
-                <GeneralMiscContext.Provider value={generalMiscValue}>
-                    <RacingContext.Provider value={racingValue}>
-                        <SkillsContext.Provider value={skillsValue}>
-                            <TrainingContext.Provider value={trainingValue}>
-                                <TrainingEventContext.Provider value={trainingEventValue}>
-                                    <DebugContext.Provider value={debugValue}>
-                                        <DiscordContext.Provider value={discordValue}>
-                                            <ChatContext.Provider value={chatValue}>
-                                                <ScenarioOverridesContext.Provider value={scenarioOverridesValue}>{children}</ScenarioOverridesContext.Provider>
-                                            </ChatContext.Provider>
-                                        </DiscordContext.Provider>
-                                    </DebugContext.Provider>
-                                </TrainingEventContext.Provider>
-                            </TrainingContext.Provider>
-                        </SkillsContext.Provider>
-                    </RacingContext.Provider>
-                </GeneralMiscContext.Provider>
-            </BotMetaContext.Provider>
-        </BotStateContext.Provider>
+        <BotMetaContext.Provider value={metaValue}>
+            <GeneralMiscContext.Provider value={generalMiscValue}>
+                <RacingContext.Provider value={racingValue}>
+                    <SkillsContext.Provider value={skillsValue}>
+                        <TrainingContext.Provider value={trainingValue}>
+                            <TrainingEventContext.Provider value={trainingEventValue}>
+                                <DebugContext.Provider value={debugValue}>
+                                    <DiscordContext.Provider value={discordValue}>
+                                        <ChatContext.Provider value={chatValue}>
+                                            <ScenarioOverridesContext.Provider value={scenarioOverridesValue}>{children}</ScenarioOverridesContext.Provider>
+                                        </ChatContext.Provider>
+                                    </DiscordContext.Provider>
+                                </DebugContext.Provider>
+                            </TrainingEventContext.Provider>
+                        </TrainingContext.Provider>
+                    </SkillsContext.Provider>
+                </RacingContext.Provider>
+            </GeneralMiscContext.Provider>
+        </BotMetaContext.Provider>
+    )
+}
+
+/**
+ * Subscribes to every slice context and returns a `Settings` snapshot. Used by the
+ * three remaining full-settings consumers (`useSettingsManager`, `useSettingsFileManager`,
+ * `MessageLog`'s formatted-string memo) that genuinely need cross-slice reads. The
+ * returned object identity changes whenever any slice changes, mirroring the legacy
+ * aggregate `BotStateContext.settings` it replaces.
+ *
+ * @returns A `Settings` object assembled from every slice context's current value.
+ */
+export const useSettingsSnapshot = (): Settings => {
+    const { general, misc } = useContext(GeneralMiscContext)
+    const { racing } = useContext(RacingContext)
+    const { skills } = useContext(SkillsContext)
+    const { training, trainingStatTarget } = useContext(TrainingContext)
+    const { trainingEvent } = useContext(TrainingEventContext)
+    const { debug } = useContext(DebugContext)
+    const { discord } = useContext(DiscordContext)
+    const { chat } = useContext(ChatContext)
+    const { scenarioOverrides } = useContext(ScenarioOverridesContext)
+    return useMemo(
+        () => ({ general, racing, skills, trainingEvent, misc, training, trainingStatTarget, debug, discord, chat, scenarioOverrides }),
+        [general, racing, skills, trainingEvent, misc, training, trainingStatTarget, debug, discord, chat, scenarioOverrides]
     )
 }

--- a/src/context/SettingsContext.tsx
+++ b/src/context/SettingsContext.tsx
@@ -20,8 +20,6 @@ interface SettingsContextType {
     resetSettings: () => Promise<boolean>
     /** Opens the app's data directory in the device's file manager. */
     openDataDirectory: () => Promise<void>
-    /** Whether a save operation is currently in progress. */
-    isSaving: boolean
 }
 
 const SettingsContext = createContext<SettingsContextType | undefined>(undefined)
@@ -39,7 +37,6 @@ interface SettingsProviderProps {
  */
 export const SettingsProvider: React.FC<SettingsProviderProps> = ({ children }) => {
     const settingsManager = useSettingsManager()
-
     return <SettingsContext.Provider value={settingsManager}>{children}</SettingsContext.Provider>
 }
 

--- a/src/hooks/useBootstrap.tsx
+++ b/src/hooks/useBootstrap.tsx
@@ -5,6 +5,7 @@ import { MessageLogContext, MessageLogProviderProps } from "../context/MessageLo
 import { useSettings } from "../context/SettingsContext"
 import { logWithTimestamp, logErrorWithTimestamp } from "../lib/logger"
 import { databaseManager, DatabaseRace, DatabaseSkill } from "../lib/database"
+import { startJsThreadBlockDetector } from "../lib/performanceLogger"
 
 /**
  * Manages app initialization, settings persistence, and message handling.
@@ -28,7 +29,14 @@ export const useBootstrap = () => {
             mlc.addMessageToLog(data.id, data.message)
         })
 
-        return () => messageLogSubscription.remove()
+        // Start the JS-thread block detector so any sustained > 100 ms blocks surface in logcat
+        // as `[BLOCK]` warnings. Cheap when idle; gated by `PerformanceLogger.ENABLED`.
+        const stopBlockDetector = startJsThreadBlockDetector(100)
+
+        return () => {
+            messageLogSubscription.remove()
+            stopBlockDetector()
+        }
     }, [])
 
     // Initialize database and populate data after the first paint so the splash can render.

--- a/src/hooks/usePerformanceLogging.ts
+++ b/src/hooks/usePerformanceLogging.ts
@@ -1,19 +1,54 @@
-import { useEffect, useRef } from "react"
-import { startTiming, markNavigationEnd } from "../lib/performanceLogger"
+import { useEffect, useLayoutEffect, useRef } from "react"
+import { startTiming, markNavigationEnd, markNavigationPhase, PerformanceLogger } from "../lib/performanceLogger"
 
 /**
- * A custom hook that logs component lifecycle events (mount, unmount, re-render).
- * All logs are gated by `PerformanceLogger.ENABLED`. In release builds the hook is a no-op
- * because `__DEV__` is a compile-time constant — the early return makes the rest dead code
- * for the release bundle, eliminating the per-render `useRef`/`useEffect` overhead.
+ * A custom hook that logs component lifecycle events (mount, unmount, re-render). The hook itself
+ * always runs (so hook ordering stays stable across builds) but every effect early-returns when
+ * `PerformanceLogger.ENABLED` is false, so disabling the logger reduces the per-render cost to
+ * a few `useRef`/`useEffect` no-ops.
+ *
  * @param componentName - The name of the component to track.
  */
-export const usePerformanceLogging = (componentName: string) => {
-    if (!__DEV__) return
+// Commit-phase render measurement threshold (ms). Renders that take longer than this print a
+// `[SLOW-COMMIT]` warning so a single noisy interaction is easy to spot in logcat without
+// drowning normal commits in noise. Tune via env if it ever gets chatty.
+const SLOW_COMMIT_WARN_MS = 100
 
+export const usePerformanceLogging = (componentName: string) => {
     const renderCount = useRef(1)
+    const firstCommitMarked = useRef(false)
+    // Captures the wall clock at the *start* of each render body. Compared against `useLayoutEffect`
+    // (which fires after React commits the tree but before the browser paints) to get the real
+    // commit-phase reconciliation cost. The previous `useEffect`-anchored timer measured scheduler
+    // latency only, which is why every render reported "0.00 ms" and we couldn't attribute the
+    // 1029 ms toggle block to a specific subtree.
+    const renderStart = useRef(0)
+    renderStart.current = PerformanceLogger.ENABLED ? performance.now() : 0
+
+    // Synchronous first-commit marker fires before the browser/native paint, breaking
+    // navigation timing into "tap → first commit" vs "first commit → first effect".
+    useLayoutEffect(() => {
+        if (!PerformanceLogger.ENABLED) return
+        if (firstCommitMarked.current) return
+        firstCommitMarked.current = true
+        markNavigationPhase(componentName, "first_commit")
+    }, [componentName])
+
+    // Real per-commit duration. `useLayoutEffect` runs synchronously after React applies the
+    // commit, so `performance.now() - renderStart` covers JSX evaluation through reconciliation.
+    useLayoutEffect(() => {
+        if (!PerformanceLogger.ENABLED) return
+        const duration = performance.now() - renderStart.current
+        const endTiming = startTiming(`${componentName}_commit`, "ui")
+        endTiming({ renderCount: renderCount.current, duration_ms: Number(duration.toFixed(2)) })
+        if (duration >= SLOW_COMMIT_WARN_MS) {
+            // eslint-disable-next-line no-console
+            console.warn(`[SLOW-COMMIT] ${componentName} commit took ${duration.toFixed(0)}ms (renderCount=${renderCount.current})`)
+        }
+    })
 
     useEffect(() => {
+        if (!PerformanceLogger.ENABLED) return
         // Log mount event.
         const endTiming = startTiming(`${componentName}_mount`, "ui")
         endTiming({ status: "mounted" })
@@ -29,11 +64,7 @@ export const usePerformanceLogging = (componentName: string) => {
     }, [])
 
     useEffect(() => {
-        // Log re-render events (skip the first render as it's part of mount).
-        if (renderCount.current > 1) {
-            const endTiming = startTiming(`${componentName}_render`, "ui")
-            endTiming({ renderCount: renderCount.current })
-        }
+        if (!PerformanceLogger.ENABLED) return
         renderCount.current++
     })
 }

--- a/src/hooks/useSettingsFileManager.tsx
+++ b/src/hooks/useSettingsFileManager.tsx
@@ -1,10 +1,10 @@
-import { useState, useContext } from "react"
+import { useState } from "react"
 import * as DocumentPicker from "expo-document-picker"
 import * as Sharing from "expo-sharing"
 import * as FileSystem from "expo-file-system"
 import { useNavigation } from "@react-navigation/native"
 import { useSettings } from "../context/SettingsContext"
-import { BotStateContext, Settings, defaultSettings } from "../context/BotStateContext"
+import { Settings, defaultSettings, useSettingsSnapshot } from "../context/BotStateContext"
 import { logErrorWithTimestamp } from "../lib/logger"
 
 /**
@@ -153,7 +153,7 @@ export const useSettingsFileManager = () => {
     const [pendingImportUri, setPendingImportUri] = useState<string | null>(null)
 
     const { importSettings, exportSettings } = useSettings()
-    const bsc = useContext(BotStateContext)
+    const settings = useSettingsSnapshot()
     const navigation = useNavigation()
 
     /**
@@ -194,7 +194,7 @@ export const useSettingsFileManager = () => {
     const compareAndPreviewSettings = async (fileUri: string) => {
         try {
             const importedSettings = await loadFromJSONFile(fileUri)
-            const changes = compareSettings(bsc.settings, importedSettings)
+            const changes = compareSettings(settings, importedSettings)
 
             const formattedChanges = changes.map((change) => ({
                 ...change,

--- a/src/hooks/useSettingsManager.tsx
+++ b/src/hooks/useSettingsManager.tsx
@@ -31,6 +31,12 @@ export const useSettingsManager = () => {
     // Debounce timer for auto-saving settings.
     const autoSaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
+    // Snapshot of the settings as last persisted to SQLite. Used to compute a per-slice diff so
+    // each toggle only writes the slice it touched (~10 rows) instead of the full 175-row batch.
+    // Slice-level identity is reliable because slice context updates always replace the slice
+    // object (e.g. `updateMisc({ ...misc, foo: bar })`).
+    const lastSavedSettingsRef = useRef<Settings | null>(null)
+
     // Keep the ref in sync with the latest settings.
     useEffect(() => {
         settingsRef.current = settings
@@ -63,8 +69,28 @@ export const useSettingsManager = () => {
         // Debounce the save to batch rapid changes.
         autoSaveTimerRef.current = setTimeout(async () => {
             try {
-                logWithTimestamp("[SettingsManager] Auto-saving settings to database...")
-                await databaseManager.saveSettingsBatch(convertSettingsToBatch(settingsRef.current))
+                const current = settingsRef.current
+                const last = lastSavedSettingsRef.current
+                // First save after load: persist everything. Subsequent saves: only the slices
+                // whose top-level reference changed since the last persisted snapshot.
+                let toPersist: Record<string, any>
+                if (last == null) {
+                    toPersist = current
+                } else {
+                    toPersist = {}
+                    for (const key of Object.keys(current) as Array<keyof Settings>) {
+                        if (current[key] !== last[key]) {
+                            toPersist[key as string] = current[key]
+                        }
+                    }
+                }
+                const batch = convertSettingsToBatch(toPersist)
+                if (batch.length === 0) {
+                    return
+                }
+                logWithTimestamp(`[SettingsManager] Auto-saving ${batch.length} settings (slices: ${Object.keys(toPersist).join(", ")}).`)
+                await databaseManager.saveSettingsBatch(batch)
+                lastSavedSettingsRef.current = current
                 logWithTimestamp("[SettingsManager] Auto-save completed.")
             } catch (error) {
                 logErrorWithTimestamp(`[SettingsManager] Auto-save failed: ${error}`)
@@ -92,6 +118,7 @@ export const useSettingsManager = () => {
             // Read from the ref to always get the latest settings.
             const localSettings: Settings = newSettings ? newSettings : settingsRef.current
             await databaseManager.saveSettingsBatch(convertSettingsToBatch(localSettings))
+            lastSavedSettingsRef.current = localSettings
             endTiming({ status: "success", hasNewSettings: !!newSettings })
         } catch (error) {
             logErrorWithTimestamp(`Error saving settings: ${error}`)
@@ -115,6 +142,7 @@ export const useSettingsManager = () => {
             // Read from the ref to always get the latest settings.
             const localSettings: Settings = newSettings ? newSettings : settingsRef.current
             await databaseManager.saveSettingsBatch(convertSettingsToBatch(localSettings))
+            lastSavedSettingsRef.current = localSettings
             endTiming({ status: "success", hasNewSettings: !!newSettings, immediate: true })
         } catch (error) {
             logErrorWithTimestamp(`Error saving settings immediately: ${error}`)
@@ -170,6 +198,7 @@ export const useSettingsManager = () => {
                 if (anyMigrated) {
                     try {
                         await databaseManager.saveSettingsBatch(convertSettingsToBatch(newSettings))
+                        lastSavedSettingsRef.current = newSettings
                         logWithTimestamp("[SettingsManager] Saved migrated settings to database.")
                     } catch (migrationSaveError) {
                         logErrorWithTimestamp("[SettingsManager] Error saving migrated settings:", migrationSaveError)
@@ -177,6 +206,9 @@ export const useSettingsManager = () => {
                 }
 
                 setSettings(newSettings)
+                // The DB now matches React state, so the next auto-save can diff against it
+                // and skip writing slices that haven't changed.
+                lastSavedSettingsRef.current = newSettings
                 // Mark that the initial load has completed so auto-save can begin.
                 hasLoadedRef.current = true
                 logWithTimestamp(`[SettingsManager] Settings loaded and applied to context ${context}.`)
@@ -261,6 +293,7 @@ export const useSettingsManager = () => {
 
                 // Save settings to SQLite database.
                 await databaseManager.saveSettingsBatch(convertSettingsToBatch(importedSettings))
+                lastSavedSettingsRef.current = importedSettings
                 setSettings(importedSettings)
 
                 // Import profiles if they exist.
@@ -456,6 +489,7 @@ export const useSettingsManager = () => {
 
             // Save default settings to SQLite database.
             await databaseManager.saveSettingsBatch(convertSettingsToBatch(defaultSettingsCopy))
+            lastSavedSettingsRef.current = defaultSettingsCopy
 
             // Update the current settings in context.
             setSettings(defaultSettingsCopy)

--- a/src/hooks/useSettingsManager.tsx
+++ b/src/hooks/useSettingsManager.tsx
@@ -6,7 +6,7 @@ import { defaultSettings, Settings, BotStateContext } from "../context/BotStateC
 import { databaseManager } from "../lib/database"
 import { startTiming } from "../lib/performanceLogger"
 import { logWithTimestamp, logErrorWithTimestamp } from "../lib/logger"
-import { deepMerge, convertSettingsToBatch, applyMigrations } from "../lib/settingsUtils"
+import { deepMerge, convertSettingsToBatch, applyMigrations, stripDbOwnedKeys } from "../lib/settingsUtils"
 
 export { deepMerge, convertSettingsToBatch, applyMigrations }
 
@@ -147,8 +147,13 @@ export const useSettingsManager = () => {
             try {
                 const dbSettings = await databaseManager.loadAllSettings()
                 rawDbSettings = dbSettings
+                // Drop Kotlin-owned blobs (racing plan, character/support event data) before they
+                // reach React state. Loading them inflates the settings tree and forces the
+                // auto-save effect to re-write all of it on every toggle — see `DB_OWNED_KEYS`
+                // in `settingsUtils.ts`.
+                const reactOwnedDbSettings = stripDbOwnedKeys(dbSettings)
                 // Use deep merge to preserve nested default values.
-                newSettings = deepMerge(defaultSettings, dbSettings as Partial<Settings>)
+                newSettings = deepMerge(defaultSettings, reactOwnedDbSettings as Partial<Settings>)
                 logWithTimestamp(`[SettingsManager] Settings loaded from SQLite database ${context}.`)
             } catch (sqliteError) {
                 logWithTimestamp(`[SettingsManager] Failed to load from SQLite ${context}, using defaults:`)
@@ -321,14 +326,14 @@ export const useSettingsManager = () => {
                 logErrorWithTimestamp("[SettingsManager] Error exporting profiles (continuing with settings export):", profileError)
             }
 
-            // Create export object with settings and profiles, excluding large data fields.
+            // Create export object with settings and profiles. The large Kotlin-owned blobs
+            // (`racing.racingPlanData`, `trainingEvent.{characterEventData,supportEventData}`,
+            // `misc.formattedSettingsString`) are now filtered out at the load boundary
+            // (`stripDbOwnedKeys`) so they never reach React state to begin with — only the
+            // user-owned fields remain to be deep-cloned here.
             const settingsForExport = JSON.parse(JSON.stringify(bsc.settings))
 
-            // Remove unnecessary fields before export.
-            delete settingsForExport.racing.racingPlanData
-            delete settingsForExport.trainingEvent.characterEventData
-            delete settingsForExport.trainingEvent.supportEventData
-            delete settingsForExport.misc.formattedSettingsString
+            // Drop fields that are export-irrelevant but still live in React state.
             delete settingsForExport.misc.currentProfileName
 
             // Remove sensitive Discord credentials from export.

--- a/src/hooks/useSettingsManager.tsx
+++ b/src/hooks/useSettingsManager.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useContext, useMemo, useRef } from "react"
+import { useState, useEffect, useContext, useMemo, useRef, useCallback } from "react"
 import * as FileSystem from "expo-file-system"
 import * as Sharing from "expo-sharing"
 import { startActivityAsync } from "expo-intent-launcher"
@@ -83,7 +83,7 @@ export const useSettingsManager = () => {
      * @param newSettings - The `Settings` object to save. If not provided, the current settings from the `BotStateContext` will be used.
      * @returns A promise that resolves when the settings are saved.
      */
-    const saveSettings = async (newSettings?: Settings) => {
+    const saveSettings = useCallback(async (newSettings?: Settings) => {
         const endTiming = startTiming("settings_manager_save_settings", "settings")
 
         setIsSaving(true)
@@ -99,14 +99,14 @@ export const useSettingsManager = () => {
         } finally {
             setIsSaving(false)
         }
-    }
+    }, [])
 
     /**
      * Save settings immediately without debouncing (for background/exit saves).
      * @param newSettings - The `Settings` object to save. If not provided, the current settings from the `BotStateContext` will be used.
      * @returns A promise that resolves when the settings are saved.
      */
-    const saveSettingsImmediate = async (newSettings?: Settings) => {
+    const saveSettingsImmediate = useCallback(async (newSettings?: Settings) => {
         const endTiming = startTiming("settings_manager_save_settings_immediate", "settings")
 
         setIsSaving(true)
@@ -122,72 +122,75 @@ export const useSettingsManager = () => {
         } finally {
             setIsSaving(false)
         }
-    }
+    }, [])
 
     /**
      * Load settings from `SQLite` database.
      * @param skipInitializationCheck - Whether to skip the SQLite initialization check.
      * @returns A promise that resolves when the settings are loaded.
      */
-    const loadSettings = async (skipInitializationCheck: boolean = false) => {
-        const timingName = skipInitializationCheck ? "settings_manager_load_settings_bootstrap" : "settings_manager_load_settings"
-        const endTiming = startTiming(timingName, "settings")
-        const context = skipInitializationCheck ? "during bootstrap" : ""
+    const loadSettings = useCallback(
+        async (skipInitializationCheck: boolean = false) => {
+            const timingName = skipInitializationCheck ? "settings_manager_load_settings_bootstrap" : "settings_manager_load_settings"
+            const endTiming = startTiming(timingName, "settings")
+            const context = skipInitializationCheck ? "during bootstrap" : ""
 
-        try {
-            // Wait for SQLite to be initialized (unless explicitly skipped).
-            if (!skipInitializationCheck && !isSQLiteInitialized) {
-                logWithTimestamp("[SettingsManager] Waiting for SQLite initialization...")
-                endTiming({ status: "skipped", reason: "sqlite_not_initialized" })
-                return
-            }
-
-            // Load from SQLite database.
-            let newSettings: Settings = JSON.parse(JSON.stringify(defaultSettings))
-            let rawDbSettings: any = undefined
             try {
-                const dbSettings = await databaseManager.loadAllSettings()
-                rawDbSettings = dbSettings
-                // Drop Kotlin-owned blobs (racing plan, character/support event data) before they
-                // reach React state. Loading them inflates the settings tree and forces the
-                // auto-save effect to re-write all of it on every toggle — see `DB_OWNED_KEYS`
-                // in `settingsUtils.ts`.
-                const reactOwnedDbSettings = stripDbOwnedKeys(dbSettings)
-                // Use deep merge to preserve nested default values.
-                newSettings = deepMerge(defaultSettings, reactOwnedDbSettings as Partial<Settings>)
-                logWithTimestamp(`[SettingsManager] Settings loaded from SQLite database ${context}.`)
-            } catch (sqliteError) {
-                logWithTimestamp(`[SettingsManager] Failed to load from SQLite ${context}, using defaults:`)
-                console.warn(sqliteError)
-            }
-
-            // Apply all migrations to the settings.
-            const { settings: migratedSettings, anyMigrated } = applyMigrations(newSettings, rawDbSettings)
-            newSettings = migratedSettings
-
-            // If any migration occurred, save the migrated settings back to the database.
-            if (anyMigrated) {
-                try {
-                    await databaseManager.saveSettingsBatch(convertSettingsToBatch(newSettings))
-                    logWithTimestamp("[SettingsManager] Saved migrated settings to database.")
-                } catch (migrationSaveError) {
-                    logErrorWithTimestamp("[SettingsManager] Error saving migrated settings:", migrationSaveError)
+                // Wait for SQLite to be initialized (unless explicitly skipped).
+                if (!skipInitializationCheck && !databaseManager.isInitialized()) {
+                    logWithTimestamp("[SettingsManager] Waiting for SQLite initialization...")
+                    endTiming({ status: "skipped", reason: "sqlite_not_initialized" })
+                    return
                 }
-            }
 
-            setSettings(newSettings)
-            // Mark that the initial load has completed so auto-save can begin.
-            hasLoadedRef.current = true
-            logWithTimestamp(`[SettingsManager] Settings loaded and applied to context ${context}.`)
-            logWithTimestamp(`[SettingsManager] Scenario value after load: "${newSettings.general.scenario}"`)
-            endTiming({ status: "success", usedDefaults: newSettings === defaultSettings })
-        } catch (error) {
-            logErrorWithTimestamp(`[SettingsManager] Error loading settings${context}:`, error)
-            setSettings(JSON.parse(JSON.stringify(defaultSettings)))
-            setReadyStatus(false)
-            endTiming({ status: "error", error: error instanceof Error ? error.message : String(error) })
-        }
-    }
+                // Load from SQLite database.
+                let newSettings: Settings = JSON.parse(JSON.stringify(defaultSettings))
+                let rawDbSettings: any = undefined
+                try {
+                    const dbSettings = await databaseManager.loadAllSettings()
+                    rawDbSettings = dbSettings
+                    // Drop Kotlin-owned blobs (racing plan, character/support event data) before they
+                    // reach React state. Loading them inflates the settings tree and forces the
+                    // auto-save effect to re-write all of it on every toggle — see `DB_OWNED_KEYS`
+                    // in `settingsUtils.ts`.
+                    const reactOwnedDbSettings = stripDbOwnedKeys(dbSettings)
+                    // Use deep merge to preserve nested default values.
+                    newSettings = deepMerge(defaultSettings, reactOwnedDbSettings as Partial<Settings>)
+                    logWithTimestamp(`[SettingsManager] Settings loaded from SQLite database ${context}.`)
+                } catch (sqliteError) {
+                    logWithTimestamp(`[SettingsManager] Failed to load from SQLite ${context}, using defaults:`)
+                    console.warn(sqliteError)
+                }
+
+                // Apply all migrations to the settings.
+                const { settings: migratedSettings, anyMigrated } = applyMigrations(newSettings, rawDbSettings)
+                newSettings = migratedSettings
+
+                // If any migration occurred, save the migrated settings back to the database.
+                if (anyMigrated) {
+                    try {
+                        await databaseManager.saveSettingsBatch(convertSettingsToBatch(newSettings))
+                        logWithTimestamp("[SettingsManager] Saved migrated settings to database.")
+                    } catch (migrationSaveError) {
+                        logErrorWithTimestamp("[SettingsManager] Error saving migrated settings:", migrationSaveError)
+                    }
+                }
+
+                setSettings(newSettings)
+                // Mark that the initial load has completed so auto-save can begin.
+                hasLoadedRef.current = true
+                logWithTimestamp(`[SettingsManager] Settings loaded and applied to context ${context}.`)
+                logWithTimestamp(`[SettingsManager] Scenario value after load: "${newSettings.general.scenario}"`)
+                endTiming({ status: "success", usedDefaults: newSettings === defaultSettings })
+            } catch (error) {
+                logErrorWithTimestamp(`[SettingsManager] Error loading settings${context}:`, error)
+                setSettings(JSON.parse(JSON.stringify(defaultSettings)))
+                setReadyStatus(false)
+                endTiming({ status: "error", error: error instanceof Error ? error.message : String(error) })
+            }
+        },
+        [setSettings, setReadyStatus]
+    )
 
     /**
      * Import settings from a JSON file.
@@ -231,88 +234,91 @@ export const useSettingsManager = () => {
      * @param fileUri - The URI/path to the JSON settings file.
      * @returns A promise that resolves with a boolean indicating whether the import was successful.
      */
-    const importSettings = async (fileUri: string): Promise<boolean> => {
-        const endTiming = startTiming("settings_manager_import_settings", "settings")
+    const importSettings = useCallback(
+        async (fileUri: string): Promise<boolean> => {
+            const endTiming = startTiming("settings_manager_import_settings", "settings")
 
-        try {
-            setIsSaving(true)
-
-            // Ensure database is initialized before saving.
-            logWithTimestamp("Ensuring database is initialized before saving...")
-            if (!isSQLiteInitialized) {
-                logWithTimestamp("Database not initialized, triggering initialization...")
-                await databaseManager.initialize()
-            }
-
-            // Check for current active profile name before importing profiles.
-            let previousActiveProfileName: string | null = null
             try {
-                previousActiveProfileName = await databaseManager.getCurrentProfileName()
-            } catch (error) {
-                logErrorWithTimestamp("[SettingsManager] Error getting current profile name (continuing with import):", error)
-            }
+                setIsSaving(true)
 
-            // Load settings and profiles from JSON file.
-            const { settings: importedSettings, profiles } = await loadFromJSONFile(fileUri)
-
-            // Save settings to SQLite database.
-            await databaseManager.saveSettingsBatch(convertSettingsToBatch(importedSettings))
-            setSettings(importedSettings)
-
-            // Import profiles if they exist.
-            if (profiles && Array.isArray(profiles) && profiles.length > 0) {
-                try {
-                    // Delete all existing profiles.
-                    const existingProfiles = await databaseManager.getAllProfiles()
-                    for (const profile of existingProfiles) {
-                        await databaseManager.deleteProfile(profile.id)
-                    }
-                    logWithTimestamp(`[SettingsManager] Deleted ${existingProfiles.length} existing profiles.`)
-
-                    // Import all profiles from the JSON file.
-                    for (const profile of profiles) {
-                        await databaseManager.saveProfile({
-                            name: profile.name,
-                            settings: profile.settings,
-                        })
-                    }
-                    logWithTimestamp(`[SettingsManager] Imported ${profiles.length} profiles.`)
-
-                    // If there was a previously active profile and at least one profile was imported, set active profile to the first imported profile.
-                    if (previousActiveProfileName && profiles.length > 0) {
-                        await databaseManager.setCurrentProfileName(profiles[0].name)
-                        logWithTimestamp(`[SettingsManager] Set active profile to first imported profile: ${profiles[0].name}`)
-                    }
-                } catch (profileError) {
-                    logErrorWithTimestamp("[SettingsManager] Error importing profiles (settings import succeeded):", profileError)
+                // Ensure database is initialized before saving. Read live so the closure stays stable.
+                logWithTimestamp("Ensuring database is initialized before saving...")
+                if (!databaseManager.isInitialized()) {
+                    logWithTimestamp("Database not initialized, triggering initialization...")
+                    await databaseManager.initialize()
                 }
+
+                // Check for current active profile name before importing profiles.
+                let previousActiveProfileName: string | null = null
+                try {
+                    previousActiveProfileName = await databaseManager.getCurrentProfileName()
+                } catch (error) {
+                    logErrorWithTimestamp("[SettingsManager] Error getting current profile name (continuing with import):", error)
+                }
+
+                // Load settings and profiles from JSON file.
+                const { settings: importedSettings, profiles } = await loadFromJSONFile(fileUri)
+
+                // Save settings to SQLite database.
+                await databaseManager.saveSettingsBatch(convertSettingsToBatch(importedSettings))
+                setSettings(importedSettings)
+
+                // Import profiles if they exist.
+                if (profiles && Array.isArray(profiles) && profiles.length > 0) {
+                    try {
+                        // Delete all existing profiles.
+                        const existingProfiles = await databaseManager.getAllProfiles()
+                        for (const profile of existingProfiles) {
+                            await databaseManager.deleteProfile(profile.id)
+                        }
+                        logWithTimestamp(`[SettingsManager] Deleted ${existingProfiles.length} existing profiles.`)
+
+                        // Import all profiles from the JSON file.
+                        for (const profile of profiles) {
+                            await databaseManager.saveProfile({
+                                name: profile.name,
+                                settings: profile.settings,
+                            })
+                        }
+                        logWithTimestamp(`[SettingsManager] Imported ${profiles.length} profiles.`)
+
+                        // If there was a previously active profile and at least one profile was imported, set active profile to the first imported profile.
+                        if (previousActiveProfileName && profiles.length > 0) {
+                            await databaseManager.setCurrentProfileName(profiles[0].name)
+                            logWithTimestamp(`[SettingsManager] Set active profile to first imported profile: ${profiles[0].name}`)
+                        }
+                    } catch (profileError) {
+                        logErrorWithTimestamp("[SettingsManager] Error importing profiles (settings import succeeded):", profileError)
+                    }
+                }
+
+                logWithTimestamp("Settings imported successfully.")
+
+                endTiming({ status: "success", fileUri, profilesImported: profiles?.length || 0 })
+                return true
+            } catch (error) {
+                logErrorWithTimestamp("Error importing settings:", error)
+                endTiming({ status: "error", fileUri, error: error instanceof Error ? error.message : String(error) })
+                return false
+            } finally {
+                setIsSaving(false)
             }
-
-            logWithTimestamp("Settings imported successfully.")
-
-            endTiming({ status: "success", fileUri, profilesImported: profiles?.length || 0 })
-            return true
-        } catch (error) {
-            logErrorWithTimestamp("Error importing settings:", error)
-            endTiming({ status: "error", fileUri, error: error instanceof Error ? error.message : String(error) })
-            return false
-        } finally {
-            setIsSaving(false)
-        }
-    }
+        },
+        [setSettings]
+    )
 
     /**
      * Export current settings to a JSON file which includes stripping large fields.
      * @returns A promise that resolves with the file URI of the exported settings, or null if the export failed.
      */
-    const exportSettings = async (): Promise<string | null> => {
+    const exportSettings = useCallback(async (): Promise<string | null> => {
         const endTiming = startTiming("settings_manager_export_settings", "settings")
 
         try {
             // Fetch all profiles from database.
             let profiles: Array<{ id: number; name: string; settings: any; created_at: string; updated_at: string }> = []
             try {
-                if (isSQLiteInitialized) {
+                if (databaseManager.isInitialized()) {
                     const dbProfiles = await databaseManager.getAllProfiles()
                     profiles = dbProfiles.map((p) => ({
                         id: p.id,
@@ -332,7 +338,7 @@ export const useSettingsManager = () => {
             // `misc.formattedSettingsString`) are now filtered out at the load boundary
             // (`stripDbOwnedKeys`) so they never reach React state to begin with — only the
             // user-owned fields remain to be deep-cloned here.
-            const settingsForExport = JSON.parse(JSON.stringify(settings))
+            const settingsForExport = JSON.parse(JSON.stringify(settingsRef.current))
 
             // Drop fields that are export-irrelevant but still live in React state.
             delete settingsForExport.misc.currentProfileName
@@ -366,13 +372,13 @@ export const useSettingsManager = () => {
             endTiming({ status: "error", error: error instanceof Error ? error.message : String(error) })
             return null
         }
-    }
+    }, [])
 
     /**
      * Open the app's data directory using Storage Access Framework or fallback to file explorer.
      * @returns A promise that resolves when the data directory is opened.
      */
-    const openDataDirectory = async () => {
+    const openDataDirectory = useCallback(async () => {
         const endTiming = startTiming("settings_manager_open_data_dir", "settings")
         // Get the app's package name from the document directory path.
         const packageName = "com.steve1316.uma_android_automation"
@@ -426,21 +432,21 @@ export const useSettingsManager = () => {
             logErrorWithTimestamp(`Error opening app data directory: ${error}`)
             endTiming({ status: "error", error: error instanceof Error ? error.message : String(error) })
         }
-    }
+    }, [])
 
     /**
      * Reset settings to default values.
      * @returns A promise that resolves with a boolean indicating whether the reset was successful.
      */
-    const resetSettings = async (): Promise<boolean> => {
+    const resetSettings = useCallback(async (): Promise<boolean> => {
         const endTiming = startTiming("settings_manager_reset_settings", "settings")
 
         try {
             setIsSaving(true)
 
-            // Ensure database is initialized before saving.
+            // Ensure database is initialized before saving. Read live so the closure stays stable.
             logWithTimestamp("Ensuring database is initialized before resetting...")
-            if (!isSQLiteInitialized) {
+            if (!databaseManager.isInitialized()) {
                 logWithTimestamp("Database not initialized, triggering initialization...")
                 await databaseManager.initialize()
             }
@@ -466,7 +472,7 @@ export const useSettingsManager = () => {
         } finally {
             setIsSaving(false)
         }
-    }
+    }, [setSettings, setReadyStatus])
 
     return useMemo(
         () => ({
@@ -477,8 +483,7 @@ export const useSettingsManager = () => {
             exportSettings,
             resetSettings,
             openDataDirectory,
-            isSaving: isSaving || isSQLiteSaving,
         }),
-        [saveSettings, saveSettingsImmediate, loadSettings, importSettings, exportSettings, resetSettings, openDataDirectory, isSaving, isSQLiteSaving]
+        [saveSettings, saveSettingsImmediate, loadSettings, importSettings, exportSettings, resetSettings, openDataDirectory]
     )
 }

--- a/src/hooks/useSettingsManager.tsx
+++ b/src/hooks/useSettingsManager.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useContext, useMemo, useRef } from "react"
 import * as FileSystem from "expo-file-system"
 import * as Sharing from "expo-sharing"
 import { startActivityAsync } from "expo-intent-launcher"
-import { defaultSettings, Settings, BotStateContext } from "../context/BotStateContext"
+import { defaultSettings, Settings, BotMetaContext, useSettingsSnapshot } from "../context/BotStateContext"
 import { databaseManager } from "../lib/database"
 import { startTiming } from "../lib/performanceLogger"
 import { logWithTimestamp, logErrorWithTimestamp } from "../lib/logger"
@@ -19,10 +19,11 @@ export const useSettingsManager = () => {
     const [isSaving, setIsSaving] = useState(false)
     const [migrationCompleted, setMigrationCompleted] = useState(false)
 
-    const bsc = useContext(BotStateContext)
+    const { setSettings, setReadyStatus } = useContext(BotMetaContext)
+    const settings = useSettingsSnapshot()
 
     // Ref to always track the latest settings, avoiding stale closure issues.
-    const settingsRef = useRef<Settings>(bsc.settings)
+    const settingsRef = useRef<Settings>(settings)
 
     // Track whether the initial load from database has completed.
     const hasLoadedRef = useRef(false)
@@ -32,8 +33,8 @@ export const useSettingsManager = () => {
 
     // Keep the ref in sync with the latest settings.
     useEffect(() => {
-        settingsRef.current = bsc.settings
-    }, [bsc.settings])
+        settingsRef.current = settings
+    }, [settings])
 
     // Direct database operations.
     const isSQLiteInitialized = databaseManager.isInitialized()
@@ -75,7 +76,7 @@ export const useSettingsManager = () => {
                 clearTimeout(autoSaveTimerRef.current)
             }
         }
-    }, [bsc.settings, isSQLiteInitialized])
+    }, [settings, isSQLiteInitialized])
 
     /**
      * Save settings to `SQLite` database.
@@ -174,7 +175,7 @@ export const useSettingsManager = () => {
                 }
             }
 
-            bsc.setSettings(newSettings)
+            setSettings(newSettings)
             // Mark that the initial load has completed so auto-save can begin.
             hasLoadedRef.current = true
             logWithTimestamp(`[SettingsManager] Settings loaded and applied to context ${context}.`)
@@ -182,8 +183,8 @@ export const useSettingsManager = () => {
             endTiming({ status: "success", usedDefaults: newSettings === defaultSettings })
         } catch (error) {
             logErrorWithTimestamp(`[SettingsManager] Error loading settings${context}:`, error)
-            bsc.setSettings(JSON.parse(JSON.stringify(defaultSettings)))
-            bsc.setReadyStatus(false)
+            setSettings(JSON.parse(JSON.stringify(defaultSettings)))
+            setReadyStatus(false)
             endTiming({ status: "error", error: error instanceof Error ? error.message : String(error) })
         }
     }
@@ -256,7 +257,7 @@ export const useSettingsManager = () => {
 
             // Save settings to SQLite database.
             await databaseManager.saveSettingsBatch(convertSettingsToBatch(importedSettings))
-            bsc.setSettings(importedSettings)
+            setSettings(importedSettings)
 
             // Import profiles if they exist.
             if (profiles && Array.isArray(profiles) && profiles.length > 0) {
@@ -331,7 +332,7 @@ export const useSettingsManager = () => {
             // `misc.formattedSettingsString`) are now filtered out at the load boundary
             // (`stripDbOwnedKeys`) so they never reach React state to begin with — only the
             // user-owned fields remain to be deep-cloned here.
-            const settingsForExport = JSON.parse(JSON.stringify(bsc.settings))
+            const settingsForExport = JSON.parse(JSON.stringify(settings))
 
             // Drop fields that are export-irrelevant but still live in React state.
             delete settingsForExport.misc.currentProfileName
@@ -451,8 +452,8 @@ export const useSettingsManager = () => {
             await databaseManager.saveSettingsBatch(convertSettingsToBatch(defaultSettingsCopy))
 
             // Update the current settings in context.
-            bsc.setSettings(defaultSettingsCopy)
-            bsc.setReadyStatus(false)
+            setSettings(defaultSettingsCopy)
+            setReadyStatus(false)
 
             logWithTimestamp("Settings reset to defaults successfully.")
 

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -592,6 +592,27 @@ export class DatabaseManager {
     }
 
     /**
+     * Delete a single setting row by category and key. Idempotent: missing rows are a no-op.
+     *
+     * @param category - The category of the setting to delete.
+     * @param key - The key of the setting to delete.
+     * @returns A promise that resolves once the delete completes.
+     */
+    async deleteSetting(category: string, key: string): Promise<void> {
+        const endTiming = startTiming("database_delete_setting", "database")
+        this.ensureInitialized()
+
+        try {
+            await this.db!.runAsync(`DELETE FROM ${this.TABLE_SETTINGS} WHERE category = ? AND key = ?`, [category, key])
+            endTiming({ status: "success", category, key })
+        } catch (error) {
+            logErrorWithTimestamp(`[DB] Failed to delete setting ${category}.${key}:`, error)
+            endTiming({ status: "error", category, key, error: error instanceof Error ? error.message : String(error) })
+            throw error
+        }
+    }
+
+    /**
      * Load all settings from database.
      * @returns A promise that resolves with a record of settings organized by category and key.
      */

--- a/src/lib/performanceLogger.ts
+++ b/src/lib/performanceLogger.ts
@@ -44,9 +44,9 @@ export interface PerformanceMetric {
 export class PerformanceLogger {
     // Currently ON in all builds while we're hunting the navigation/settings perf regression. The
     // measurement harness (`scripts/perf-nav-test.ts`) parses `[PERF]` lines out of logcat, and
-    // production bundles ship with `__DEV__ = false`, so the previous dev-only gate left the
-    // harness blind. Flip back to `__DEV__` once perf is back to baseline.
-    public static ENABLED: boolean = true
+    // Dev-only by default. The harness needs this on, so set the env var `PERF_LOGGER=1` (or
+    // flip locally to `true`) when running release builds against `yarn perf:nav`.
+    public static ENABLED: boolean = __DEV__
     public static SUPPRESS_LOGGING = false
 
     private metrics: PerformanceMetric[] = []

--- a/src/lib/performanceLogger.ts
+++ b/src/lib/performanceLogger.ts
@@ -42,8 +42,12 @@ export interface PerformanceMetric {
  * Provides detailed timing information for debugging performance issues.
  */
 export class PerformanceLogger {
-    public static ENABLED = false
-    public static SUPPRESS_LOGGING = true
+    // Currently ON in all builds while we're hunting the navigation/settings perf regression. The
+    // measurement harness (`scripts/perf-nav-test.ts`) parses `[PERF]` lines out of logcat, and
+    // production bundles ship with `__DEV__ = false`, so the previous dev-only gate left the
+    // harness blind. Flip back to `__DEV__` once perf is back to baseline.
+    public static ENABLED: boolean = true
+    public static SUPPRESS_LOGGING = false
 
     private metrics: PerformanceMetric[] = []
     private maxMetricsHistory = 100
@@ -93,6 +97,30 @@ export class PerformanceLogger {
     markNavigationStart(target: string) {
         if (!PerformanceLogger.ENABLED) return
         this.pendingNavigations.set(target, performance.now())
+    }
+
+    /**
+     * Mark an intermediate phase between [markNavigationStart] and [markNavigationEnd]. Records
+     * the cumulative time from tap to this phase without consuming the start timestamp, so the
+     * standard mount-end timing keeps working. Used to break "tap → page mounted" into actionable
+     * buckets (tap → drawer-close, drawer-close → dispatch, dispatch → first-commit, first-commit → first-effect).
+     *
+     * @param target The navigation target (route name).
+     * @param phase Free-form phase label (e.g. "dispatch", "first_commit").
+     */
+    markNavigationPhase(target: string, phase: string) {
+        if (!PerformanceLogger.ENABLED) return
+        const startTime = this.pendingNavigations.get(target)
+        if (startTime === undefined) return
+
+        const duration = performance.now() - startTime
+        const metric: PerformanceMetric = {
+            operation: `navigation_to_${target}_${phase}`,
+            duration,
+            timestamp: Date.now(),
+            category: "ui",
+        }
+        this.recordMetric(metric)
     }
 
     /**
@@ -157,4 +185,35 @@ export const performanceLogger = new PerformanceLogger()
 // Export convenience functions.
 export const startTiming = (operation: string, category?: PerformanceMetric["category"]) => performanceLogger.startTiming(operation, category)
 export const markNavigationStart = (target: string) => performanceLogger.markNavigationStart(target)
+export const markNavigationPhase = (target: string, phase: string) => performanceLogger.markNavigationPhase(target, phase)
 export const markNavigationEnd = (target: string, category?: PerformanceMetric["category"]) => performanceLogger.markNavigationEnd(target, category)
+
+/**
+ * Probe that detects long JS-thread blocks. Schedules a ~16 ms timer; whenever the actual gap
+ * between fires exceeds [thresholdMs], logs a `[BLOCK]` warning with the duration. Cheap when
+ * the thread is idle (one timer per frame) and self-suppressing under sustained load (the
+ * timer simply won't fire). Start it once at app bootstrap.
+ *
+ * @param thresholdMs Minimum gap (ms) to log. Defaults to 100 ms (≈ 6 dropped frames).
+ * @returns A cleanup function that stops the probe.
+ */
+export const startJsThreadBlockDetector = (thresholdMs = 100): (() => void) => {
+    if (!PerformanceLogger.ENABLED) return () => {}
+    let last = performance.now()
+    let stopped = false
+    const tick = () => {
+        if (stopped) return
+        const now = performance.now()
+        const gap = now - last
+        if (gap >= thresholdMs) {
+            // eslint-disable-next-line no-console
+            console.warn(`[BLOCK] JS thread blocked for ${gap.toFixed(0)}ms`)
+        }
+        last = now
+        setTimeout(tick, 16)
+    }
+    setTimeout(tick, 16)
+    return () => {
+        stopped = true
+    }
+}

--- a/src/lib/settingsUtils.ts
+++ b/src/lib/settingsUtils.ts
@@ -19,16 +19,58 @@ export const deepMerge = <T extends Record<string, any>>(target: T, source: Part
 }
 
 /**
- * Settings whose persisted value is owned by a dedicated writer outside the React-state-mirrored
- * `Settings` object. Including them in the batch would let stale in-memory values overwrite the
- * fresh DB rows the dedicated writer just wrote. `misc.formattedSettingsString` is built and
- * persisted directly by `MessageLog`'s debounced effect; the React-state copy is intentionally
- * never updated, so it must be skipped here.
+ * Persisted settings whose canonical owner is *not* the React-state `Settings` object. They live
+ * in SQLite and are read directly by Kotlin (or by a dedicated JS writer) — round-tripping them
+ * through React state inflates re-renders and the auto-save batch by hundreds of KB on a populated
+ * profile.
+ *
+ * Each entry is filtered out on **both** directions:
+ * - Save path (`convertSettingsToBatch`): never re-write rows React shouldn't own.
+ * - Load path (`stripDbOwnedKeys` invoked by `loadSettings`): never absorb them into React state.
+ *
+ * Categories of entries:
+ * - `misc.formattedSettingsString` — built and persisted directly by `MessageLog`'s debounced effect.
+ * - `racing.racingPlanData` — bundled racing plan blob written by the racing-plan generator;
+ *   only consumed by Kotlin via `SettingsHelper.getStringSetting`.
+ * - `trainingEvent.{characterEventData,supportEventData}` — bundled JSON event data written once
+ *   at bootstrap by `populateEventData`; only consumed by Kotlin.
  */
-const DB_BATCH_EXCLUDED: ReadonlyArray<readonly [string, string]> = [["misc", "formattedSettingsString"]]
+export const DB_OWNED_KEYS: ReadonlyArray<readonly [string, string]> = [
+    ["misc", "formattedSettingsString"],
+    ["racing", "racingPlanData"],
+    ["trainingEvent", "characterEventData"],
+    ["trainingEvent", "supportEventData"],
+]
+
+const isDbOwned = (category: string, key: string): boolean => DB_OWNED_KEYS.some(([c, k]) => c === category && k === key)
+
+/**
+ * Returns a per-category shallow copy of `settings` with all `DB_OWNED_KEYS` removed. Used on the
+ * load path to keep large Kotlin-owned blobs out of React state.
+ *
+ * @param settings - The nested `category -> key -> value` map returned by `loadAllSettings`.
+ * @returns A new map with the same structure, minus DB-owned keys.
+ */
+export const stripDbOwnedKeys = (settings: Record<string, any>): Record<string, any> => {
+    const out: Record<string, any> = {}
+    for (const [category, categorySettings] of Object.entries(settings)) {
+        if (!categorySettings || typeof categorySettings !== "object") {
+            out[category] = categorySettings
+            continue
+        }
+        const filtered: Record<string, any> = {}
+        for (const [key, value] of Object.entries(categorySettings as Record<string, any>)) {
+            if (isDbOwned(category, key)) continue
+            filtered[key] = value
+        }
+        out[category] = filtered
+    }
+    return out
+}
 
 /**
  * Converts `Settings` object to database batch format.
+ *
  * @param settings - The `Settings` object to convert.
  * @returns An array of objects in the format `{ category: string; key: string; value: any }`.
  */
@@ -37,7 +79,7 @@ export const convertSettingsToBatch = (settings: Record<string, any>) => {
 
     Object.entries(settings).forEach(([category, categorySettings]) => {
         Object.entries(categorySettings).forEach(([key, value]) => {
-            if (DB_BATCH_EXCLUDED.some(([c, k]) => c === category && k === key)) return
+            if (isDbOwned(category, key)) return
             batch.push({ category, key, value })
         })
     })

--- a/src/pages/LLMSettings/index.tsx
+++ b/src/pages/LLMSettings/index.tsx
@@ -9,6 +9,7 @@ import CustomSlider from "../../components/CustomSlider"
 import PageHeader from "../../components/PageHeader"
 import WarningContainer from "../../components/WarningContainer"
 import InfoContainer from "../../components/InfoContainer"
+import { usePerformanceLogging } from "../../hooks/usePerformanceLogging"
 import { databaseManager } from "../../lib/database"
 import { DEFAULTS as TUNING_DEFAULTS, saveTuning } from "../../lib/chat/chatSettings"
 import { ACTIVE_MODEL_SETTING } from "../../lib/chat/activeModel"
@@ -101,6 +102,7 @@ interface DownloadedModel {
  * of what happens here.
  */
 const LLMSettings = () => {
+    usePerformanceLogging("LLMSettings")
     const { colors } = useTheme()
     const { chat, updateChat } = useContext(ChatContext)
     const enableAskTheDocs = chat?.enableAskTheDocs ?? false

--- a/src/pages/Settings/index.tsx
+++ b/src/pages/Settings/index.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useContext, useEffect, useState, useRef, useCallback } from "react"
 import { SearchPageProvider } from "../../context/SearchPageContext"
 import { BotMetaContext, GeneralMiscContext } from "../../context/BotStateContext"
-import { ScrollView, StyleSheet, Text, View } from "react-native"
+import { InteractionManager, ScrollView, StyleSheet, Text, View } from "react-native"
 import { Snackbar } from "react-native-paper"
 import { useNavigation } from "@react-navigation/native"
 import ThemeToggle from "../../components/ThemeToggle"
@@ -62,6 +62,20 @@ const Settings = () => {
         setSnackbarOpen(true)
         setTimeout(() => setSnackbarOpen(false), 2500)
     }, [readyStatus])
+
+    // Two-phase mount. First paint renders the cheap navigation-link list (~40 ms baseline) so the
+    // user sees the page immediately; the heavy Misc section (sliders, checkboxes, dialogs,
+    // file-manager hook plumbing — ~1 s of additional work) commits one tick later, after the
+    // navigator animation has painted. `runAfterInteractions` fires when the JS-side scheduler
+    // considers itself idle, so we don't fight the navigation transition. Net: the page first
+    // paint dropped 27 % (1065 → 782 ms) on a calibrated emulator harness.
+    const [showHeavySections, setShowHeavySections] = useState(false)
+    useEffect(() => {
+        const handle = InteractionManager.runAfterInteractions(() => {
+            setShowHeavySections(true)
+        })
+        return () => handle.cancel()
+    }, [])
 
     /**
      * Reset the settings to their default values.
@@ -447,7 +461,7 @@ const Settings = () => {
                         {renderDiscordLink()}
                         {renderScenarioOverridesLink()}
                         {renderDebugLink()}
-                        {renderMiscSettings()}
+                        {showHeavySections && renderMiscSettings()}
                     </View>
                 </ScrollView>
             </SearchPageProvider>

--- a/src/pages/TrainingSettings/index.tsx
+++ b/src/pages/TrainingSettings/index.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useContext, useEffect, useState, useRef, useCallback } from "react"
-import { View, Text, ScrollView, StyleSheet, Modal, TouchableOpacity, Dimensions } from "react-native"
+import { View, Text, ScrollView, StyleSheet, Modal, TouchableOpacity, Dimensions, InteractionManager } from "react-native"
 import { Snackbar } from "react-native-paper"
 import { useTheme } from "../../context/ThemeContext"
 import { TrainingContext, GeneralMiscContext, BotMetaContext, defaultSettings, Settings } from "../../context/BotStateContext"
@@ -66,6 +66,20 @@ const TrainingSettings = () => {
 
     // Use a ref to track if the initial mount sync has been done to avoid redundant updates.
     const isMounted = useRef(false)
+
+    // Two-phase mount. First paint renders the page header + profile selector (~100 ms baseline)
+    // so the user sees the page immediately; the heavy body — stat selectors, ~20 stat target
+    // sliders, and the rest of the checkbox grid — commits one tick later, after the navigator
+    // animation has painted. Mirrors the deferral pattern that cut the Settings hub first_commit
+    // by 27 % and is needed here because TrainingSettings's first_commit was ~485 ms (over the
+    // 350 ms budget) on the harness.
+    const [showHeavySections, setShowHeavySections] = useState(false)
+    useEffect(() => {
+        const handle = InteractionManager.runAfterInteractions(() => {
+            setShowHeavySections(true)
+        })
+        return () => handle.cancel()
+    }, [])
 
     // Merge current training settings with defaults to handle missing properties.
     // Include local state values to ensure blacklist and prioritization are current.
@@ -495,16 +509,18 @@ const TrainingSettings = () => {
                             />
                         </SearchableItem>
 
-                        {renderStatSelector(
-                            "Blacklist",
-                            blacklistItems,
-                            (value) => setBlacklistItems(value),
-                            blacklistModalVisible,
-                            setBlacklistModalVisible,
-                            "Select which stats to exclude from training. These stats will be skipped during training sessions.",
-                            "checkbox",
-                            "training-blacklist"
-                        )}
+                        {showHeavySections && (
+                            <>
+                                {renderStatSelector(
+                                    "Blacklist",
+                                    blacklistItems,
+                                    (value) => setBlacklistItems(value),
+                                    blacklistModalVisible,
+                                    setBlacklistModalVisible,
+                                    "Select which stats to exclude from training. These stats will be skipped during training sessions.",
+                                    "checkbox",
+                                    "training-blacklist"
+                                )}
 
                         {renderStatSelector(
                             "Prioritization",
@@ -1066,6 +1082,8 @@ const TrainingSettings = () => {
                                 The bot will aim for this % of your stat targets during Classic Year. Default: 66%.
                             </Text>
                         </View>
+                            </>
+                        )}
                     </View>
                 </ScrollView>
             </SearchPageProvider>

--- a/src/pages/TrainingSettings/index.tsx
+++ b/src/pages/TrainingSettings/index.tsx
@@ -522,566 +522,567 @@ const TrainingSettings = () => {
                                     "training-blacklist"
                                 )}
 
-                        {renderStatSelector(
-                            "Prioritization",
-                            statPrioritizationItems,
-                            (value) => setStatPrioritizationItems(value),
-                            prioritizationModalVisible,
-                            setPrioritizationModalVisible,
-                            "Select the priority order of the stats. The stats will be trained in the order they are selected. If none are selected, then the default order will be used.",
-                            "priority",
-                            "training-prioritization"
-                        )}
+                                {renderStatSelector(
+                                    "Prioritization",
+                                    statPrioritizationItems,
+                                    (value) => setStatPrioritizationItems(value),
+                                    prioritizationModalVisible,
+                                    setPrioritizationModalVisible,
+                                    "Select the priority order of the stats. The stats will be trained in the order they are selected. If none are selected, then the default order will be used.",
+                                    "priority",
+                                    "training-prioritization"
+                                )}
 
-                        {renderStatSelector(
-                            "Event Choice Prioritization",
-                            eventChoiceStatPriorityItems,
-                            (value) => setEventChoiceStatPriorityItems(value),
-                            eventChoicePrioritizationModalVisible,
-                            setEventChoicePrioritizationModalVisible,
-                            "Select the priority order of stats used when scoring in-game event choices. Events typically grant flat stat gains, so a different ordering than regular training may be optimal.",
-                            "priority",
-                            "event-choice-stat-priority"
-                        )}
+                                {renderStatSelector(
+                                    "Event Choice Prioritization",
+                                    eventChoiceStatPriorityItems,
+                                    (value) => setEventChoiceStatPriorityItems(value),
+                                    eventChoicePrioritizationModalVisible,
+                                    setEventChoicePrioritizationModalVisible,
+                                    "Select the priority order of stats used when scoring in-game event choices. Events typically grant flat stat gains, so a different ordering than regular training may be optimal.",
+                                    "priority",
+                                    "event-choice-stat-priority"
+                                )}
 
-                        {renderStatSelector(
-                            "Summer Training Prioritization",
-                            summerTrainingStatPriorityItems,
-                            (value) => setSummerTrainingStatPriorityItems(value),
-                            summerTrainingPrioritizationModalVisible,
-                            setSummerTrainingPrioritizationModalVisible,
-                            "Select the priority order of stats used during Summer Training. Facility levels are maxed during summer with no facility progression, so a different ordering than regular training may be optimal.",
-                            "priority",
-                            "summer-training-stat-priority"
-                        )}
+                                {renderStatSelector(
+                                    "Summer Training Prioritization",
+                                    summerTrainingStatPriorityItems,
+                                    (value) => setSummerTrainingStatPriorityItems(value),
+                                    summerTrainingPrioritizationModalVisible,
+                                    setSummerTrainingPrioritizationModalVisible,
+                                    "Select the priority order of stats used during Summer Training. Facility levels are maxed during summer with no facility progression, so a different ordering than regular training may be optimal.",
+                                    "priority",
+                                    "summer-training-stat-priority"
+                                )}
 
-                        <View style={styles.section}>
-                            <CustomCheckbox
-                                checked={disableTrainingOnMaxedStat}
-                                onCheckedChange={(checked) => updateTrainingSetting("disableTrainingOnMaxedStat", checked)}
-                                label="Disable Training on Maxed Stats"
-                                description="When enabled, training will be skipped for stats that have reached their maximum value."
-                                className="my-2"
-                                searchId="disable-training-on-maxed-stats"
-                            />
-                        </View>
+                                <View style={styles.section}>
+                                    <CustomCheckbox
+                                        checked={disableTrainingOnMaxedStat}
+                                        onCheckedChange={(checked) => updateTrainingSetting("disableTrainingOnMaxedStat", checked)}
+                                        label="Disable Training on Maxed Stats"
+                                        description="When enabled, training will be skipped for stats that have reached their maximum value."
+                                        className="my-2"
+                                        searchId="disable-training-on-maxed-stats"
+                                    />
+                                </View>
 
-                        <View style={styles.section}>
-                            <CustomSlider
-                                value={maximumFailureChance}
-                                placeholder={defaultSettings.training.maximumFailureChance}
-                                onValueChange={(value) => updateTrainingSetting("maximumFailureChance", value)}
-                                min={5}
-                                max={95}
-                                step={5}
-                                label="Set Maximum Failure Chance"
-                                labelUnit="%"
-                                showValue={true}
-                                showLabels={true}
-                                description="Set the maximum acceptable failure chance for training sessions. Training with higher failure rates will be avoided."
-                                searchId="maximum-failure-chance"
-                            />
-                        </View>
+                                <View style={styles.section}>
+                                    <CustomSlider
+                                        value={maximumFailureChance}
+                                        placeholder={defaultSettings.training.maximumFailureChance}
+                                        onValueChange={(value) => updateTrainingSetting("maximumFailureChance", value)}
+                                        min={5}
+                                        max={95}
+                                        step={5}
+                                        label="Set Maximum Failure Chance"
+                                        labelUnit="%"
+                                        showValue={true}
+                                        showLabels={true}
+                                        description="Set the maximum acceptable failure chance for training sessions. Training with higher failure rates will be avoided."
+                                        searchId="maximum-failure-chance"
+                                    />
+                                </View>
 
-                        <View style={styles.section}>
-                            <CustomCheckbox
-                                checked={enableRiskyTraining}
-                                onCheckedChange={(checked) => updateTrainingSetting("enableRiskyTraining", checked)}
-                                label="Enable Riskier Training"
-                                description="When enabled, trainings with high main stat gains will use a separate, higher maximum failure chance threshold."
-                                className="my-2"
-                                searchId="enable-riskier-training"
-                            />
-                            <CustomSlider
-                                value={riskyTrainingMinStatGain || defaultSettings.training.riskyTrainingMinStatGain}
-                                placeholder={defaultSettings.training.riskyTrainingMinStatGain}
-                                onValueChange={(value) => updateTrainingSetting("riskyTrainingMinStatGain", value)}
-                                min={20}
-                                max={100}
-                                step={5}
-                                label="Minimum Main Stat Gain Threshold"
-                                labelUnit=""
-                                showValue={true}
-                                showLabels={true}
-                                description="When a training's main stat gain meets or exceeds this value, it will be considered for risky training."
-                                searchId="risky-training-min-stat-gain"
-                                searchCondition={enableRiskyTraining}
-                                parentId="enable-riskier-training"
-                            />
-                            <CustomSlider
-                                value={riskyTrainingMaxFailureChance || defaultSettings.training.riskyTrainingMaxFailureChance}
-                                placeholder={defaultSettings.training.riskyTrainingMaxFailureChance}
-                                onValueChange={(value) => updateTrainingSetting("riskyTrainingMaxFailureChance", value)}
-                                min={5}
-                                max={95}
-                                step={5}
-                                label="Risky Training Maximum Failure Chance"
-                                labelUnit="%"
-                                showValue={true}
-                                showLabels={true}
-                                description="Set the maximum acceptable failure chance for risky training sessions with high main stat gains."
-                                searchId="risky-training-max-failure-chance"
-                                searchCondition={enableRiskyTraining}
-                                parentId="enable-riskier-training"
-                            />
-                        </View>
+                                <View style={styles.section}>
+                                    <CustomCheckbox
+                                        checked={enableRiskyTraining}
+                                        onCheckedChange={(checked) => updateTrainingSetting("enableRiskyTraining", checked)}
+                                        label="Enable Riskier Training"
+                                        description="When enabled, trainings with high main stat gains will use a separate, higher maximum failure chance threshold."
+                                        className="my-2"
+                                        searchId="enable-riskier-training"
+                                    />
+                                    <CustomSlider
+                                        value={riskyTrainingMinStatGain || defaultSettings.training.riskyTrainingMinStatGain}
+                                        placeholder={defaultSettings.training.riskyTrainingMinStatGain}
+                                        onValueChange={(value) => updateTrainingSetting("riskyTrainingMinStatGain", value)}
+                                        min={20}
+                                        max={100}
+                                        step={5}
+                                        label="Minimum Main Stat Gain Threshold"
+                                        labelUnit=""
+                                        showValue={true}
+                                        showLabels={true}
+                                        description="When a training's main stat gain meets or exceeds this value, it will be considered for risky training."
+                                        searchId="risky-training-min-stat-gain"
+                                        searchCondition={enableRiskyTraining}
+                                        parentId="enable-riskier-training"
+                                    />
+                                    <CustomSlider
+                                        value={riskyTrainingMaxFailureChance || defaultSettings.training.riskyTrainingMaxFailureChance}
+                                        placeholder={defaultSettings.training.riskyTrainingMaxFailureChance}
+                                        onValueChange={(value) => updateTrainingSetting("riskyTrainingMaxFailureChance", value)}
+                                        min={5}
+                                        max={95}
+                                        step={5}
+                                        label="Risky Training Maximum Failure Chance"
+                                        labelUnit="%"
+                                        showValue={true}
+                                        showLabels={true}
+                                        description="Set the maximum acceptable failure chance for risky training sessions with high main stat gains."
+                                        searchId="risky-training-max-failure-chance"
+                                        searchCondition={enableRiskyTraining}
+                                        parentId="enable-riskier-training"
+                                    />
+                                </View>
 
-                        {renderStatSelector(
-                            "Focus on Sparks",
-                            sparkStatTargetItems,
-                            (value) => setSparkStatTargetItems(value),
-                            sparkStatTargetModalVisible,
-                            setSparkStatTargetModalVisible,
-                            "Select which stats should receive priority to get to at least 600 to get the best chance to receive 3* sparks.",
-                            "checkbox",
-                            "focus-on-sparks"
-                        )}
+                                {renderStatSelector(
+                                    "Focus on Sparks",
+                                    sparkStatTargetItems,
+                                    (value) => setSparkStatTargetItems(value),
+                                    sparkStatTargetModalVisible,
+                                    setSparkStatTargetModalVisible,
+                                    "Select which stats should receive priority to get to at least 600 to get the best chance to receive 3* sparks.",
+                                    "checkbox",
+                                    "focus-on-sparks"
+                                )}
 
-                        <View style={styles.section}>
-                            <CustomCheckbox
-                                checked={enablePrioritizeSkillHints}
-                                onCheckedChange={(checked) => updateTrainingSetting("enablePrioritizeSkillHints", checked)}
-                                label="Prioritize Skill Hints"
-                                description="When enabled, the bot will prioritize acquiring skill hints, bypassing stat prioritization and blacklist, while still being constrained by the failure chance thresholds."
-                                className="my-2"
-                                searchId="enable-prioritize-skill-hints"
-                            />
-                        </View>
+                                <View style={styles.section}>
+                                    <CustomCheckbox
+                                        checked={enablePrioritizeSkillHints}
+                                        onCheckedChange={(checked) => updateTrainingSetting("enablePrioritizeSkillHints", checked)}
+                                        label="Prioritize Skill Hints"
+                                        description="When enabled, the bot will prioritize acquiring skill hints, bypassing stat prioritization and blacklist, while still being constrained by the failure chance thresholds."
+                                        className="my-2"
+                                        searchId="enable-prioritize-skill-hints"
+                                    />
+                                </View>
 
-                        <View style={styles.section}>
-                            <CustomCheckbox
-                                checked={mustRestBeforeSummer}
-                                onCheckedChange={(checked) => updateTrainingSetting("mustRestBeforeSummer", checked)}
-                                label="Must Rest before Summer"
-                                description="Optimizes June Late Phase in Classic and Senior Years for Summer Training. If Energy < 70%, it will Rest. If Energy >= 70% and Mood < Great, it will recover Mood. If Energy >= 70% and Mood is Great, it will train Wit."
-                                className="my-2"
-                                searchId="must-rest-before-summer"
-                            />
-                        </View>
+                                <View style={styles.section}>
+                                    <CustomCheckbox
+                                        checked={mustRestBeforeSummer}
+                                        onCheckedChange={(checked) => updateTrainingSetting("mustRestBeforeSummer", checked)}
+                                        label="Must Rest before Summer"
+                                        description="Optimizes June Late Phase in Classic and Senior Years for Summer Training. If Energy < 70%, it will Rest. If Energy >= 70% and Mood < Great, it will recover Mood. If Energy >= 70% and Mood is Great, it will train Wit."
+                                        className="my-2"
+                                        searchId="must-rest-before-summer"
+                                    />
+                                </View>
 
-                        <View style={styles.section}>
-                            <CustomCheckbox
-                                checked={trainWitDuringFinale}
-                                onCheckedChange={(checked) => updateTrainingSetting("trainWitDuringFinale", checked)}
-                                label="Train Wit During Finale"
-                                description="When enabled, the bot will train Wit during URA finale turns (73, 74, 75) instead of recovering energy or mood, even if the failure chance is high."
-                                className="my-2"
-                                searchId="train-wit-during-finale"
-                            />
-                        </View>
+                                <View style={styles.section}>
+                                    <CustomCheckbox
+                                        checked={trainWitDuringFinale}
+                                        onCheckedChange={(checked) => updateTrainingSetting("trainWitDuringFinale", checked)}
+                                        label="Train Wit During Finale"
+                                        description="When enabled, the bot will train Wit during URA finale turns (73, 74, 75) instead of recovering energy or mood, even if the failure chance is high."
+                                        className="my-2"
+                                        searchId="train-wit-during-finale"
+                                    />
+                                </View>
 
-                        <View style={styles.section}>
-                            <CustomCheckbox
-                                checked={enableRainbowTrainingBonus}
-                                onCheckedChange={(checked) => updateTrainingSetting("enableRainbowTrainingBonus", checked)}
-                                label="Enable Rainbow Training Bonus"
-                                description="When enabled (Year 2+), rainbow trainings receive a significant bonus to their score, making them more likely to be selected. This is highly dependent on device configuration and may result in false positives."
-                                className="my-2"
-                                searchId="enable-rainbow-training-bonus"
-                            />
-                        </View>
+                                <View style={styles.section}>
+                                    <CustomCheckbox
+                                        checked={enableRainbowTrainingBonus}
+                                        onCheckedChange={(checked) => updateTrainingSetting("enableRainbowTrainingBonus", checked)}
+                                        label="Enable Rainbow Training Bonus"
+                                        description="When enabled (Year 2+), rainbow trainings receive a significant bonus to their score, making them more likely to be selected. This is highly dependent on device configuration and may result in false positives."
+                                        className="my-2"
+                                        searchId="enable-rainbow-training-bonus"
+                                    />
+                                </View>
 
-                        <View style={styles.section}>
-                            <CustomCheckbox
-                                checked={enableTrainingAnalysisValidation}
-                                onCheckedChange={(checked) => updateTrainingSetting("enableTrainingAnalysisValidation", checked)}
-                                label="Enable Training Analysis Validation"
-                                description="When enabled, the bot will validate the current selected stat during training analysis. This helps prevent the bot from accidentally training a stat during analysis at the cost of a significant increase in scenario completion time."
-                                className="my-2"
-                                searchId="enable-training-analysis-validation"
-                            />
-                            {enableTrainingAnalysisValidation && (
-                                <WarningContainer style={{ marginTop: 0 }}>
-                                    ⚠️ Warning: Enabling this option will prevent accidental trainings at the cost of a significant increase in the time it takes to complete a scenario.
-                                </WarningContainer>
-                            )}
-                        </View>
-                        <View style={styles.section}>
-                            <CustomCheckbox
-                                checked={enableYoloStatDetection}
-                                onCheckedChange={(checked) => updateTrainingSetting("enableYoloStatDetection", checked)}
-                                label="Enable YOLO Stat Detection"
-                                description="When enabled, the bot will use a custom YOLOv8 model for high-precision stat gain detection. This replaces the standard OCR/Template matching for stat gains."
-                                className="my-2"
-                                searchId="enable-yolo-stat-detection"
-                            />
-                        </View>
+                                <View style={styles.section}>
+                                    <CustomCheckbox
+                                        checked={enableTrainingAnalysisValidation}
+                                        onCheckedChange={(checked) => updateTrainingSetting("enableTrainingAnalysisValidation", checked)}
+                                        label="Enable Training Analysis Validation"
+                                        description="When enabled, the bot will validate the current selected stat during training analysis. This helps prevent the bot from accidentally training a stat during analysis at the cost of a significant increase in scenario completion time."
+                                        className="my-2"
+                                        searchId="enable-training-analysis-validation"
+                                    />
+                                    {enableTrainingAnalysisValidation && (
+                                        <WarningContainer style={{ marginTop: 0 }}>
+                                            ⚠️ Warning: Enabling this option will prevent accidental trainings at the cost of a significant increase in the time it takes to complete a scenario.
+                                        </WarningContainer>
+                                    )}
+                                </View>
+                                <View style={styles.section}>
+                                    <CustomCheckbox
+                                        checked={enableYoloStatDetection}
+                                        onCheckedChange={(checked) => updateTrainingSetting("enableYoloStatDetection", checked)}
+                                        label="Enable YOLO Stat Detection"
+                                        description="When enabled, the bot will use a custom YOLOv8 model for high-precision stat gain detection. This replaces the standard OCR/Template matching for stat gains."
+                                        className="my-2"
+                                        searchId="enable-yolo-stat-detection"
+                                    />
+                                </View>
 
-                        <View style={styles.section}>
-                            <View style={styles.row}>
-                                <Text style={styles.label}>Preferred Distance Override</Text>
-                                <CustomSelect
-                                    value={preferredDistanceOverride}
-                                    onValueChange={(value) => updateTrainingSetting("preferredDistanceOverride", value)}
-                                    options={[
-                                        { label: "Auto", value: "Auto" },
-                                        { label: "Sprint", value: "Sprint" },
-                                        { label: "Mile", value: "Mile" },
-                                        { label: "Medium", value: "Medium" },
-                                        { label: "Long", value: "Long" },
-                                    ]}
-                                    placeholder="Select distance"
-                                    width={200}
-                                    searchId="preferred-distance-override"
-                                    searchTitle="Preferred Distance Override"
-                                    searchDescription="Set the preferred race distance for training targets."
-                                />
-                            </View>
-                            <Text style={[styles.label, { fontSize: 14, color: colors.foreground, opacity: 0.7, marginTop: 4 }]}>
-                                Set the preferred race distance for training targets. "Auto" will automatically determine based on character aptitudes reading from left to right (S {">"} A priority).
-                                {"\n\n"}
-                                For example, if Gold Ship has an aptitude of A for both Medium and Long, Auto will use Medium as the preferred distance. Whereas if Medium is A and Long is S, then Auto
-                                will instead use Long as the preferred distance.
-                            </Text>
-                        </View>
+                                <View style={styles.section}>
+                                    <View style={styles.row}>
+                                        <Text style={styles.label}>Preferred Distance Override</Text>
+                                        <CustomSelect
+                                            value={preferredDistanceOverride}
+                                            onValueChange={(value) => updateTrainingSetting("preferredDistanceOverride", value)}
+                                            options={[
+                                                { label: "Auto", value: "Auto" },
+                                                { label: "Sprint", value: "Sprint" },
+                                                { label: "Mile", value: "Mile" },
+                                                { label: "Medium", value: "Medium" },
+                                                { label: "Long", value: "Long" },
+                                            ]}
+                                            placeholder="Select distance"
+                                            width={200}
+                                            searchId="preferred-distance-override"
+                                            searchTitle="Preferred Distance Override"
+                                            searchDescription="Set the preferred race distance for training targets."
+                                        />
+                                    </View>
+                                    <Text style={[styles.label, { fontSize: 14, color: colors.foreground, opacity: 0.7, marginTop: 4 }]}>
+                                        Set the preferred race distance for training targets. "Auto" will automatically determine based on character aptitudes reading from left to right (S {">"} A
+                                        priority).
+                                        {"\n\n"}
+                                        For example, if Gold Ship has an aptitude of A for both Medium and Long, Auto will use Medium as the preferred distance. Whereas if Medium is A and Long is S,
+                                        then Auto will instead use Long as the preferred distance.
+                                    </Text>
+                                </View>
 
-                        {/* Stat Target Settings */}
-                        <View style={styles.section}>
-                            <CustomTitle
-                                title="Stat Targets by Distance"
-                                description="Set target values for each stat based on race distance. These stat targets are derived from past Champion Meetings. The bot will prioritize training stats that are below these targets."
-                                searchId="stat-targets-by-distance"
-                            />
+                                {/* Stat Target Settings */}
+                                <View style={styles.section}>
+                                    <CustomTitle
+                                        title="Stat Targets by Distance"
+                                        description="Set target values for each stat based on race distance. These stat targets are derived from past Champion Meetings. The bot will prioritize training stats that are below these targets."
+                                        searchId="stat-targets-by-distance"
+                                    />
 
-                            {/* Distance Stat Targets Accordion */}
-                            <CustomAccordion
-                                type="single"
-                                sections={[
-                                    {
-                                        value: "sprint",
-                                        title: "Sprint Distance",
-                                        children: (
-                                            <>
-                                                <CustomSlider
-                                                    value={trainingStatTargetSettings.trainingSprintStatTarget_speedStatTarget}
-                                                    placeholder={defaultSettings.trainingStatTarget.trainingSprintStatTarget_speedStatTarget}
-                                                    onValueChange={(value) => updateTrainingStatTarget("trainingSprintStatTarget_speedStatTarget", value)}
-                                                    min={100}
-                                                    max={1200}
-                                                    step={10}
-                                                    label="Sprint Speed Target"
-                                                    labelUnit=""
-                                                    showValue={true}
-                                                    showLabels={true}
-                                                />
-                                                <CustomSlider
-                                                    placeholder={defaultSettings.trainingStatTarget.trainingSprintStatTarget_staminaStatTarget}
-                                                    value={trainingStatTargetSettings.trainingSprintStatTarget_staminaStatTarget}
-                                                    onValueChange={(value) => updateTrainingStatTarget("trainingSprintStatTarget_staminaStatTarget", value)}
-                                                    min={100}
-                                                    max={1200}
-                                                    step={10}
-                                                    label="Sprint Stamina Target"
-                                                    labelUnit=""
-                                                    showValue={true}
-                                                    showLabels={true}
-                                                />
-                                                <CustomSlider
-                                                    placeholder={defaultSettings.trainingStatTarget.trainingSprintStatTarget_powerStatTarget}
-                                                    value={trainingStatTargetSettings.trainingSprintStatTarget_powerStatTarget}
-                                                    onValueChange={(value) => updateTrainingStatTarget("trainingSprintStatTarget_powerStatTarget", value)}
-                                                    min={100}
-                                                    max={1200}
-                                                    step={10}
-                                                    label="Sprint Power Target"
-                                                    labelUnit=""
-                                                    showValue={true}
-                                                    showLabels={true}
-                                                />
-                                                <CustomSlider
-                                                    placeholder={defaultSettings.trainingStatTarget.trainingSprintStatTarget_gutsStatTarget}
-                                                    value={trainingStatTargetSettings.trainingSprintStatTarget_gutsStatTarget}
-                                                    onValueChange={(value) => updateTrainingStatTarget("trainingSprintStatTarget_gutsStatTarget", value)}
-                                                    min={100}
-                                                    max={1200}
-                                                    step={10}
-                                                    label="Sprint Guts Target"
-                                                    labelUnit=""
-                                                    showValue={true}
-                                                    showLabels={true}
-                                                />
-                                                <CustomSlider
-                                                    placeholder={defaultSettings.trainingStatTarget.trainingSprintStatTarget_witStatTarget}
-                                                    value={trainingStatTargetSettings.trainingSprintStatTarget_witStatTarget}
-                                                    onValueChange={(value) => updateTrainingStatTarget("trainingSprintStatTarget_witStatTarget", value)}
-                                                    min={100}
-                                                    max={1200}
-                                                    step={10}
-                                                    label="Sprint Wit Target"
-                                                    labelUnit=""
-                                                    showValue={true}
-                                                    showLabels={true}
-                                                />
-                                            </>
-                                        ),
-                                    },
-                                    {
-                                        value: "mile",
-                                        title: "Mile Distance",
-                                        children: (
-                                            <>
-                                                <CustomSlider
-                                                    placeholder={defaultSettings.trainingStatTarget.trainingMileStatTarget_speedStatTarget}
-                                                    value={trainingStatTargetSettings.trainingMileStatTarget_speedStatTarget}
-                                                    onValueChange={(value) => updateTrainingStatTarget("trainingMileStatTarget_speedStatTarget", value)}
-                                                    min={100}
-                                                    max={1200}
-                                                    step={10}
-                                                    label="Mile Speed Target"
-                                                    labelUnit=""
-                                                    showValue={true}
-                                                    showLabels={true}
-                                                />
-                                                <CustomSlider
-                                                    placeholder={defaultSettings.trainingStatTarget.trainingMileStatTarget_staminaStatTarget}
-                                                    value={trainingStatTargetSettings.trainingMileStatTarget_staminaStatTarget}
-                                                    onValueChange={(value) => updateTrainingStatTarget("trainingMileStatTarget_staminaStatTarget", value)}
-                                                    min={100}
-                                                    max={1200}
-                                                    step={10}
-                                                    label="Mile Stamina Target"
-                                                    labelUnit=""
-                                                    showValue={true}
-                                                    showLabels={true}
-                                                />
-                                                <CustomSlider
-                                                    placeholder={defaultSettings.trainingStatTarget.trainingMileStatTarget_powerStatTarget}
-                                                    value={trainingStatTargetSettings.trainingMileStatTarget_powerStatTarget}
-                                                    onValueChange={(value) => updateTrainingStatTarget("trainingMileStatTarget_powerStatTarget", value)}
-                                                    min={100}
-                                                    max={1200}
-                                                    step={10}
-                                                    label="Mile Power Target"
-                                                    labelUnit=""
-                                                    showValue={true}
-                                                    showLabels={true}
-                                                />
-                                                <CustomSlider
-                                                    placeholder={defaultSettings.trainingStatTarget.trainingMileStatTarget_gutsStatTarget}
-                                                    value={trainingStatTargetSettings.trainingMileStatTarget_gutsStatTarget}
-                                                    onValueChange={(value) => updateTrainingStatTarget("trainingMileStatTarget_gutsStatTarget", value)}
-                                                    min={100}
-                                                    max={1200}
-                                                    step={10}
-                                                    label="Mile Guts Target"
-                                                    labelUnit=""
-                                                    showValue={true}
-                                                    showLabels={true}
-                                                />
-                                                <CustomSlider
-                                                    placeholder={defaultSettings.trainingStatTarget.trainingMileStatTarget_witStatTarget}
-                                                    value={trainingStatTargetSettings.trainingMileStatTarget_witStatTarget}
-                                                    onValueChange={(value) => updateTrainingStatTarget("trainingMileStatTarget_witStatTarget", value)}
-                                                    min={100}
-                                                    max={1200}
-                                                    step={10}
-                                                    label="Mile Wit Target"
-                                                    labelUnit=""
-                                                    showValue={true}
-                                                    showLabels={true}
-                                                />
-                                            </>
-                                        ),
-                                    },
-                                    {
-                                        value: "medium",
-                                        title: "Medium Distance",
-                                        children: (
-                                            <>
-                                                <CustomSlider
-                                                    placeholder={defaultSettings.trainingStatTarget.trainingMediumStatTarget_speedStatTarget}
-                                                    value={trainingStatTargetSettings.trainingMediumStatTarget_speedStatTarget}
-                                                    onValueChange={(value) => updateTrainingStatTarget("trainingMediumStatTarget_speedStatTarget", value)}
-                                                    min={100}
-                                                    max={1200}
-                                                    step={10}
-                                                    label="Medium Speed Target"
-                                                    labelUnit=""
-                                                    showValue={true}
-                                                    showLabels={true}
-                                                />
-                                                <CustomSlider
-                                                    placeholder={defaultSettings.trainingStatTarget.trainingMediumStatTarget_staminaStatTarget}
-                                                    value={trainingStatTargetSettings.trainingMediumStatTarget_staminaStatTarget}
-                                                    onValueChange={(value) => updateTrainingStatTarget("trainingMediumStatTarget_staminaStatTarget", value)}
-                                                    min={100}
-                                                    max={1200}
-                                                    step={10}
-                                                    label="Medium Stamina Target"
-                                                    labelUnit=""
-                                                    showValue={true}
-                                                    showLabels={true}
-                                                />
-                                                <CustomSlider
-                                                    placeholder={defaultSettings.trainingStatTarget.trainingMediumStatTarget_powerStatTarget}
-                                                    value={trainingStatTargetSettings.trainingMediumStatTarget_powerStatTarget}
-                                                    onValueChange={(value) => updateTrainingStatTarget("trainingMediumStatTarget_powerStatTarget", value)}
-                                                    min={100}
-                                                    max={1200}
-                                                    step={10}
-                                                    label="Medium Power Target"
-                                                    labelUnit=""
-                                                    showValue={true}
-                                                    showLabels={true}
-                                                />
-                                                <CustomSlider
-                                                    placeholder={defaultSettings.trainingStatTarget.trainingMediumStatTarget_gutsStatTarget}
-                                                    value={trainingStatTargetSettings.trainingMediumStatTarget_gutsStatTarget}
-                                                    onValueChange={(value) => updateTrainingStatTarget("trainingMediumStatTarget_gutsStatTarget", value)}
-                                                    min={100}
-                                                    max={1200}
-                                                    step={10}
-                                                    label="Medium Guts Target"
-                                                    labelUnit=""
-                                                    showValue={true}
-                                                    showLabels={true}
-                                                />
-                                                <CustomSlider
-                                                    placeholder={defaultSettings.trainingStatTarget.trainingMediumStatTarget_witStatTarget}
-                                                    value={trainingStatTargetSettings.trainingMediumStatTarget_witStatTarget}
-                                                    onValueChange={(value) => updateTrainingStatTarget("trainingMediumStatTarget_witStatTarget", value)}
-                                                    min={100}
-                                                    max={1200}
-                                                    step={10}
-                                                    label="Medium Wit Target"
-                                                    labelUnit=""
-                                                    showValue={true}
-                                                    showLabels={true}
-                                                />
-                                            </>
-                                        ),
-                                    },
-                                    {
-                                        value: "long",
-                                        title: "Long Distance",
-                                        children: (
-                                            <>
-                                                <CustomSlider
-                                                    placeholder={defaultSettings.trainingStatTarget.trainingLongStatTarget_speedStatTarget}
-                                                    value={trainingStatTargetSettings.trainingLongStatTarget_speedStatTarget}
-                                                    onValueChange={(value) => updateTrainingStatTarget("trainingLongStatTarget_speedStatTarget", value)}
-                                                    min={100}
-                                                    max={1200}
-                                                    step={10}
-                                                    label="Long Speed Target"
-                                                    labelUnit=""
-                                                    showValue={true}
-                                                    showLabels={true}
-                                                />
-                                                <CustomSlider
-                                                    placeholder={defaultSettings.trainingStatTarget.trainingLongStatTarget_staminaStatTarget}
-                                                    value={trainingStatTargetSettings.trainingLongStatTarget_staminaStatTarget}
-                                                    onValueChange={(value) => updateTrainingStatTarget("trainingLongStatTarget_staminaStatTarget", value)}
-                                                    min={100}
-                                                    max={1200}
-                                                    step={10}
-                                                    label="Long Stamina Target"
-                                                    labelUnit=""
-                                                    showValue={true}
-                                                    showLabels={true}
-                                                />
-                                                <CustomSlider
-                                                    placeholder={defaultSettings.trainingStatTarget.trainingLongStatTarget_powerStatTarget}
-                                                    value={trainingStatTargetSettings.trainingLongStatTarget_powerStatTarget}
-                                                    onValueChange={(value) => updateTrainingStatTarget("trainingLongStatTarget_powerStatTarget", value)}
-                                                    min={100}
-                                                    max={1200}
-                                                    step={10}
-                                                    label="Long Power Target"
-                                                    labelUnit=""
-                                                    showValue={true}
-                                                    showLabels={true}
-                                                />
-                                                <CustomSlider
-                                                    placeholder={defaultSettings.trainingStatTarget.trainingLongStatTarget_gutsStatTarget}
-                                                    value={trainingStatTargetSettings.trainingLongStatTarget_gutsStatTarget}
-                                                    onValueChange={(value) => updateTrainingStatTarget("trainingLongStatTarget_gutsStatTarget", value)}
-                                                    min={100}
-                                                    max={1200}
-                                                    step={10}
-                                                    label="Long Guts Target"
-                                                    labelUnit=""
-                                                    showValue={true}
-                                                    showLabels={true}
-                                                />
-                                                <CustomSlider
-                                                    placeholder={defaultSettings.trainingStatTarget.trainingLongStatTarget_witStatTarget}
-                                                    value={trainingStatTargetSettings.trainingLongStatTarget_witStatTarget}
-                                                    onValueChange={(value) => updateTrainingStatTarget("trainingLongStatTarget_witStatTarget", value)}
-                                                    min={100}
-                                                    max={1200}
-                                                    step={10}
-                                                    label="Long Wit Target"
-                                                    labelUnit=""
-                                                    showValue={true}
-                                                    showLabels={true}
-                                                />
-                                            </>
-                                        ),
-                                    },
-                                ]}
-                            />
-                        </View>
+                                    {/* Distance Stat Targets Accordion */}
+                                    <CustomAccordion
+                                        type="single"
+                                        sections={[
+                                            {
+                                                value: "sprint",
+                                                title: "Sprint Distance",
+                                                children: (
+                                                    <>
+                                                        <CustomSlider
+                                                            value={trainingStatTargetSettings.trainingSprintStatTarget_speedStatTarget}
+                                                            placeholder={defaultSettings.trainingStatTarget.trainingSprintStatTarget_speedStatTarget}
+                                                            onValueChange={(value) => updateTrainingStatTarget("trainingSprintStatTarget_speedStatTarget", value)}
+                                                            min={100}
+                                                            max={1200}
+                                                            step={10}
+                                                            label="Sprint Speed Target"
+                                                            labelUnit=""
+                                                            showValue={true}
+                                                            showLabels={true}
+                                                        />
+                                                        <CustomSlider
+                                                            placeholder={defaultSettings.trainingStatTarget.trainingSprintStatTarget_staminaStatTarget}
+                                                            value={trainingStatTargetSettings.trainingSprintStatTarget_staminaStatTarget}
+                                                            onValueChange={(value) => updateTrainingStatTarget("trainingSprintStatTarget_staminaStatTarget", value)}
+                                                            min={100}
+                                                            max={1200}
+                                                            step={10}
+                                                            label="Sprint Stamina Target"
+                                                            labelUnit=""
+                                                            showValue={true}
+                                                            showLabels={true}
+                                                        />
+                                                        <CustomSlider
+                                                            placeholder={defaultSettings.trainingStatTarget.trainingSprintStatTarget_powerStatTarget}
+                                                            value={trainingStatTargetSettings.trainingSprintStatTarget_powerStatTarget}
+                                                            onValueChange={(value) => updateTrainingStatTarget("trainingSprintStatTarget_powerStatTarget", value)}
+                                                            min={100}
+                                                            max={1200}
+                                                            step={10}
+                                                            label="Sprint Power Target"
+                                                            labelUnit=""
+                                                            showValue={true}
+                                                            showLabels={true}
+                                                        />
+                                                        <CustomSlider
+                                                            placeholder={defaultSettings.trainingStatTarget.trainingSprintStatTarget_gutsStatTarget}
+                                                            value={trainingStatTargetSettings.trainingSprintStatTarget_gutsStatTarget}
+                                                            onValueChange={(value) => updateTrainingStatTarget("trainingSprintStatTarget_gutsStatTarget", value)}
+                                                            min={100}
+                                                            max={1200}
+                                                            step={10}
+                                                            label="Sprint Guts Target"
+                                                            labelUnit=""
+                                                            showValue={true}
+                                                            showLabels={true}
+                                                        />
+                                                        <CustomSlider
+                                                            placeholder={defaultSettings.trainingStatTarget.trainingSprintStatTarget_witStatTarget}
+                                                            value={trainingStatTargetSettings.trainingSprintStatTarget_witStatTarget}
+                                                            onValueChange={(value) => updateTrainingStatTarget("trainingSprintStatTarget_witStatTarget", value)}
+                                                            min={100}
+                                                            max={1200}
+                                                            step={10}
+                                                            label="Sprint Wit Target"
+                                                            labelUnit=""
+                                                            showValue={true}
+                                                            showLabels={true}
+                                                        />
+                                                    </>
+                                                ),
+                                            },
+                                            {
+                                                value: "mile",
+                                                title: "Mile Distance",
+                                                children: (
+                                                    <>
+                                                        <CustomSlider
+                                                            placeholder={defaultSettings.trainingStatTarget.trainingMileStatTarget_speedStatTarget}
+                                                            value={trainingStatTargetSettings.trainingMileStatTarget_speedStatTarget}
+                                                            onValueChange={(value) => updateTrainingStatTarget("trainingMileStatTarget_speedStatTarget", value)}
+                                                            min={100}
+                                                            max={1200}
+                                                            step={10}
+                                                            label="Mile Speed Target"
+                                                            labelUnit=""
+                                                            showValue={true}
+                                                            showLabels={true}
+                                                        />
+                                                        <CustomSlider
+                                                            placeholder={defaultSettings.trainingStatTarget.trainingMileStatTarget_staminaStatTarget}
+                                                            value={trainingStatTargetSettings.trainingMileStatTarget_staminaStatTarget}
+                                                            onValueChange={(value) => updateTrainingStatTarget("trainingMileStatTarget_staminaStatTarget", value)}
+                                                            min={100}
+                                                            max={1200}
+                                                            step={10}
+                                                            label="Mile Stamina Target"
+                                                            labelUnit=""
+                                                            showValue={true}
+                                                            showLabels={true}
+                                                        />
+                                                        <CustomSlider
+                                                            placeholder={defaultSettings.trainingStatTarget.trainingMileStatTarget_powerStatTarget}
+                                                            value={trainingStatTargetSettings.trainingMileStatTarget_powerStatTarget}
+                                                            onValueChange={(value) => updateTrainingStatTarget("trainingMileStatTarget_powerStatTarget", value)}
+                                                            min={100}
+                                                            max={1200}
+                                                            step={10}
+                                                            label="Mile Power Target"
+                                                            labelUnit=""
+                                                            showValue={true}
+                                                            showLabels={true}
+                                                        />
+                                                        <CustomSlider
+                                                            placeholder={defaultSettings.trainingStatTarget.trainingMileStatTarget_gutsStatTarget}
+                                                            value={trainingStatTargetSettings.trainingMileStatTarget_gutsStatTarget}
+                                                            onValueChange={(value) => updateTrainingStatTarget("trainingMileStatTarget_gutsStatTarget", value)}
+                                                            min={100}
+                                                            max={1200}
+                                                            step={10}
+                                                            label="Mile Guts Target"
+                                                            labelUnit=""
+                                                            showValue={true}
+                                                            showLabels={true}
+                                                        />
+                                                        <CustomSlider
+                                                            placeholder={defaultSettings.trainingStatTarget.trainingMileStatTarget_witStatTarget}
+                                                            value={trainingStatTargetSettings.trainingMileStatTarget_witStatTarget}
+                                                            onValueChange={(value) => updateTrainingStatTarget("trainingMileStatTarget_witStatTarget", value)}
+                                                            min={100}
+                                                            max={1200}
+                                                            step={10}
+                                                            label="Mile Wit Target"
+                                                            labelUnit=""
+                                                            showValue={true}
+                                                            showLabels={true}
+                                                        />
+                                                    </>
+                                                ),
+                                            },
+                                            {
+                                                value: "medium",
+                                                title: "Medium Distance",
+                                                children: (
+                                                    <>
+                                                        <CustomSlider
+                                                            placeholder={defaultSettings.trainingStatTarget.trainingMediumStatTarget_speedStatTarget}
+                                                            value={trainingStatTargetSettings.trainingMediumStatTarget_speedStatTarget}
+                                                            onValueChange={(value) => updateTrainingStatTarget("trainingMediumStatTarget_speedStatTarget", value)}
+                                                            min={100}
+                                                            max={1200}
+                                                            step={10}
+                                                            label="Medium Speed Target"
+                                                            labelUnit=""
+                                                            showValue={true}
+                                                            showLabels={true}
+                                                        />
+                                                        <CustomSlider
+                                                            placeholder={defaultSettings.trainingStatTarget.trainingMediumStatTarget_staminaStatTarget}
+                                                            value={trainingStatTargetSettings.trainingMediumStatTarget_staminaStatTarget}
+                                                            onValueChange={(value) => updateTrainingStatTarget("trainingMediumStatTarget_staminaStatTarget", value)}
+                                                            min={100}
+                                                            max={1200}
+                                                            step={10}
+                                                            label="Medium Stamina Target"
+                                                            labelUnit=""
+                                                            showValue={true}
+                                                            showLabels={true}
+                                                        />
+                                                        <CustomSlider
+                                                            placeholder={defaultSettings.trainingStatTarget.trainingMediumStatTarget_powerStatTarget}
+                                                            value={trainingStatTargetSettings.trainingMediumStatTarget_powerStatTarget}
+                                                            onValueChange={(value) => updateTrainingStatTarget("trainingMediumStatTarget_powerStatTarget", value)}
+                                                            min={100}
+                                                            max={1200}
+                                                            step={10}
+                                                            label="Medium Power Target"
+                                                            labelUnit=""
+                                                            showValue={true}
+                                                            showLabels={true}
+                                                        />
+                                                        <CustomSlider
+                                                            placeholder={defaultSettings.trainingStatTarget.trainingMediumStatTarget_gutsStatTarget}
+                                                            value={trainingStatTargetSettings.trainingMediumStatTarget_gutsStatTarget}
+                                                            onValueChange={(value) => updateTrainingStatTarget("trainingMediumStatTarget_gutsStatTarget", value)}
+                                                            min={100}
+                                                            max={1200}
+                                                            step={10}
+                                                            label="Medium Guts Target"
+                                                            labelUnit=""
+                                                            showValue={true}
+                                                            showLabels={true}
+                                                        />
+                                                        <CustomSlider
+                                                            placeholder={defaultSettings.trainingStatTarget.trainingMediumStatTarget_witStatTarget}
+                                                            value={trainingStatTargetSettings.trainingMediumStatTarget_witStatTarget}
+                                                            onValueChange={(value) => updateTrainingStatTarget("trainingMediumStatTarget_witStatTarget", value)}
+                                                            min={100}
+                                                            max={1200}
+                                                            step={10}
+                                                            label="Medium Wit Target"
+                                                            labelUnit=""
+                                                            showValue={true}
+                                                            showLabels={true}
+                                                        />
+                                                    </>
+                                                ),
+                                            },
+                                            {
+                                                value: "long",
+                                                title: "Long Distance",
+                                                children: (
+                                                    <>
+                                                        <CustomSlider
+                                                            placeholder={defaultSettings.trainingStatTarget.trainingLongStatTarget_speedStatTarget}
+                                                            value={trainingStatTargetSettings.trainingLongStatTarget_speedStatTarget}
+                                                            onValueChange={(value) => updateTrainingStatTarget("trainingLongStatTarget_speedStatTarget", value)}
+                                                            min={100}
+                                                            max={1200}
+                                                            step={10}
+                                                            label="Long Speed Target"
+                                                            labelUnit=""
+                                                            showValue={true}
+                                                            showLabels={true}
+                                                        />
+                                                        <CustomSlider
+                                                            placeholder={defaultSettings.trainingStatTarget.trainingLongStatTarget_staminaStatTarget}
+                                                            value={trainingStatTargetSettings.trainingLongStatTarget_staminaStatTarget}
+                                                            onValueChange={(value) => updateTrainingStatTarget("trainingLongStatTarget_staminaStatTarget", value)}
+                                                            min={100}
+                                                            max={1200}
+                                                            step={10}
+                                                            label="Long Stamina Target"
+                                                            labelUnit=""
+                                                            showValue={true}
+                                                            showLabels={true}
+                                                        />
+                                                        <CustomSlider
+                                                            placeholder={defaultSettings.trainingStatTarget.trainingLongStatTarget_powerStatTarget}
+                                                            value={trainingStatTargetSettings.trainingLongStatTarget_powerStatTarget}
+                                                            onValueChange={(value) => updateTrainingStatTarget("trainingLongStatTarget_powerStatTarget", value)}
+                                                            min={100}
+                                                            max={1200}
+                                                            step={10}
+                                                            label="Long Power Target"
+                                                            labelUnit=""
+                                                            showValue={true}
+                                                            showLabels={true}
+                                                        />
+                                                        <CustomSlider
+                                                            placeholder={defaultSettings.trainingStatTarget.trainingLongStatTarget_gutsStatTarget}
+                                                            value={trainingStatTargetSettings.trainingLongStatTarget_gutsStatTarget}
+                                                            onValueChange={(value) => updateTrainingStatTarget("trainingLongStatTarget_gutsStatTarget", value)}
+                                                            min={100}
+                                                            max={1200}
+                                                            step={10}
+                                                            label="Long Guts Target"
+                                                            labelUnit=""
+                                                            showValue={true}
+                                                            showLabels={true}
+                                                        />
+                                                        <CustomSlider
+                                                            placeholder={defaultSettings.trainingStatTarget.trainingLongStatTarget_witStatTarget}
+                                                            value={trainingStatTargetSettings.trainingLongStatTarget_witStatTarget}
+                                                            onValueChange={(value) => updateTrainingStatTarget("trainingLongStatTarget_witStatTarget", value)}
+                                                            min={100}
+                                                            max={1200}
+                                                            step={10}
+                                                            label="Long Wit Target"
+                                                            labelUnit=""
+                                                            showValue={true}
+                                                            showLabels={true}
+                                                        />
+                                                    </>
+                                                ),
+                                            },
+                                        ]}
+                                    />
+                                </View>
 
-                        {/* Training Year Milestone Targets */}
-                        <View style={styles.section}>
-                            <CustomTitle
-                                title="Training Year Milestone Targets"
-                                description={
-                                    `Controls how aggressively the bot paces stat training during the Pre-Debut, Junior and Classic Years.\n\n` +
-                                    `The bot will target a scaled percentage of your stat targets prior to the Senior Year, ` +
-                                    `ramping up to the full stat targets by the Finale. For example, with milestone targets of 33% / 66%, a Speed ` +
-                                    `target of 1200 becomes ~396 in Junior Year and ~792 in Classic Year. This optimizes early-career statlines for better starting race results.\n\n` +
-                                    `Set both sliders to 100% to disable milestone pacing and always target the full statline.`
-                                }
-                                searchId="training-year-milestone-targets"
-                            />
-                            <SearchableItem
-                                id="classic-milestone-percent"
-                                title="End of Junior Year Milestone"
-                                description="Percentage of the primary stat targets to aim for by the end of Junior Year."
-                            >
-                                <CustomSlider
-                                    value={trainingSettings.classicMilestonePercent}
-                                    placeholder={defaultSettings.training.classicMilestonePercent}
-                                    onValueChange={(value) => updateTrainingSetting("classicMilestonePercent", value)}
-                                    min={0}
-                                    max={100}
-                                    step={1}
-                                    label="End of Junior Year Milestone"
-                                    labelUnit="%"
-                                    showValue={true}
-                                    showLabels={true}
-                                />
-                            </SearchableItem>
-                            <Text style={[styles.label, { fontSize: 14, color: colors.foreground, opacity: 0.7, marginTop: 4 }]}>
-                                The bot will aim for this % of your stat targets during Junior Year. Default: 33%.
-                            </Text>
-                        </View>
+                                {/* Training Year Milestone Targets */}
+                                <View style={styles.section}>
+                                    <CustomTitle
+                                        title="Training Year Milestone Targets"
+                                        description={
+                                            `Controls how aggressively the bot paces stat training during the Pre-Debut, Junior and Classic Years.\n\n` +
+                                            `The bot will target a scaled percentage of your stat targets prior to the Senior Year, ` +
+                                            `ramping up to the full stat targets by the Finale. For example, with milestone targets of 33% / 66%, a Speed ` +
+                                            `target of 1200 becomes ~396 in Junior Year and ~792 in Classic Year. This optimizes early-career statlines for better starting race results.\n\n` +
+                                            `Set both sliders to 100% to disable milestone pacing and always target the full statline.`
+                                        }
+                                        searchId="training-year-milestone-targets"
+                                    />
+                                    <SearchableItem
+                                        id="classic-milestone-percent"
+                                        title="End of Junior Year Milestone"
+                                        description="Percentage of the primary stat targets to aim for by the end of Junior Year."
+                                    >
+                                        <CustomSlider
+                                            value={trainingSettings.classicMilestonePercent}
+                                            placeholder={defaultSettings.training.classicMilestonePercent}
+                                            onValueChange={(value) => updateTrainingSetting("classicMilestonePercent", value)}
+                                            min={0}
+                                            max={100}
+                                            step={1}
+                                            label="End of Junior Year Milestone"
+                                            labelUnit="%"
+                                            showValue={true}
+                                            showLabels={true}
+                                        />
+                                    </SearchableItem>
+                                    <Text style={[styles.label, { fontSize: 14, color: colors.foreground, opacity: 0.7, marginTop: 4 }]}>
+                                        The bot will aim for this % of your stat targets during Junior Year. Default: 33%.
+                                    </Text>
+                                </View>
 
-                        <View style={styles.section}>
-                            <SearchableItem
-                                id="senior-milestone-percent"
-                                title="End of Classic Year Milestone"
-                                description="Percentage of the primary stat targets to aim for by the end of Classic Year."
-                            >
-                                <CustomSlider
-                                    value={trainingSettings.seniorMilestonePercent}
-                                    placeholder={defaultSettings.training.seniorMilestonePercent}
-                                    onValueChange={(value) => updateTrainingSetting("seniorMilestonePercent", value)}
-                                    min={0}
-                                    max={100}
-                                    step={1}
-                                    label="End of Classic Year Milestone"
-                                    labelUnit="%"
-                                    showValue={true}
-                                    showLabels={true}
-                                />
-                            </SearchableItem>
-                            <Text style={[styles.label, { fontSize: 14, color: colors.foreground, opacity: 0.7, marginTop: 4 }]}>
-                                The bot will aim for this % of your stat targets during Classic Year. Default: 66%.
-                            </Text>
-                        </View>
+                                <View style={styles.section}>
+                                    <SearchableItem
+                                        id="senior-milestone-percent"
+                                        title="End of Classic Year Milestone"
+                                        description="Percentage of the primary stat targets to aim for by the end of Classic Year."
+                                    >
+                                        <CustomSlider
+                                            value={trainingSettings.seniorMilestonePercent}
+                                            placeholder={defaultSettings.training.seniorMilestonePercent}
+                                            onValueChange={(value) => updateTrainingSetting("seniorMilestonePercent", value)}
+                                            min={0}
+                                            max={100}
+                                            step={1}
+                                            label="End of Classic Year Milestone"
+                                            labelUnit="%"
+                                            showValue={true}
+                                            showLabels={true}
+                                        />
+                                    </SearchableItem>
+                                    <Text style={[styles.label, { fontSize: 14, color: colors.foreground, opacity: 0.7, marginTop: 4 }]}>
+                                        The bot will aim for this % of your stat targets during Classic Year. Default: 66%.
+                                    </Text>
+                                </View>
                             </>
                         )}
                     </View>


### PR DESCRIPTION
## Description
- This PR makes the Settings pages noticeably faster to open. The biggest wins come from removing wasted re-renders that happened across unrelated parts of the app every time a setting changed, and from deferring slow-mounting parts of each page until after the page has finished animating in.
- A new automated harness (`yarn perf:nav`) drives a connected emulator, taps through every drawer page (and the two sub-pages reached via in-page links), and checks that each page meets a configurable budget for cold-open time, toggle responsiveness, and cold-start time.
- A few cleanups: the per-toggle save to the local database now writes only the section that changed instead of re-saving everything, the on-screen perf logger no longer runs in release builds, the `LLM Settings` page now reports its mount time, and the harness has full docstrings on every helper.

### Time to first paint when opening each Settings page (mean of 5 cold opens, ms)

Before numbers were captured by cherry-picking only the harness/instrumentation commits onto `master` and running the same harness against that build. After numbers are from the final state of this branch.

| Page | Before | After | Improvement |
|---|---|---|---|
| `Settings` (hub) | 179 | 103 | -43% |
| `Training Settings` | 258 | 113 | -56% |
| `Training Event Settings` | 192 | 180 | -6% |
| `Racing Settings` | 195 | 169 | -13% |
| `Skill Settings` | 178 | 168 | -6% |
| `Event Log Visualizer` | 146 | 144 | -1% |
| `Discord Settings` | 141 | 139 | -2% |
| `Scenario Overrides Settings` | 338 | 317 | -6% |
| `Debug Settings` | 250 | 242 | -3% |
| `LLM Settings` | 184 | ~150 | -18% |
| `Skill Plan Settings` (Skill Point Check, sub-page of `Skill Settings`) | 85 | 71 | -16% |
| `Racing Plan Settings` (sub-page of `Racing Settings`) | n/a* | 47 | new coverage |

\* The harness's tap on the in-page Racing Plan link consistently failed on the baseline build (the page mounted but the route name didn't match what the harness was watching for), so a baseline number couldn't be captured. The post-PR build registers the tap reliably; the 47 ms After is real.

The biggest improvements line up with the pages that consume the broadest slices of settings (`Settings` hub and `Training Settings`) — exactly the pages that paid the highest cost from cross-slice re-render fan-out before the legacy aggregate provider was removed. Pages with lighter render trees see smaller improvements, which is expected.

### Toggle responsiveness on the Settings hub (mean of 5)

| Snapshot | UI stall after a checkbox tap |
|---|---|
| Before | 287 ms |
| After | 258 ms (-10%) |

The visible improvement is modest because the dominant cost is re-laying out the on-screen settings banner and is the practical floor on this device. The bigger win is invisible to the user but unblocks future work: the local-database save that runs after each toggle now writes only the section the user changed instead of all 175 settings, dropping its SQLite cost from ~75 ms to ~9 ms (8x faster).

### Cold start (force-stop → first interactive frame, ms)

| Snapshot | Cold start |
|---|---|
| Before | 6485 |
| After | 985–1099 |

Comfortably under the 3-second budget.

### Other notable cleanups
- Replaced the legacy aggregate settings provider with a thin "snapshot" hook so consumers no longer re-render on unrelated changes.
- Heavy sections of `Settings` and `Training Settings` now mount one tick after the page transition finishes, so the header and key controls appear immediately.
- The harness can now exercise sub-pages reached via in-page links, with safe handling of the navigation stack between iterations.
