### PR TITLE
Avoid opening Training Items dialog when reserved energy item is the only one available

### DIFF
--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/Trackblazer.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/Trackblazer.kt
@@ -2233,6 +2233,19 @@ class Trackblazer(game: Game) : Campaign(game) {
     }
 
     /**
+     * Returns the energy item name currently being conserved as the last-resort emergency-race-recovery stash.
+     *
+     * Mirrors the conservation logic inside `isBestEnergyItemToUse` so the dialog-open gate predicts the same outcome the dialog scan would reach.
+     *
+     * @param inventory The inventory snapshot to evaluate.
+     * @return The conserved item name, or `null` if conservation is bypassed or no conservable item is in inventory.
+     */
+    private fun getConservedEnergyItem(inventory: Map<String, Int>): String? {
+        if (bForceUseReservedItem) return null
+        return energyItemConservationOrder.firstOrNull { (inventory[it] ?: 0) > 0 }
+    }
+
+    /**
      * Orchestrates the usage of items based on dynamic conditions and updates internal inventory.
      *
      * @param trainee Reference to the trainee's state.
@@ -2242,8 +2255,12 @@ class Trackblazer(game: Game) : Campaign(game) {
         if (date.day < 13) return
 
         val needSync = !bInventorySynced
+        val conservedEnergyItem = getConservedEnergyItem(currentInventory)
         val hasEnergyItems =
-            currentInventory.any { (name, count) -> count > 0 && shopList.energyItemNames.contains(name) } ||
+            currentInventory.any { (name, count) ->
+                val effectiveCount = if (name == conservedEnergyItem) count - 1 else count
+                effectiveCount > 0 && shopList.energyItemNames.contains(name)
+            } ||
                 ((currentInventory["Royal Kale Juice"] ?: 0) > 0)
         val hasMoodItems = currentInventory.any { (name, count) -> count > 0 && (name == "Berry Sweet Cupcake" || name == "Plain Cupcake") }
         val hasBadConditionItems = currentInventory.any { (name, count) -> count > 0 && shopList.badConditionHealItemNames.contains(name) }


### PR DESCRIPTION
## Description
- This PR adjusts `useItems()` to predict the conservation outcome from cached inventory before opening the in-game Training Items dialog, so when the only energy item available is the one being reserved as the last-resort emergency-race-recovery stash (and no other item category needs the dialog), the dialog open is skipped entirely. Previously the bot would open the dialog, scan it, and conclude no item should be used — wasting roughly 5 seconds of UI work per pass, sometimes twice in the same turn.