### PR TITLE
Skip Training Items dialog when bad-condition items don't match active statuses

### DIFF
--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/Trackblazer.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/Trackblazer.kt
@@ -1848,10 +1848,11 @@ class Trackblazer(game: Game) : Campaign(game) {
                         val isCharm = name == "Good-Luck Charm" && failureChance >= 20
 
                         // Determine if this item is actually useful right now.
+                        // isBad items are also isQuick, but they must clear the condition-match gate; let the isBad clause own them.
                         val isUseful =
                             isStat ||
-                                isBad ||
-                                isQuick ||
+                                (isBad && trainee != null && canHealActiveNegativeStatus(name, trainee)) ||
+                                (isQuick && !isBad) ||
                                 (isEnergy && trainee != null && trainee.energy <= 100) ||
                                 // We might want any energy item if not full.
                                 (isMood && trainee != null && trainee.mood < Mood.GREAT) ||
@@ -2259,6 +2260,21 @@ class Trackblazer(game: Game) : Campaign(game) {
     }
 
     /**
+     * Returns true when the given heal item targets at least one of the trainee's currently active negative statuses.
+     * Miracle Cure heals every status; every other entry in `badConditionMap` heals exactly one specific status.
+     * Used to short-circuit the Training Items dialog when no inventory item can actually clear an active condition.
+     *
+     * @param itemName The name of the item to check.
+     * @param trainee The current trainee snapshot (currentNegativeStatuses is read).
+     * @return True if the item can heal an active negative status; false otherwise.
+     */
+    private fun canHealActiveNegativeStatus(itemName: String, trainee: Trainee): Boolean {
+        if (itemName == "Miracle Cure") return true
+        val target = badConditionMap[itemName] ?: return false
+        return trainee.currentNegativeStatuses.contains(target)
+    }
+
+    /**
      * Orchestrates the usage of items based on dynamic conditions and updates internal inventory.
      *
      * @param trainee Reference to the trainee's state.
@@ -2276,7 +2292,7 @@ class Trackblazer(game: Game) : Campaign(game) {
             } ||
                 ((currentInventory["Royal Kale Juice"] ?: 0) > 0)
         val hasMoodItems = currentInventory.any { (name, count) -> count > 0 && (name == "Berry Sweet Cupcake" || name == "Plain Cupcake") }
-        val hasBadConditionItems = currentInventory.any { (name, count) -> count > 0 && shopList.badConditionHealItemNames.contains(name) }
+        val hasBadConditionItems = currentInventory.any { (name, count) -> count > 0 && shopList.badConditionHealItemNames.contains(name) && canHealActiveNegativeStatus(name, trainee) }
         val hasStatItems = currentInventory.any { (name, count) -> count > 0 && shopList.statItemNames.contains(name) }
 
         val skipTrainingEffectItems = shouldConserveTrainingEffectItems(trainingSelected, trainee)


### PR DESCRIPTION
## Description
- This PR tightens the Trackblazer "Bad conditions" gate and items-of-interest filter to require that an inventory item actually heals one of the trainee's currently active negative statuses, instead of opening the Training Items dialog whenever any "Heal Bad Conditions" item is in inventory.
- A new `canHealActiveNegativeStatus()` helper consults `badConditionMap` (and treats `Miracle Cure` as universal) so the dialog and the inventory scroll both short-circuit when no item can clear an active condition. This mirrors the existing `shouldConserveTrainingEffectItems()` pattern.

Before this change, the dialog would open and exit immediately when, for example, only `Night Owl` was active and only `Rich Hand Cream` (heals `Skin Outbreak`) was in inventory:

```
00:12:05.001 [VERBOSE] [TRAINEE] Negative Statuses: Night Owl
00:12:05.001 [INFO] [TRACKBLAZER] Opening Training Items dialog (Bad conditions)...
00:12:06.463 [VERBOSE] [TRACKBLAZER] Item "Rich Hand Cream" read as disabled in dialog, so skipping its usage.
00:12:06.464 [INFO] [TRACKBLAZER] All items of interest processed. Exiting scan early.
```