### PR TITLE
Remove the `Stop on Unexpected Popups` setting

### DIFF
--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Campaign.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Campaign.kt
@@ -1520,21 +1520,14 @@ abstract class Campaign(game: Game) : Task(game) {
     /**
      * Performs miscellaneous checks to resolve instances where the bot might be stuck.
      *
-     * @return True if the checks passed, false if the bot encountered a warning popup and needs to exit.
+     * @return True if a misc check handled the current screen, false otherwise.
      */
     open fun performMiscChecks(): Boolean {
         MessageLog.i(TAG, "\n[MISC] Beginning check for misc cases...")
 
         val sourceBitmap = game.imageUtils.getSourceBitmap()
 
-        if (game.enablePopupCheck && ButtonCancel.check(game.imageUtils, sourceBitmap = sourceBitmap)) {
-            MessageLog.v(TAG, "\n[END] Bot may have encountered a warning popup. Exiting now...")
-            game.notificationMessage = "Bot may have encountered a warning popup"
-            if (DiscordUtils.enableDiscordNotifications) {
-                DiscordUtils.queue.add("```diff\n- ${MessageLog.getSystemTimeString()} Bot may have encountered a warning popup. Exiting now...\n```")
-            }
-            throw CampaignBreakpointException(game.notificationMessage)
-        } else if (ButtonNext.click(game.imageUtils, sourceBitmap = sourceBitmap)) {
+        if (ButtonNext.click(game.imageUtils, sourceBitmap = sourceBitmap)) {
             // Now confirm the completion of a Training Goal popup.
             MessageLog.i(TAG, "[MISC] Popup detected that needs to be dismissed with the \"Next\" button.")
             game.wait(2.0)

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Game.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Game.kt
@@ -52,9 +52,6 @@ class Game(val myContext: Context) {
     /** Whether debug mode is enabled for additional logging and saving debugging images to storage. */
     val debugMode: Boolean = SettingsHelper.getBooleanSetting("debug", "enableDebugMode")
 
-    /** Whether to check for certain popups to stop at during execution. */
-    val enablePopupCheck: Boolean = SettingsHelper.getBooleanSetting("general", "enablePopupCheck")
-
     /** The default wait delay between common actions. */
     val waitDelay: Double = SettingsHelper.getDoubleSetting("general", "waitDelay")
 

--- a/src/components/MessageLog/index.tsx
+++ b/src/components/MessageLog/index.tsx
@@ -385,7 +385,6 @@ ${longTargetsString}
 🏇 Trackblazer Preferred Surfaces: ${settings.scenarioOverrides?.trackblazerPreferredSurfaces?.length === 0 ? "None" : settings.scenarioOverrides?.trackblazerPreferredSurfaces?.join(", ")}
 
 ---------- Misc Options ----------
-🛑 Stop on Unexpected Popups: ${settings.general.enablePopupCheck ? "✅" : "❌"}
 🔍 Enable Crane Game Attempt: ${settings.general.enableCraneGameAttempt ? "✅" : "❌"}
 🛑 Stop Before Finals: ${settings.general.enableStopBeforeFinals ? "✅" : "❌"}
 🛑 Stop At Date: ${settings.general.enableStopAtDate ? `✅ (${settings.general.stopAtDates.join(", ")})` : "❌"}

--- a/src/context/BotStateContext.tsx
+++ b/src/context/BotStateContext.tsx
@@ -46,7 +46,6 @@ export interface Settings {
     // General settings
     general: {
         scenario: string
-        enablePopupCheck: boolean
         enableCraneGameAttempt: boolean
         enableStopBeforeFinals: boolean
         enableStopAtDate: boolean
@@ -236,7 +235,6 @@ export interface Settings {
 export const defaultSettings: Settings = {
     general: {
         scenario: "",
-        enablePopupCheck: false,
         enableCraneGameAttempt: false,
         enableStopBeforeFinals: false,
         enableStopAtDate: false,

--- a/src/data/searchConfig.ts
+++ b/src/data/searchConfig.ts
@@ -17,12 +17,6 @@ const searchConfig: SearchOption[] = [
     // Settings (SettingsMain)
     // ============================================================
     {
-        id: "settings-popup-check",
-        title: "Stop on Unexpected Popups",
-        description: "Stops the bot when an unexpected popup with a Cancel button is detected (e.g. lack of fans or trophies). You will need to dismiss the popup and restart the bot manually.",
-        page: "SettingsMain",
-    },
-    {
         id: "settings-stop-before-finals",
         title: "Stop before Finals",
         description: "Stops the bot on turn 72 so you can purchase skills before the final races.",

--- a/src/hooks/__tests__/useSettingsManager.test.ts
+++ b/src/hooks/__tests__/useSettingsManager.test.ts
@@ -69,11 +69,11 @@ describe("deepMerge", () => {
 
 describe("convertSettingsToBatch", () => {
     it("converts single category with two keys to batch entries", () => {
-        const settings = { general: { scenario: "URA", enablePopupCheck: true } } as any
+        const settings = { general: { scenario: "URA", enableCraneGameAttempt: true } } as any
         const batch = convertSettingsToBatch(settings)
         expect(batch).toHaveLength(2)
         expect(batch).toContainEqual({ category: "general", key: "scenario", value: "URA" })
-        expect(batch).toContainEqual({ category: "general", key: "enablePopupCheck", value: true })
+        expect(batch).toContainEqual({ category: "general", key: "enableCraneGameAttempt", value: true })
     })
 
     it("converts multiple categories", () => {

--- a/src/lib/settingsUtils.ts
+++ b/src/lib/settingsUtils.ts
@@ -162,5 +162,12 @@ export const applyMigrations = (settings: any, rawSettings?: any): { settings: a
         logWithTimestamp("[SettingsManager] Migrated stopAtDate to stopAtDates array.")
     }
 
+    // Migration: Drop the removed enablePopupCheck setting.
+    if (general?.enablePopupCheck !== undefined) {
+        delete general.enablePopupCheck
+        anyMigrated = true
+        logWithTimestamp("[SettingsManager] Dropped removed setting enablePopupCheck.")
+    }
+
     return { settings: migratedSettings, anyMigrated }
 }

--- a/src/pages/Settings/index.tsx
+++ b/src/pages/Settings/index.tsx
@@ -230,17 +230,6 @@ const Settings = () => {
                 <CustomTitle title="Misc Settings" description="General settings for the bot that don't fit into the other categories." />
 
                 <CustomCheckbox
-                    searchId="settings-popup-check"
-                    checked={general.enablePopupCheck}
-                    onCheckedChange={(checked) => {
-                        updateGeneral({ enablePopupCheck: checked })
-                    }}
-                    label="Stop on Unexpected Popups"
-                    description="Stops the bot when an unexpected popup with a Cancel button is detected (e.g. lack of fans or trophies). You will need to dismiss the popup and restart the bot manually."
-                    className="mt-4"
-                />
-
-                <CustomCheckbox
                     searchId="settings-stop-before-finals"
                     checked={general.enableStopBeforeFinals}
                     onCheckedChange={(checked) => {


### PR DESCRIPTION
## Description
- This PR removes the `enablePopupCheck` setting (a.k.a. "Stop on Unexpected Popups") because it has caused multiple false-positive bug reports where users believed the bot crashed when in reality it matched the `ButtonCancel` template in `performMiscChecks()` and tripped the early `CampaignBreakpointException` exit.
- With the setting gone, when `ButtonCancel` would have matched mid-loop the flow now falls through to the existing `ButtonBack.click()` fallback in `performMiscChecks()`, so the bot navigates back like any other unrecognized screen instead of stopping.

```
00:13:11.349 [INFO] [MISC] Beginning check for misc cases...

00:13:11.420 [VERBOSE] [END] Bot may have encountered a warning popup. Exiting now...
00:13:11.428 [INFO] Success (TASK_RESULT_BREAKPOINT_REACHED): Bot may have encountered a warning popup
```