### PR TITLE
Restore .cxx purge in `gradlew clean` to fix CMake GLOB mismatch regression

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -260,3 +260,24 @@ dependencies {
 
 }
 
+// //////////////////////////////////////////////////////////////////////////////////////////////////
+// //////////////////////////////////////////////////////////////////////////////////////////////////
+// Clean Hardening
+// //////////////////////////////////////////////////////////////////////////////////////////////////
+// //////////////////////////////////////////////////////////////////////////////////////////////////
+
+// Delete `build/` and `.cxx/` before `externalNativeBuildClean<variant>` runs. Without this,
+// gradlew clean invokes ninja clean against a stale `.cxx/` cache, which forces CMake to
+// re-configure and trips a GLOB mismatch on missing RN codegen sources (RNLlamaSpec,
+// RNCSlider, etc.). Removing `.cxx/` up front means there is nothing for ninja to clean.
+tasks.register('cleanBuildArtifacts', Delete) {
+    delete("${projectDir}/build")
+    delete("${projectDir}/.cxx")
+}
+
+clean.dependsOn(cleanBuildArtifacts)
+
+tasks.matching { it.name.startsWith('externalNativeBuildClean') }.configureEach {
+    mustRunAfter('cleanBuildArtifacts')
+}
+


### PR DESCRIPTION
## Description

- This PR restores the `.cxx/` and `build/` directory purge that was silently dropped from `android/app/build.gradle` when the `cleanBundle` task was removed in PR #301. Without that purge, `gradlew clean` invokes `:app:externalNativeBuildCleanDebug` against a stale `.cxx/` cache, which forces CMake to re-configure and trips a `GLOB mismatch!` on missing RN codegen sources (e.g. `RNLlamaSpec/ComponentDescriptors.cpp`, `RNCSlider-generated.cpp`), making `yarn build:clean`, `yarn clean`, and `yarn build:debug:clean` all fail every time.
- The fix adds a slim `cleanBuildArtifacts` Gradle task that deletes `${projectDir}/build` and `${projectDir}/.cxx`, wires `clean.dependsOn(cleanBuildArtifacts)`, and uses `mustRunAfter` to guarantee `cleanBuildArtifacts` runs before any `externalNativeBuildClean<variant>` task — so ninja never gets a chance to re-run CMake against the broken cache.

Original failure log:

```
Task :app:externalNativeBuildCleanDebug FAILED
C/C++: -- GLOB mismatch!
C/C++: CMake Error at .../node_modules/llama.rn/.../CMakeLists.txt:11 (add_library):
C/C++:   Cannot find source file:
C/C++:     .../RNLlamaSpec/ComponentDescriptors.cpp
C/C++: CMake Error at .../node_modules/@react-native-community/slider/.../CMakeLists.txt:15 (add_library):
C/C++:   No SOURCES given to target: react_codegen_RNCSlider
C/C++: CMake Generate step failed.  Build files cannot be regenerated correctly.

FAILURE: Build failed with an exception.

What went wrong: Execution failed for task ':app:externalNativeBuildCleanDebug'.
```