### PR TITLE
Stop Home re-render storm during bot log streaming

### DIFF
--- a/src/components/MessageLog/index.tsx
+++ b/src/components/MessageLog/index.tsx
@@ -1,5 +1,5 @@
 import { useContext, useState, useMemo, useCallback, memo, useEffect, useRef } from "react"
-import { MessageLogContext } from "../../context/MessageLogContext"
+import { MessageLogDataContext } from "../../context/MessageLogContext"
 import { BotMetaContext, Settings, useSettingsSnapshot } from "../../context/BotStateContext"
 import { useSettings } from "../../context/SettingsContext"
 import { databaseManager } from "../../lib/database"
@@ -191,7 +191,7 @@ const LogItem = memo(({ item, fontSize, onLongPress, enableMessageIdDisplay }: {
  * and a formatted settings summary as the intro message.
  */
 const MessageLog = () => {
-    const mlc = useContext(MessageLogContext)
+    const mlc = useContext(MessageLogDataContext)
     const { appName, appVersion, setSettings } = useContext(BotMetaContext)
     const settings = useSettingsSnapshot()
     const { saveSettingsImmediate } = useSettings()

--- a/src/context/MessageLogContext.tsx
+++ b/src/context/MessageLogContext.tsx
@@ -11,25 +11,37 @@ export interface MessageLogEntry {
 }
 
 /**
- * Context value interface for the MessageLog provider.
- * Exposes the message log array and methods to update it.
+ * Data slice of the message log context. Holds the array itself, which gets a new identity on
+ * every log push. Subscribe here only if you actually read `messageLog`.
  */
-export interface MessageLogProviderProps {
+export interface MessageLogDataProps {
     /** The array of all message log entries. */
     messageLog: MessageLogEntry[]
+}
+
+/**
+ * Dispatch slice of the message log context. Holds identity-stable setters that never change
+ * after the first render, so subscribers do not re-commit when the log array changes.
+ */
+export interface MessageLogDispatchProps {
     /** Direct setter for the entire message log array. */
     setMessageLog: React.Dispatch<React.SetStateAction<MessageLogEntry[]>>
     /** Appends a new message entry to the log. */
     addMessageToLog: (id: number, message: string) => void
 }
 
-export const MessageLogContext = createContext<MessageLogProviderProps>({} as MessageLogProviderProps)
+export const MessageLogDataContext = createContext<MessageLogDataProps>({} as MessageLogDataProps)
+export const MessageLogDispatchContext = createContext<MessageLogDispatchProps>({} as MessageLogDispatchProps)
 
 /**
- * Provider component for the MessageLog context.
- * Manages the message log entries and provides methods to add new messages.
+ * Provider component for the message log contexts. Splits the log array and the setters into
+ * two separate contexts so high-frequency log pushes from the Kotlin bot service do not
+ * re-render every consumer. Only the viewer that actually reads `messageLog` subscribes to
+ * the data context. Pages that just clear or append (Home, useBootstrap) subscribe to the
+ * stable dispatch context and never re-commit on log churn.
+ *
  * @param children The child components to render within the provider.
- * @returns The message log context provider.
+ * @returns The nested data + dispatch context providers.
  */
 export const MessageLogProvider = ({ children }: any): React.ReactElement => {
     const [messageLog, setMessageLog] = useState<MessageLogEntry[]>([])
@@ -43,15 +55,12 @@ export const MessageLogProvider = ({ children }: any): React.ReactElement => {
         setMessageLog((prev) => [...prev, { id, message }])
     }, [])
 
-    // Memoize the provider value to prevent cascading re-renders.
-    const providerValues = useMemo<MessageLogProviderProps>(
-        () => ({
-            messageLog,
-            setMessageLog,
-            addMessageToLog,
-        }),
-        [messageLog, addMessageToLog]
-    )
+    const dataValue = useMemo<MessageLogDataProps>(() => ({ messageLog }), [messageLog])
+    const dispatchValue = useMemo<MessageLogDispatchProps>(() => ({ setMessageLog, addMessageToLog }), [addMessageToLog])
 
-    return <MessageLogContext.Provider value={providerValues}>{children}</MessageLogContext.Provider>
+    return (
+        <MessageLogDataContext.Provider value={dataValue}>
+            <MessageLogDispatchContext.Provider value={dispatchValue}>{children}</MessageLogDispatchContext.Provider>
+        </MessageLogDataContext.Provider>
+    )
 }

--- a/src/hooks/useBootstrap.tsx
+++ b/src/hooks/useBootstrap.tsx
@@ -1,7 +1,7 @@
 import { useContext, useEffect, useState, useRef } from "react"
 import { DeviceEventEmitter, AppState, InteractionManager } from "react-native"
 import { BotMetaContext, GeneralMiscContext } from "../context/BotStateContext"
-import { MessageLogContext, MessageLogProviderProps } from "../context/MessageLogContext"
+import { MessageLogDispatchContext, MessageLogDispatchProps } from "../context/MessageLogContext"
 import { useSettings } from "../context/SettingsContext"
 import { logWithTimestamp, logErrorWithTimestamp } from "../lib/logger"
 import { databaseManager, DatabaseRace, DatabaseSkill } from "../lib/database"
@@ -18,7 +18,7 @@ export const useBootstrap = () => {
 
     const { setReadyStatus } = useContext(BotMetaContext)
     const { general } = useContext(GeneralMiscContext)
-    const mlc = useContext(MessageLogContext) as MessageLogProviderProps
+    const mlc = useContext(MessageLogDispatchContext) as MessageLogDispatchProps
 
     // Hook for managing settings persistence.
     const { saveSettingsImmediate, loadSettings } = useSettings()

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -6,7 +6,7 @@ import { useSettings } from "../../context/SettingsContext"
 import { logWithTimestamp, logErrorWithTimestamp } from "../../lib/logger"
 import { Animated, DeviceEventEmitter, StyleSheet, View, NativeModules } from "react-native"
 import { Snackbar } from "react-native-paper"
-import { MessageLogContext } from "../../context/MessageLogContext"
+import { MessageLogDispatchContext } from "../../context/MessageLogContext"
 import { useTheme } from "../../context/ThemeContext"
 import { Text } from "../../components/ui/text"
 import { AlertDialog, AlertDialogAction, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from "../../components/ui/alert-dialog"
@@ -75,7 +75,7 @@ const Home = () => {
 
     const { readyStatus, setReadyStatus, setAppName, setAppVersion } = useContext(BotMetaContext)
     const { general, updateGeneral } = useContext(GeneralMiscContext)
-    const mlc = useContext(MessageLogContext)
+    const mlc = useContext(MessageLogDispatchContext)
     const { saveSettings } = useSettings()
 
     const pulseAnim = useRef(new Animated.Value(1)).current


### PR DESCRIPTION
## Description
- This PR splits `MessageLogContext` into a `MessageLogDataContext` (`{ messageLog }`) and a `MessageLogDispatchContext` (`{ setMessageLog, addMessageToLog }`) so that high-frequency log pushes from the Kotlin bot service no longer force every subscriber to re-commit. `Home` and `useBootstrap` only use the setters, so they now subscribe to the stable dispatch context and stop re-rendering on every log line, while `MessageLog` (the actual viewer) subscribes to the data context.
- Previously, with perf logs enabled while running through `yarn android`, the metro console was flooded with `Home_commit` warnings every ~700-1500 ms while the bot was running (even with the app backgrounded) because the provider value churned its identity per log push.

```
LOG  [PERF] UI - Home_commit: 0.03ms | Details: {"renderCount":1583,"duration_ms":1540.02}
WARN  [SLOW-COMMIT] Home commit took 1540ms (renderCount=1583)
```