### PR TITLE
Add Log Files tab to the Remote Log Viewer

### DIFF
--- a/android/app/src/main/assets/log_viewer.html
+++ b/android/app/src/main/assets/log_viewer.html
@@ -1507,6 +1507,169 @@
                     font-size: 8px;
                 }
             }
+
+            /* ////////////////////////////////////////////////////////////////////////////////////////////////// */
+            /* ////////////////////////////////////////////////////////////////////////////////////////////////// */
+            /* Log Files Tab */
+
+            .log-files-list-container {
+                flex: 1;
+                overflow-y: auto;
+                background: var(--bg-primary);
+                padding: 16px 20px;
+            }
+
+            .log-files-list {
+                display: flex;
+                flex-direction: column;
+                gap: 6px;
+            }
+
+            .log-files-empty {
+                color: var(--text-muted);
+                font-style: italic;
+                padding: 24px 0;
+                text-align: center;
+            }
+
+            .log-file-row {
+                display: grid;
+                grid-template-columns: 1fr auto auto auto;
+                gap: 16px;
+                align-items: center;
+                padding: 10px 14px;
+                background: var(--bg-secondary);
+                border: 1px solid var(--border-color);
+                border-radius: var(--radius);
+                cursor: pointer;
+                transition: border-color var(--transition), background var(--transition);
+            }
+
+            .log-file-row:hover {
+                border-color: var(--accent-blue);
+                background: var(--bg-tertiary);
+            }
+
+            .log-file-name {
+                font-family: "JetBrains Mono", monospace;
+                font-size: 13px;
+                color: var(--text-primary);
+                overflow: hidden;
+                text-overflow: ellipsis;
+                white-space: nowrap;
+            }
+
+            .log-file-meta {
+                font-size: 12px;
+                color: var(--text-muted);
+                white-space: nowrap;
+            }
+
+            .log-file-download {
+                background: var(--accent-gradient);
+                color: white;
+                border: none;
+                padding: 6px 12px;
+                font-size: 12px;
+                font-weight: 600;
+                border-radius: var(--radius);
+                cursor: pointer;
+                text-decoration: none;
+                display: inline-flex;
+                align-items: center;
+                gap: 6px;
+                transition: transform var(--transition), opacity var(--transition);
+            }
+
+            .log-file-download:hover {
+                transform: translateY(-1px);
+                opacity: 0.9;
+            }
+
+            .log-file-modal {
+                display: none;
+                position: fixed;
+                inset: 0;
+                z-index: 1000;
+                /* Solid opaque overlay - no backdrop-filter, since the dashboard streams live updates and re-blurring every paint causes lag. */
+                background: rgba(10, 10, 15, 0.96);
+                align-items: center;
+                justify-content: center;
+                padding: 40px;
+            }
+
+            .log-file-modal.visible {
+                display: flex;
+            }
+
+            .log-file-modal-content {
+                background: var(--bg-secondary);
+                border: 1px solid var(--border-color);
+                border-radius: var(--radius);
+                width: min(92vw, 1100px);
+                max-height: 90vh;
+                display: flex;
+                flex-direction: column;
+                box-shadow: 0 0 50px rgba(0, 0, 0, 0.8);
+                animation: modalZoom 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+                overflow: hidden;
+            }
+
+            .log-file-modal-header {
+                display: flex;
+                align-items: center;
+                gap: 12px;
+                padding: 12px 16px;
+                background: var(--bg-tertiary);
+                border-bottom: 1px solid var(--border-color);
+                flex-shrink: 0;
+            }
+
+            /* Normalize <a> and <button> sizing so the Download and Close buttons render identically. */
+            .log-file-modal-header .refresh-btn {
+                font-family: inherit;
+                font-size: 13px;
+                line-height: 1.2;
+                text-decoration: none;
+            }
+
+            .log-file-modal-title {
+                flex: 1;
+                font-family: "JetBrains Mono", monospace;
+                font-size: 13px;
+                color: var(--text-primary);
+                overflow: hidden;
+                text-overflow: ellipsis;
+                white-space: nowrap;
+            }
+
+            .log-file-modal-body {
+                flex: 1;
+                overflow: auto;
+                margin: 0;
+                padding: 16px;
+                font-family: "JetBrains Mono", monospace;
+                font-size: 12px;
+                line-height: 1.5;
+                color: var(--text-primary);
+                background: var(--bg-primary);
+                white-space: pre-wrap;
+                word-break: break-word;
+            }
+
+            @media (max-width: 768px) {
+                .log-file-row {
+                    grid-template-columns: 1fr;
+                    row-gap: 6px;
+                }
+                .log-file-download {
+                    min-height: 44px;
+                    justify-content: center;
+                }
+                .log-file-modal {
+                    padding: 12px;
+                }
+            }
         </style>
     </head>
     <body>
@@ -1529,6 +1692,7 @@
         <nav class="tab-nav">
             <button id="logsTabBtn" class="tab-btn active" onclick="switchTab('logs')">Logs & Dashboard</button>
             <button id="imagesTabBtn" class="tab-btn" onclick="switchTab('images')">Debug Images</button>
+            <button id="logFilesTabBtn" class="tab-btn" onclick="switchTab('logFiles')">Log Files</button>
         </nav>
 
         <!-- Logs & Dashboard View -->
@@ -1778,6 +1942,35 @@
         <div id="imageModal" class="modal" onclick="closeModal()">
             <span class="modal-close">&times;</span>
             <img class="modal-content" id="enlargedImage">
+        </div>
+
+        <!-- Log Files View -->
+        <div id="logFilesView" class="tab-view">
+            <div class="image-toolbar">
+                <button class="refresh-btn" onclick="loadLogFiles()">Refresh</button>
+                <div id="logFilesStatus" class="image-status"></div>
+                <div class="message-count" style="margin-left: auto; margin-right: 0px">
+                    Files: <span id="logFilesCount">0</span> &middot; Total: <span id="logFilesTotalSize">0 B</span>
+                </div>
+            </div>
+            <div id="logFilesListContainer" class="log-files-list-container">
+                <div id="logFilesList" class="log-files-list">
+                    <!-- File rows will be injected here. -->
+                </div>
+                <div id="logFilesEmpty" class="log-files-empty" style="display: none;">No log files yet. Completed sessions will show up here.</div>
+            </div>
+        </div>
+
+        <!-- Log File Viewer Modal -->
+        <div id="logFileModal" class="log-file-modal">
+            <div class="log-file-modal-content">
+                <div class="log-file-modal-header">
+                    <span id="logFileModalTitle" class="log-file-modal-title"></span>
+                    <a id="logFileModalDownload" class="refresh-btn" href="#" download>Download</a>
+                    <button class="refresh-btn" onclick="closeLogFileModal()">Close</button>
+                </div>
+                <pre id="logFileModalBody" class="log-file-modal-body"></pre>
+            </div>
         </div>
 
         <!-- Footer -->
@@ -3552,19 +3745,27 @@
 
             /**
              * Switches between different view tabs.
-             * @param {string} tabID - The ID of the tab to switch to ('logs' or 'images').
+             * @param {string} tabID - The ID of the tab to switch to ('logs', 'images', or 'logFiles').
              */
             function switchTab(tabID) {
                 // Update buttons.
                 document.getElementById("logsTabBtn").classList.toggle("active", tabID === "logs")
                 document.getElementById("imagesTabBtn").classList.toggle("active", tabID === "images")
+                document.getElementById("logFilesTabBtn").classList.toggle("active", tabID === "logFiles")
 
                 // Update views.
                 document.getElementById("logsView").classList.toggle("active", tabID === "logs")
                 document.getElementById("imagesView").classList.toggle("active", tabID === "images")
+                document.getElementById("logFilesView").classList.toggle("active", tabID === "logFiles")
 
                 if (tabID === "logs" && autoScroll) {
                     scrollToBottom()
+                }
+
+                // Lazy-load the log files index on first activation; user can hit Refresh for re-fetches.
+                if (tabID === "logFiles" && !window.__logFilesLoaded) {
+                    loadLogFiles()
+                    window.__logFilesLoaded = true
                 }
             }
 
@@ -3676,7 +3877,167 @@
 
             // Close modal on Escape key.
             document.addEventListener("keydown", function(e) {
-                if (e.key === "Escape") closeModal()
+                if (e.key === "Escape") {
+                    closeModal()
+                    closeLogFileModal()
+                }
+            })
+
+            // ==============================================
+            // Log Files Tab
+            // ==============================================
+
+            const LOG_FILE_PREVIEW_BYTE_LIMIT = 5 * 1024 * 1024
+            // Cache the latest /logs/files response so the row click handlers can read each file's size
+            // without an extra HEAD request when deciding whether to preview inline or just offer download.
+            let logFilesCache = []
+
+            /**
+             * Formats a byte count into a short human-readable string.
+             * @param {number} bytes - The byte count.
+             * @returns {string} A short label like "12.4 KB" or "1.8 MB".
+             */
+            function formatFileSize(bytes) {
+                if (!Number.isFinite(bytes) || bytes < 0) return "0 B"
+                if (bytes < 1024) return bytes + " B"
+                if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + " KB"
+                if (bytes < 1024 * 1024 * 1024) return (bytes / (1024 * 1024)).toFixed(2) + " MB"
+                return (bytes / (1024 * 1024 * 1024)).toFixed(2) + " GB"
+            }
+
+            /**
+             * Formats a unix-millis timestamp into "YYYY-MM-DD HH:MM" local time.
+             * @param {number} ms - Milliseconds since epoch.
+             * @returns {string} The formatted timestamp.
+             */
+            function formatLogFileTimestamp(ms) {
+                const d = new Date(ms)
+                const pad = (n) => String(n).padStart(2, "0")
+                return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`
+            }
+
+            /**
+             * Fetches the list of completed log files from the server and renders them.
+             */
+            async function loadLogFiles() {
+                const listEl = document.getElementById("logFilesList")
+                const emptyEl = document.getElementById("logFilesEmpty")
+                const statusEl = document.getElementById("logFilesStatus")
+                const countEl = document.getElementById("logFilesCount")
+                const totalEl = document.getElementById("logFilesTotalSize")
+
+                statusEl.textContent = "Loading..."
+                try {
+                    const res = await fetch("/logs/files")
+                    if (!res.ok) throw new Error(`HTTP ${res.status}`)
+                    const data = await res.json()
+                    const files = Array.isArray(data.files) ? data.files : []
+                    logFilesCache = files
+
+                    countEl.textContent = String(data.count || files.length)
+                    totalEl.textContent = formatFileSize(data.totalSize || 0)
+                    statusEl.textContent = ""
+
+                    listEl.innerHTML = ""
+                    if (files.length === 0) {
+                        emptyEl.style.display = "block"
+                    } else {
+                        emptyEl.style.display = "none"
+                        for (const file of files) {
+                            listEl.appendChild(renderLogFileRow(file))
+                        }
+                    }
+                } catch (err) {
+                    statusEl.textContent = "Failed to load log files."
+                    console.error("loadLogFiles failed:", err)
+                }
+            }
+
+            /**
+             * Builds a single row element for one log file.
+             * @param {{name: string, size: number, modified: number}} file - The file metadata.
+             * @returns {HTMLElement} The row element.
+             */
+            function renderLogFileRow(file) {
+                const row = document.createElement("div")
+                row.className = "log-file-row"
+                row.title = "Click to view"
+
+                const name = document.createElement("span")
+                name.className = "log-file-name"
+                name.textContent = file.name
+
+                const modified = document.createElement("span")
+                modified.className = "log-file-meta"
+                modified.textContent = formatLogFileTimestamp(file.modified)
+
+                const size = document.createElement("span")
+                size.className = "log-file-meta"
+                size.textContent = formatFileSize(file.size)
+
+                const download = document.createElement("a")
+                download.className = "log-file-download"
+                download.href = `/logs/files/${encodeURIComponent(file.name)}?download=1`
+                download.setAttribute("download", file.name)
+                download.textContent = "Download"
+                // Prevent the row click handler from firing when the user just wants to download.
+                download.addEventListener("click", (e) => e.stopPropagation())
+
+                row.appendChild(name)
+                row.appendChild(modified)
+                row.appendChild(size)
+                row.appendChild(download)
+
+                row.addEventListener("click", () => openLogFile(file.name))
+                return row
+            }
+
+            /**
+             * Opens the inline viewer modal for a single log file.
+             * Files larger than LOG_FILE_PREVIEW_BYTE_LIMIT show a placeholder instead of fetching, to avoid freezing the browser.
+             * @param {string} name - The filename.
+             */
+            async function openLogFile(name) {
+                const modal = document.getElementById("logFileModal")
+                const titleEl = document.getElementById("logFileModalTitle")
+                const bodyEl = document.getElementById("logFileModalBody")
+                const downloadEl = document.getElementById("logFileModalDownload")
+
+                titleEl.textContent = name
+                downloadEl.href = `/logs/files/${encodeURIComponent(name)}?download=1`
+                downloadEl.setAttribute("download", name)
+                bodyEl.textContent = "Loading..."
+                modal.classList.add("visible")
+
+                const cached = logFilesCache.find((f) => f.name === name)
+                if (cached && cached.size > LOG_FILE_PREVIEW_BYTE_LIMIT) {
+                    bodyEl.textContent = `File is ${formatFileSize(cached.size)} - too large to preview inline. Use the Download button above to save it.`
+                    return
+                }
+
+                try {
+                    const res = await fetch(`/logs/files/${encodeURIComponent(name)}`)
+                    if (!res.ok) throw new Error(`HTTP ${res.status}`)
+                    bodyEl.textContent = await res.text()
+                } catch (err) {
+                    bodyEl.textContent = `Failed to load log file: ${err.message}`
+                    console.error("openLogFile failed:", err)
+                }
+            }
+
+            /**
+             * Closes the log file viewer modal and frees the body memory.
+             */
+            function closeLogFileModal() {
+                const modal = document.getElementById("logFileModal")
+                if (!modal.classList.contains("visible")) return
+                modal.classList.remove("visible")
+                document.getElementById("logFileModalBody").textContent = ""
+            }
+
+            // Close the log file modal when clicking the dimmed backdrop (but not the inner content).
+            document.getElementById("logFileModal").addEventListener("click", function(e) {
+                if (e.target === this) closeLogFileModal()
             })
 
             // Initiate the connection and settings when the page loads.

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/utils/LogStreamServer.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/utils/LogStreamServer.kt
@@ -1014,6 +1014,101 @@ object LogStreamServer {
                             }
                         }
 
+                        // List every completed-session .txt log file in the /logs/ directory, sorted most-recent-first.
+                        get("/logs/files") {
+                            try {
+                                val logsDir = File(context.getExternalFilesDir(null), "logs")
+                                val filesArray = JSONArray()
+                                var totalSize = 0L
+
+                                if (logsDir.exists() && logsDir.isDirectory) {
+                                    val logFiles = logsDir.listFiles { _, name -> name.lowercase().endsWith(".txt") } ?: emptyArray()
+                                    for (file in logFiles.sortedByDescending { it.lastModified() }) {
+                                        val size = file.length()
+                                        totalSize += size
+                                        filesArray.put(
+                                            JSONObject().apply {
+                                                put("name", file.name)
+                                                put("size", size)
+                                                put("modified", file.lastModified())
+                                            },
+                                        )
+                                    }
+                                }
+
+                                val response =
+                                    JSONObject().apply {
+                                        put("files", filesArray)
+                                        put("count", filesArray.length())
+                                        put("totalSize", totalSize)
+                                    }
+                                call.respondText(response.toString(), ContentType.Application.Json)
+                            } catch (e: Exception) {
+                                Log.e(TAG, "[ERROR] /logs/files:: Failed to list log files: ${e.message}")
+                                call.respondText(
+                                    """{"files":[],"count":0,"totalSize":0,"error":"Failed to list log files."}""",
+                                    ContentType.Application.Json,
+                                    HttpStatusCode.InternalServerError,
+                                )
+                            }
+                        }
+
+                        // Serve a single log file by name. Inline by default, or as a download attachment when ?download=1.
+                        get("/logs/files/{filename}") {
+                            try {
+                                val raw = call.parameters["filename"]
+                                if (raw.isNullOrEmpty()) {
+                                    call.respondText("Missing filename.", ContentType.Text.Plain, HttpStatusCode.BadRequest)
+                                    return@get
+                                }
+                                // Reject path-traversal characters and any name not ending in .txt.
+                                if (raw.contains('/') ||
+                                    raw.contains('\\') ||
+                                    raw.contains("..") ||
+                                    raw.contains(' ') ||
+                                    !raw.lowercase().endsWith(".txt")
+                                ) {
+                                    call.respondText("Invalid filename.", ContentType.Text.Plain, HttpStatusCode.BadRequest)
+                                    return@get
+                                }
+
+                                val logsDir = File(context.getExternalFilesDir(null), "logs")
+                                if (!logsDir.exists() || !logsDir.isDirectory) {
+                                    call.respondText("File not found.", ContentType.Text.Plain, HttpStatusCode.NotFound)
+                                    return@get
+                                }
+
+                                // Whitelist against the actual directory listing - the canonical guarantee against any encoded payload.
+                                val available = logsDir.listFiles { _, name -> name.lowercase().endsWith(".txt") }?.map { it.name }?.toSet() ?: emptySet()
+                                if (raw !in available) {
+                                    call.respondText("File not found.", ContentType.Text.Plain, HttpStatusCode.NotFound)
+                                    return@get
+                                }
+
+                                val target = File(logsDir, raw)
+                                // Belt-and-suspenders containment check.
+                                if (!target.canonicalPath.startsWith(logsDir.canonicalPath + File.separator)) {
+                                    call.respondText("Invalid filename.", ContentType.Text.Plain, HttpStatusCode.BadRequest)
+                                    return@get
+                                }
+
+                                val isDownload = call.request.queryParameters["download"] == "1"
+                                if (isDownload) {
+                                    call.response.header(HttpHeaders.ContentDisposition, "attachment; filename=\"$raw\"")
+                                } else {
+                                    call.response.header(HttpHeaders.ContentDisposition, "inline")
+                                }
+                                call.respondText(target.readText(), ContentType.Text.Plain)
+                            } catch (e: Exception) {
+                                Log.e(TAG, "[ERROR] /logs/files/{filename}:: Failed to serve log file: ${e.message}")
+                                call.respondText(
+                                    "Failed to serve log file.",
+                                    ContentType.Text.Plain,
+                                    HttpStatusCode.InternalServerError,
+                                )
+                            }
+                        }
+
                         // Handle WebSocket connections on root path (matches the HTML client).
                         webSocket("/") {
                             handleWebSocketSession(this)


### PR DESCRIPTION
## Description
- This PR adds a new "Log Files" tab to the Remote Log Viewer that lists every completed-session `.txt` log saved to the device's `/logs/` directory, with click-to-view in an inline modal and per-row download buttons. Two new Ktor routes (`/logs/files` and `/logs/files/{filename}`) back the UI, with path-traversal hardening via filename whitelisting against the actual directory listing.
