### PR TITLE
Fix chat answer looping by adding penalty_repeat and min_p sampling

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -163,9 +163,14 @@ android {
             enable true
             reset()
             //noinspection ChromeOsAbiSupport
-            include("arm64-v8a")
+            include("arm64-v8a", "x86_64")
             // armeabi-v7a dropped: llama.rn 0.12+ ships arm64-v8a only and 32-bit ARM Android phones are
             // effectively extinct (Google Play has required 64-bit since 2019).
+            // x86_64 included so the Android emulator (running on x86_64 hosts) loads native llama.rn
+            // binaries instead of running arm64-v8a through QEMU TCG translation. Must stay paired with
+            // `reactNativeArchitectures=arm64-v8a,x86_64` in android/gradle.properties - that property
+            // controls which ABIs RN actually compiles native modules for. Adding x86_64 here without
+            // it produces an x86_64 split that's missing libexpo-modules-core.so and crashes on launch.
             universalApk false
         }
     }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -34,7 +34,7 @@ android.enablePngCrunchInReleaseBuilds=true
 # Use this property to specify which architecture you want to build.
 # You can also override it from the CLI using
 # ./gradlew <task> -PreactNativeArchitectures=x86_64
-reactNativeArchitectures=arm64-v8a
+reactNativeArchitectures=arm64-v8a,x86_64
 
 # Use this property to enable support to the new architecture.
 # This will allow you to use TurboModules and the Fabric render in

--- a/src/lib/chat/deviceCapabilities.ts
+++ b/src/lib/chat/deviceCapabilities.ts
@@ -13,7 +13,7 @@ export interface DeviceCapabilities {
     availRamBytes: number
     /** Tokens from `/proc/cpuinfo`'s `Features:` line (e.g. `["fp", "asimd", "asimddp", "i8mm", ...]`). */
     cpuFeatures: string[]
-    /** Primary supported ABI (`Build.SUPPORTED_ABIS[0]`); should always be `arm64-v8a` after our split. */
+    /** Primary supported ABI (`Build.SUPPORTED_ABIS[0]`). Either `arm64-v8a` on real devices or `x86_64` on the Android emulator. */
     abi: string
 }
 
@@ -22,7 +22,7 @@ export interface DeviceCapabilities {
  * device's CPU features satisfy. `unknown` is a defensive fallback for parse failures - treated as the slow
  * baseline by the UI.
  */
-export type AccelerationTier = "v8.2-dotprod" | "v8-baseline" | "unknown"
+export type AccelerationTier = "v8.2-dotprod" | "v8-baseline" | "x86_64" | "unknown"
 
 /** Approximate free-RAM requirement for each chat-model preset, keyed by a substring of the preset URL. */
 export const PRESET_RAM_REQUIREMENTS_BYTES: Array<{ urlSubstring: string; requiredAvailRamBytes: number; label: string }> = [
@@ -58,7 +58,8 @@ export async function loadDeviceCapabilities(): Promise<DeviceCapabilities | nul
  * `v8_2` variants. The `i8mm` and `hexagon_opencl` variants are not in the APK (trimmed for size), so the
  * presence of `i8mm` is informational only and doesn't change the tier.
  */
-export function accelerationTier(features: string[]): AccelerationTier {
+export function accelerationTier(features: string[], abi?: string): AccelerationTier {
+    if (abi === "x86_64") return "x86_64"
     if (!features || features.length === 0) return "unknown"
     if (features.includes("asimddp")) return "v8.2-dotprod"
     return "v8-baseline"
@@ -73,6 +74,8 @@ export function accelerationTierLabel(tier: AccelerationTier): string {
             return "v8.2 + dotprod (fast)"
         case "v8-baseline":
             return "v8 baseline (slow)"
+        case "x86_64":
+            return "x86_64 native"
         case "unknown":
             return "unknown"
     }

--- a/src/lib/chat/llamaRunner.ts
+++ b/src/lib/chat/llamaRunner.ts
@@ -48,6 +48,12 @@ export interface ChatOptions {
     topK?: number
     /** Nucleus (top-P) sampling cutoff. Default 0.95. */
     topP?: number
+    /** Minimum probability mass relative to the most likely token. Default 0.05. Quality floor on top of top-k/top-p. */
+    minP?: number
+    /** Repetition penalty over the last `penaltyLastN` tokens. Default 1.1 - breaks paragraph-cycling on small models like qwen2.5-0.5b. */
+    penaltyRepeat?: number
+    /** Window of recent tokens that the repetition penalty looks at. Default 128. */
+    penaltyLastN?: number
     /** Strings that, when emitted, halt generation. Defaults cover Gemma + Qwen + Llama EOS markers. */
     stop?: string[]
 }
@@ -164,6 +170,9 @@ export async function chat(opts: ChatOptions, onToken?: (token: string) => void)
             temperature: opts.temperature ?? 0.35,
             top_k: opts.topK ?? 40,
             top_p: opts.topP ?? 0.95,
+            min_p: opts.minP ?? 0.05,
+            penalty_repeat: opts.penaltyRepeat ?? 1.1,
+            penalty_last_n: opts.penaltyLastN ?? 128,
             stop: opts.stop ?? DEFAULT_STOP,
         },
         (data: { token: string }) => {

--- a/src/pages/LLMSettings/index.tsx
+++ b/src/pages/LLMSettings/index.tsx
@@ -265,7 +265,7 @@ const LLMSettings = () => {
             .catch(() => undefined)
     }, [])
 
-    const tier = useMemo(() => accelerationTier(deviceCaps?.cpuFeatures ?? []), [deviceCaps])
+    const tier = useMemo(() => accelerationTier(deviceCaps?.cpuFeatures ?? [], deviceCaps?.abi), [deviceCaps])
     const recommended = useMemo(() => recommendedPreset(deviceCaps), [deviceCaps])
 
     const handleDownload = useCallback(async () => {


### PR DESCRIPTION
## Description
- This PR fixes the on-device chat bot looping the same paragraph indefinitely on small models (a sampler-config issue) and adds the `x86_64` ABI to the build so the Android emulator runs native binaries instead of routing every instruction through QEMU's ARM64-to-x86 translation layer.

### Original problem
A test chat ("What can this app do?") on the emulator with `qwen2.5-0.5b-instruct-q4_k_m.gguf` looked like this before the fix, with the same paragraph repeating until force-stopped:
```
[Chat] generation: 383 tok in 275.76s = 1.39 tok/s
```

### Note about the x86_64 variant
The `x86_64` ABI significantly boosts the performance on Android emulators and should be considered the default to-be-used moving forward. Android devices will use the `arm64-v8a` split automatically and are unaffected. One footgun worth flagging for future contributors: enabling `x86_64` requires both `splits.abi` in `android/app/build.gradle` and `reactNativeArchitectures` in `android/gradle.properties` to list both ABIs together - setting only one ships an APK whose x86_64 split is missing `libexpo-modules-core.so` and crashes at launch with `SoLoaderDSONotFoundError`.

