### PR TITLE
Warn on the Home page when `arm64-v8a` runs on `x86_64`-capable device

### DIFF
--- a/android/app/src/main/java/com/steve1316/uma_android_automation/llm/LLMChatModule.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/llm/LLMChatModule.kt
@@ -226,7 +226,7 @@ class LLMChatModule(private val reactContext: ReactApplicationContext) : ReactCo
      * Drives the diagnostic + preset-recommendation row on the LLM Settings page; called once on focus, not in
      * a hot path, so the `/proc/cpuinfo` parse is acceptable.
      *
-     * @param promise Resolves with `{ totalRamBytes, availRamBytes, cpuFeatures: string[], abi: string }`.
+     * @param promise Resolves with `{ totalRamBytes, availRamBytes, cpuFeatures: string[], abi: string, installedAbi: string }`.
      */
     @ReactMethod
     fun getDeviceCapabilities(promise: Promise) {
@@ -242,6 +242,20 @@ class LLMChatModule(private val reactContext: ReactApplicationContext) : ReactCo
             for (f in features) featureArr.pushString(f)
             map.putArray("cpuFeatures", featureArr)
             map.putString("abi", android.os.Build.SUPPORTED_ABIS.firstOrNull() ?: "unknown")
+            // The installed ABI is parsed from the native lib dir path that PackageManager extracted libs into. This tells us which split
+            // APK the user actually installed (independent of what the device prefers), so the Home banner can detect a mismatch like
+            // "device prefers x86_64 but the user installed the arm64-v8a build". Order matters: check 64-bit names before the shorter
+            // 32-bit names so /lib/arm64 isn't misclassified as armeabi-v7a.
+            val nativeLibDir = reactContext.applicationInfo.nativeLibraryDir ?: ""
+            val installedAbi =
+                when {
+                    nativeLibDir.contains("/arm64") -> "arm64-v8a"
+                    nativeLibDir.contains("/x86_64") -> "x86_64"
+                    nativeLibDir.contains("/arm") -> "armeabi-v7a"
+                    nativeLibDir.contains("/x86") -> "x86"
+                    else -> "unknown"
+                }
+            map.putString("installedAbi", installedAbi)
             promise.resolve(map)
         } catch (e: Exception) {
             Log.e(TAG, "getDeviceCapabilities:: failed: ${e.message}", e)

--- a/src/lib/chat/deviceCapabilities.ts
+++ b/src/lib/chat/deviceCapabilities.ts
@@ -15,6 +15,12 @@ export interface DeviceCapabilities {
     cpuFeatures: string[]
     /** Primary supported ABI (`Build.SUPPORTED_ABIS[0]`). Either `arm64-v8a` on real devices or `x86_64` on the Android emulator. */
     abi: string
+    /**
+     * ABI of the APK variant the user actually installed, parsed from `applicationInfo.nativeLibraryDir`. Differs from `abi` (the device's
+     * preferred ABI) when the user installed a non-native split, e.g. running the `arm64-v8a` APK on an `x86_64` emulator via Android's
+     * binary translator.
+     */
+    installedAbi: string
 }
 
 /**
@@ -45,6 +51,7 @@ export async function loadDeviceCapabilities(): Promise<DeviceCapabilities | nul
             availRamBytes: Number(raw?.availRamBytes ?? 0),
             cpuFeatures: Array.isArray(raw?.cpuFeatures) ? raw.cpuFeatures : [],
             abi: typeof raw?.abi === "string" ? raw.abi : "unknown",
+            installedAbi: typeof raw?.installedAbi === "string" ? raw.installedAbi : "unknown",
         }
     } catch {
         return null
@@ -143,4 +150,16 @@ export function formatBytes(bytes: number): string {
     if (gb >= 1) return `${gb.toFixed(1)} GB`
     const mb = bytes / 1024 / 1024
     return `${Math.round(mb)} MB`
+}
+
+/**
+ * True when the device prefers `x86_64` (i.e. running on an Android emulator) but the user installed the `arm64-v8a` split APK.
+ * Used by the Home screen to nudge emulator users toward the native build, which avoids Android's binary translator.
+ *
+ * @param caps Device capability snapshot, or `null` when the bridge call failed.
+ * @returns Whether to suggest the `x86_64` variant.
+ */
+export function shouldSuggestX8664Variant(caps: DeviceCapabilities | null): boolean {
+    if (!caps) return false
+    return caps.abi === "x86_64" && caps.installedAbi === "arm64-v8a"
 }

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -16,6 +16,7 @@ import PageHeader from "../../components/PageHeader"
 import { usePerformanceLogging } from "../../hooks/usePerformanceLogging"
 import SelectButton from "../../components/SelectButton"
 import PermissionSetupDialog from "../../components/PermissionSetupDialog"
+import { loadDeviceCapabilities, shouldSuggestX8664Variant } from "../../lib/chat/deviceCapabilities"
 
 const styles = StyleSheet.create({
     root: {
@@ -72,6 +73,7 @@ const Home = () => {
     const [deviceMetrics, setDeviceMetrics] = useState<{ width: number; height: number; dpi: number } | null>(null)
     const [unsupportedReason, setUnsupportedReason] = useState<string | null>(null)
     const [showPermissionDialog, setShowPermissionDialog] = useState<boolean>(false)
+    const [abiMismatch, setAbiMismatch] = useState<boolean>(false)
 
     const { readyStatus, setReadyStatus, setAppName, setAppVersion } = useContext(BotMetaContext)
     const { general, updateGeneral } = useContext(GeneralMiscContext)
@@ -83,8 +85,8 @@ const Home = () => {
     useEffect(() => {
         let animation: Animated.CompositeAnimation | null = null
 
-        if (unsupportedReason) {
-            // Pulsate the icon to grab attention when there's an unsupported device.
+        if (unsupportedReason !== null || abiMismatch) {
+            // Pulsate the icon to grab attention when there's an unsupported device or a slow ABI variant installed.
             animation = Animated.loop(
                 Animated.sequence([
                     Animated.timing(pulseAnim, {
@@ -107,7 +109,7 @@ const Home = () => {
         return () => {
             animation?.stop()
         }
-    }, [unsupportedReason])
+    }, [unsupportedReason, abiMismatch])
 
     useEffect(() => {
         const mediaProjectionSubscription = DeviceEventEmitter.addListener("MediaProjectionService", (data) => {
@@ -122,6 +124,7 @@ const Home = () => {
 
         getVersion()
         fetchDeviceMetrics()
+        checkAbiMismatch()
 
         return () => {
             mediaProjectionSubscription.remove()
@@ -168,6 +171,15 @@ const Home = () => {
         logWithTimestamp(`Android app ${appName} version is ${version}`)
         setAppName(appName)
         setAppVersion(version)
+    }
+
+    /**
+     * One-shot mount check for the x86_64-capable-but-arm64-installed mismatch. Mirrors `fetchDeviceMetrics` - load once, set state
+     * once, never re-runs. Result is consumed by `renderStatus` (warning icon + tooltip section) and the pulse-animation effect.
+     */
+    const checkAbiMismatch = async () => {
+        const caps = await loadDeviceCapabilities()
+        if (shouldSuggestX8664Variant(caps)) setAbiMismatch(true)
     }
 
     /**
@@ -235,7 +247,7 @@ const Home = () => {
             // Must come first because we always want the button to be red
             // if the bot is running, regardless of the other conditions.
             return "error"
-        } else if (unsupportedReason !== null) {
+        } else if (unsupportedReason !== null || abiMismatch) {
             return "warning"
         } else if (deviceMetrics === null) {
             return "warning"
@@ -248,7 +260,9 @@ const Home = () => {
 
     /** Returns a status indicator based on the device state. */
     const renderStatus = (): React.ReactElement | null => {
-        const warningText = `Current Display: ${deviceMetrics?.width}x${deviceMetrics?.height} (${deviceMetrics?.dpi} DPI).
+        const warningSections: string[] = []
+        if (unsupportedReason) {
+            warningSections.push(`Current Display: ${deviceMetrics?.width}x${deviceMetrics?.height} (${deviceMetrics?.dpi} DPI).
 
 Warning: Performance may be degraded due to ${unsupportedReason}.
 
@@ -260,9 +274,19 @@ Note: Height is not as important to meet as the width. In addition, DPI is tied 
 
 DPI = sqrt(width^2 + height^2) / diagonal
 
-where width and height of the screen is in pixels, and diagonal is the diagonal size of the physical screen in inches.`
+where width and height of the screen is in pixels, and diagonal is the diagonal size of the physical screen in inches.`)
+        }
+        if (abiMismatch) {
+            warningSections.push(`Installed Build: arm64-v8a
+Device Supports: x86_64
 
-        if (unsupportedReason) {
+Warning: The arm64 build runs through Android's binary translator on this device, which is significantly slower than running natively.
+
+Note: Reinstall using the x86_64 release APK for much better performance.`)
+        }
+        const warningText = warningSections.join("\n\n----\n\n")
+
+        if (unsupportedReason || abiMismatch) {
             return (
                 <Tooltip delayDuration={150}>
                     <TooltipTrigger>


### PR DESCRIPTION
## Description
- This PR adds a Home-screen warning when the user installs the `arm64-v8a` build on a device that supports `x86_64` natively (such as an Android emulator). The pulsing alert icon already used for unsupported display resolutions now also surfaces this ABI mismatch in its tooltip, nudging emulator users toward the faster `x86_64` release APK that ships alongside the `arm64-v8a` one.
