### PR TITLE
Add skill blacklist and color category exclusions to Skill Plan

### DIFF
--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/SkillPlan.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/SkillPlan.kt
@@ -8,6 +8,7 @@ import com.steve1316.uma_android_automation.bot.Campaign
 import com.steve1316.uma_android_automation.types.RunningStyle
 import com.steve1316.uma_android_automation.types.SkillList
 import com.steve1316.uma_android_automation.types.SkillListEntry
+import com.steve1316.uma_android_automation.types.SkillType
 import com.steve1316.uma_android_automation.types.TrackDistance
 import com.steve1316.uma_android_automation.types.TrackSurface
 import org.json.JSONObject
@@ -55,6 +56,18 @@ class SkillPlan(private val game: Game, private val campaign: Campaign) {
                             .map { it.trim() }
                             .mapNotNull { it.toIntOrNull() }
                     val skillNames: List<String> = skillIds.mapNotNull { game.skillDatabase.getSkillName(it) }
+                    val blacklistIds: List<Int> =
+                        planData
+                            .optString("blacklist", "")
+                            .split(",")
+                            .map { it.trim() }
+                            .mapNotNull { it.toIntOrNull() }
+                    val skillBlacklist: List<String> = blacklistIds.mapNotNull { game.skillDatabase.getSkillName(it) }
+                    val excludedTypes: Set<SkillType> =
+                        buildSet {
+                            if (planData.optBoolean("excludeGreenSkills", false)) add(SkillType.GREEN)
+                            if (planData.optBoolean("excludeRedSkills", false)) add(SkillType.RED)
+                        }
                     plansMap[planName] =
                         SkillPlanSettings(
                             bIsEnabled = planData.getBoolean("enabled"),
@@ -62,6 +75,8 @@ class SkillPlan(private val game: Game, private val campaign: Campaign) {
                             bEnableBuyInheritedUniqueSkills = planData.getBoolean("enableBuyInheritedUniqueSkills"),
                             bEnableBuyNegativeSkills = planData.getBoolean("enableBuyNegativeSkills"),
                             skillNames = skillNames,
+                            skillBlacklist = skillBlacklist,
+                            excludedTypes = excludedTypes,
                         )
                 }
                 plansMap
@@ -106,6 +121,8 @@ class SkillPlan(private val game: Game, private val campaign: Campaign) {
      * @property bEnableBuyInheritedUniqueSkills Whether to purchase inherited unique skills.
      * @property bEnableBuyNegativeSkills Whether to purchase negative (blue) skills.
      * @property skillNames The list of specific skill names to purchase as part of this plan.
+     * @property skillBlacklist Names of skills to exclude from purchase regardless of strategy.
+     * @property excludedTypes Skill type categories (GREEN / YELLOW / BLUE / RED) to exclude wholesale.
      */
     data class SkillPlanSettings(
         val bIsEnabled: Boolean,
@@ -113,6 +130,8 @@ class SkillPlan(private val game: Game, private val campaign: Campaign) {
         val bEnableBuyInheritedUniqueSkills: Boolean,
         val bEnableBuyNegativeSkills: Boolean,
         val skillNames: List<String>,
+        val skillBlacklist: List<String> = emptyList(),
+        val excludedTypes: Set<SkillType> = emptySet(),
     )
 
     companion object {
@@ -128,6 +147,7 @@ class SkillPlan(private val game: Game, private val campaign: Campaign) {
          * @property isInheritedUnique Whether this is an inherited unique skill.
          * @property isUserPlanned Whether this skill is in the user's plan.
          * @property communityTier The community tier ranking (lower is better, null = unranked).
+         * @property isBlacklisted Whether this skill is blacklisted by the user's plan settings (per-skill or category-level).
          */
         data class SkillCandidate(
             val name: String,
@@ -137,6 +157,7 @@ class SkillPlan(private val game: Game, private val campaign: Campaign) {
             val isInheritedUnique: Boolean = false,
             val isUserPlanned: Boolean = false,
             val communityTier: Int? = null,
+            val isBlacklisted: Boolean = false,
         ) {
             /** The ratio of rank gained to price. Higher is better. */
             val evaluationPointRatio: Double
@@ -164,7 +185,7 @@ class SkillPlan(private val game: Game, private val campaign: Campaign) {
 
             val sorted =
                 candidates
-                    .filter { it.name !in alreadyPlanned && it.price > 0 }
+                    .filter { it.name !in alreadyPlanned && it.price > 0 && !it.isBlacklisted }
                     .sortedByDescending { it.evaluationPointRatio }
 
             for (skill in sorted) {
@@ -199,7 +220,7 @@ class SkillPlan(private val game: Game, private val campaign: Campaign) {
 
             // Phase 1: Negative skills
             if (settings.bEnableBuyNegativeSkills) {
-                for (skill in candidates.filter { it.isNegative }) {
+                for (skill in candidates.filter { it.isNegative && !it.isBlacklisted }) {
                     if (skill.name in bought) continue
                     if (skill.price <= remaining) {
                         result.add(skill.name to skill.price)
@@ -211,7 +232,7 @@ class SkillPlan(private val game: Game, private val campaign: Campaign) {
 
             // Phase 2: Inherited unique skills
             if (settings.bEnableBuyInheritedUniqueSkills) {
-                for (skill in candidates.filter { it.isInheritedUnique }) {
+                for (skill in candidates.filter { it.isInheritedUnique && !it.isBlacklisted }) {
                     if (skill.name in bought) continue
                     if (skill.price <= remaining) {
                         result.add(skill.name to skill.price)
@@ -221,8 +242,8 @@ class SkillPlan(private val game: Game, private val campaign: Campaign) {
                 }
             }
 
-            // Phase 3: User-planned skills (in the order specified by plan)
-            for (skill in candidates.filter { it.isUserPlanned }) {
+            // Phase 3: User-planned skills (in the order specified by plan). Blacklist takes precedence over plan.
+            for (skill in candidates.filter { it.isUserPlanned && !it.isBlacklisted }) {
                 if (skill.name in bought) continue
                 if (skill.price <= remaining) {
                     result.add(skill.name to skill.price)
@@ -268,7 +289,7 @@ class SkillPlan(private val game: Game, private val campaign: Campaign) {
                         // For OPTIMIZE_SKILLS, filter by community tier first, then fall back to rank
                         val tiered =
                             remainingCandidates
-                                .filter { it.communityTier != null }
+                                .filter { it.communityTier != null && !it.isBlacklisted }
                                 .sortedWith(compareBy<SkillCandidate> { it.communityTier }.thenByDescending { it.evaluationPointRatio })
                         val tieredResult = mutableListOf<Pair<String, Int>>()
                         var tieredRemaining = budget - spent
@@ -368,6 +389,17 @@ class SkillPlan(private val game: Game, private val campaign: Campaign) {
     // //////////////////////////////////////////////////////////////////////////////////////////////////
 
     /**
+     * Whether the given skill entry should be excluded from purchase due to the user's blacklist settings.
+     *
+     * Returns true if the entry's name is in the per-skill blacklist OR its color category is in the excluded types set.
+     *
+     * @param entry The [SkillListEntry] under consideration.
+     * @param settings The [SkillPlanSettings] holding the blacklist and excluded categories.
+     * @return True if the entry should be skipped, false otherwise.
+     */
+    private fun isBlacklisted(entry: SkillListEntry, settings: SkillPlanSettings): Boolean = entry.name in settings.skillBlacklist || entry.skillData.type in settings.excludedTypes
+
+    /**
      * Retrieve all available negative skills from the skill list.
      *
      * @param skillPlanSettings The [SkillPlanSettings] to follow.
@@ -388,6 +420,11 @@ class SkillPlan(private val game: Game, private val campaign: Campaign) {
         for ((name, entry) in entries) {
             // Don't add any duplicate entries.
             if (name in skillsToBuy) {
+                continue
+            }
+
+            // Skip skills the user has explicitly blacklisted (per-skill or by color category).
+            if (isBlacklisted(entry, skillPlanSettings)) {
                 continue
             }
 
@@ -421,6 +458,10 @@ class SkillPlan(private val game: Game, private val campaign: Campaign) {
         val entries: Map<String, SkillListEntry> = skillList.getInheritedUniqueSkills()
         for ((name, entry) in entries) {
             if (name in skillsToBuy || name in result) {
+                continue
+            }
+
+            if (isBlacklisted(entry, skillPlanSettings)) {
                 continue
             }
 
@@ -463,6 +504,11 @@ class SkillPlan(private val game: Game, private val campaign: Campaign) {
             val entry: SkillListEntry? = skillList.getEntry(name)
             if (entry == null) {
                 MessageLog.e(TAG, "[ERROR] getUserPlannedSkills:: Failed to find entry for \"$name\".")
+                continue
+            }
+
+            // Skip skills the user has both planned AND blacklisted. Blacklist takes precedence to keep behavior predictable.
+            if (isBlacklisted(entry, skillPlanSettings)) {
                 continue
             }
 
@@ -652,6 +698,10 @@ class SkillPlan(private val game: Game, private val campaign: Campaign) {
                         continue
                     }
 
+                    if (isBlacklisted(entry, skillPlanSettings)) {
+                        continue
+                    }
+
                     if (!entry.bIsAvailable || entry.screenPrice > remainingSkillPoints) {
                         continue
                     }
@@ -707,6 +757,10 @@ class SkillPlan(private val game: Game, private val campaign: Campaign) {
             for (entry in sortedByPointRatio) {
                 // Don't add duplicate entries.
                 if (entry.name in result || entry.name in skillsToBuy) {
+                    continue
+                }
+
+                if (isBlacklisted(entry, skillPlanSettings)) {
                     continue
                 }
 

--- a/android/app/src/test/java/com/steve1316/uma_android_automation/bot/SkillPlanPurchasingTest.kt
+++ b/android/app/src/test/java/com/steve1316/uma_android_automation/bot/SkillPlanPurchasingTest.kt
@@ -475,4 +475,110 @@ class SkillPlanPurchasingTest {
             }
         }
     }
+
+    // //////////////////////////////////////////////////////////////////////////////////////////////////
+    // //////////////////////////////////////////////////////////////////////////////////////////////////
+    // Blacklist behavior
+
+    @Nested
+    @DisplayName("Skill blacklist (per-skill and category)")
+    inner class BlacklistTests {
+        @Test
+        fun `blacklisted skill never appears in OPTIMIZE_RANK output even with the best ratio`() {
+            // The blacklisted skill has the highest ratio (10.0). Without the filter it would always be picked first.
+            val candidates =
+                listOf(
+                    SkillCandidate("Top Pick", price = 10, evaluationPoints = 100, isBlacklisted = true),
+                    SkillCandidate("Runner Up", price = 50, evaluationPoints = 100),
+                    SkillCandidate("Third", price = 100, evaluationPoints = 50),
+                )
+
+            val result = calculateOptimizeRankPurchases(candidates, budget = 200)
+
+            assertFalse(result.any { it.first == "Top Pick" }, "Blacklisted skill must not be purchased")
+            assertTrue(result.any { it.first == "Runner Up" }, "Non-blacklisted skill should still be purchased")
+        }
+
+        @Test
+        fun `blacklisted skill on user plan is skipped even when the plan would otherwise buy it`() {
+            // Blacklist takes precedence over the user's planned-skill list to keep behavior predictable.
+            val candidates =
+                listOf(
+                    SkillCandidate("Planned & Blacklisted", price = 50, evaluationPoints = 80, isUserPlanned = true, isBlacklisted = true),
+                    SkillCandidate("Planned", price = 50, evaluationPoints = 80, isUserPlanned = true),
+                )
+            val settings =
+                SkillPlanSettings(
+                    bIsEnabled = true,
+                    strategy = SpendingStrategy.DEFAULT,
+                    bEnableBuyInheritedUniqueSkills = false,
+                    bEnableBuyNegativeSkills = false,
+                    skillNames = listOf("Planned & Blacklisted", "Planned"),
+                )
+
+            val result = calculateCommonPurchases(candidates, budget = 200, settings = settings)
+
+            assertFalse(result.any { it.first == "Planned & Blacklisted" }, "Blacklist must override user plan")
+            assertTrue(result.any { it.first == "Planned" }, "Non-blacklisted planned skill should still be purchased")
+        }
+
+        @Test
+        fun `category exclusion drops every matching skill regardless of strategy`() {
+            // Simulates the production layer setting isBlacklisted = true on every skill in an excluded color category.
+            val candidates =
+                (1..5).map { i ->
+                    SkillCandidate(
+                        name = "Green_$i",
+                        price = 30,
+                        evaluationPoints = 80,
+                        isBlacklisted = true,
+                    )
+                } +
+                    listOf(
+                        SkillCandidate("Yellow_1", price = 50, evaluationPoints = 60),
+                        SkillCandidate("Yellow_2", price = 60, evaluationPoints = 50),
+                    )
+            val settings =
+                SkillPlanSettings(
+                    bIsEnabled = true,
+                    strategy = SpendingStrategy.OPTIMIZE_RANK,
+                    bEnableBuyInheritedUniqueSkills = false,
+                    bEnableBuyNegativeSkills = false,
+                    skillNames = emptyList(),
+                )
+
+            val result = calculateSkillPurchases(candidates, budget = 500, settings = settings)
+
+            assertTrue(result.none { it.first.startsWith("Green_") }, "No green skills should be purchased")
+            assertTrue(result.any { it.first.startsWith("Yellow_") }, "Yellow skills are still eligible")
+        }
+
+        @Test
+        fun `empty plan with both flags off causes common phase to return empty - the no skills bought scenario`() {
+            // Pins the behavior reported by users as "bot doesn't buy any skills even though I created a planner".
+            // The production strategy DEFAULT (UI label "Do Not Spend Remaining Points") delegates to getSkillsToBuyDefaultStrategy
+            // which returns emptyMap, so the only purchases come from the common phase. With an empty plan list and both
+            // auto-buy flags off, the common phase also returns empty - meaning the bot buys nothing.
+            // (Note: the pure calculateSkillPurchases treats DEFAULT == OPTIMIZE_RANK, so we assert the common phase directly.)
+            val candidates =
+                listOf(
+                    SkillCandidate("A", price = 50, evaluationPoints = 100),
+                    SkillCandidate("B", price = 80, evaluationPoints = 200),
+                    SkillCandidate("Negative", price = 30, evaluationPoints = 20, isNegative = true),
+                    SkillCandidate("Inherited", price = 60, evaluationPoints = 90, isInheritedUnique = true),
+                )
+            val settings =
+                SkillPlanSettings(
+                    bIsEnabled = true,
+                    strategy = SpendingStrategy.DEFAULT,
+                    bEnableBuyInheritedUniqueSkills = false,
+                    bEnableBuyNegativeSkills = false,
+                    skillNames = emptyList(),
+                )
+
+            val commonResult = calculateCommonPurchases(candidates, budget = 1000, settings = settings)
+
+            assertTrue(commonResult.isEmpty(), "Common phase with no plan and both flags off should buy nothing")
+        }
+    }
 }

--- a/src/context/BotStateContext.tsx
+++ b/src/context/BotStateContext.tsx
@@ -14,8 +14,14 @@ interface SkillPlanSettingsConfig {
     enableBuyInheritedUniqueSkills: boolean
     /** Whether to buy negative skills. */
     enableBuyNegativeSkills: boolean
-    /** The serialized skill plan data. */
+    /** The serialized skill plan data (comma-separated skill IDs). */
     plan: string
+    /** Comma-separated skill IDs that should never be purchased by this plan, even when ranked highly by a strategy. */
+    blacklist: string
+    /** When true, all green skills are excluded from this plan's purchases. */
+    excludeGreenSkills: boolean
+    /** When true, all red skills (debuffs like Intimidate, Speed Eater) are excluded from this plan's purchases. */
+    excludeRedSkills: boolean
 }
 
 /**
@@ -285,6 +291,9 @@ export const defaultSettings: Settings = {
                     enableBuyInheritedUniqueSkills: false,
                     enableBuyNegativeSkills: false,
                     plan: "",
+                    blacklist: "",
+                    excludeGreenSkills: false,
+                    excludeRedSkills: false,
                 }
                 return acc
             },

--- a/src/context/searchConfig.ts
+++ b/src/context/searchConfig.ts
@@ -568,6 +568,20 @@ const searchConfig: SearchOption[] = [
         page: "SkillPlanSettingsSkillPointCheck",
         parentId: "enable-skill-plan-skillPointCheck",
     },
+    {
+        id: "exclude-green-skills-SkillPlanSettingsSkillPointCheck",
+        title: "Skip All Green Skills",
+        description: "When enabled, no green (stat-trigger) skills will be purchased by this plan.",
+        page: "SkillPlanSettingsSkillPointCheck",
+        parentId: "enable-skill-plan-skillPointCheck",
+    },
+    {
+        id: "exclude-red-skills-SkillPlanSettingsSkillPointCheck",
+        title: "Skip All Red Skills (Debuffs)",
+        description: "When enabled, no red skills (debuffs like Intimidate, Speed Eater, Tether, Intense Gaze) will be purchased by this plan.",
+        page: "SkillPlanSettingsSkillPointCheck",
+        parentId: "enable-skill-plan-skillPointCheck",
+    },
 
     // ============================================================
     // Skill Plan Settings — Pre-Finals
@@ -592,6 +606,20 @@ const searchConfig: SearchOption[] = [
         page: "SkillPlanSettingsPreFinals",
         parentId: "enable-skill-plan-preFinals",
     },
+    {
+        id: "exclude-green-skills-SkillPlanSettingsPreFinals",
+        title: "Skip All Green Skills",
+        description: "When enabled, no green (stat-trigger) skills will be purchased by this plan.",
+        page: "SkillPlanSettingsPreFinals",
+        parentId: "enable-skill-plan-preFinals",
+    },
+    {
+        id: "exclude-red-skills-SkillPlanSettingsPreFinals",
+        title: "Skip All Red Skills (Debuffs)",
+        description: "When enabled, no red skills (debuffs like Intimidate, Speed Eater, Tether, Intense Gaze) will be purchased by this plan.",
+        page: "SkillPlanSettingsPreFinals",
+        parentId: "enable-skill-plan-preFinals",
+    },
 
     // ============================================================
     // Skill Plan Settings — Career Complete
@@ -613,6 +641,20 @@ const searchConfig: SearchOption[] = [
         id: "enable-buy-negative-skills-SkillPlanSettingsCareerComplete",
         title: "Purchase All Negative Skills",
         description: "When enabled, the bot will attempt to purchase all negative skills (i.e. Firm Conditions ×).",
+        page: "SkillPlanSettingsCareerComplete",
+        parentId: "enable-skill-plan-careerComplete",
+    },
+    {
+        id: "exclude-green-skills-SkillPlanSettingsCareerComplete",
+        title: "Skip All Green Skills",
+        description: "When enabled, no green (stat-trigger) skills will be purchased by this plan.",
+        page: "SkillPlanSettingsCareerComplete",
+        parentId: "enable-skill-plan-careerComplete",
+    },
+    {
+        id: "exclude-red-skills-SkillPlanSettingsCareerComplete",
+        title: "Skip All Red Skills (Debuffs)",
+        description: "When enabled, no red skills (debuffs like Intimidate, Speed Eater, Tether, Intense Gaze) will be purchased by this plan.",
         page: "SkillPlanSettingsCareerComplete",
         parentId: "enable-skill-plan-careerComplete",
     },

--- a/src/lib/messageLog/buildSettingsBanner.ts
+++ b/src/lib/messageLog/buildSettingsBanner.ts
@@ -15,6 +15,15 @@ const safeJsonLength = (json: string): number => {
     }
 }
 
+const csvCount = (csv: string): number => (csv ? csv.split(",").filter((s) => s.trim() !== "").length : 0)
+
+const formatExcludedCategories = (plan: { excludeGreenSkills: boolean; excludeRedSkills: boolean }): string => {
+    const parts: string[] = []
+    if (plan.excludeGreenSkills) parts.push("Green")
+    if (plan.excludeRedSkills) parts.push("Red")
+    return parts.length === 0 ? "None" : parts.join(", ")
+}
+
 /**
  * Build the welcome / startup banner that summarizes the current bot configuration. Pure function of the
  * settings snapshot. The output is rendered at the top of the in-app message log and persisted to SQLite
@@ -154,14 +163,18 @@ ${longTargetsString}
         settings.skills.plans.preFinals.enabled
             ? `\n\t💲 Buy All Inherited Unique Skills: ${settings.skills.plans.preFinals.enableBuyInheritedUniqueSkills ? "✅" : "❌"}\n\t💲 Buy All Negative Skills: ${
                   settings.skills.plans.preFinals.enableBuyNegativeSkills ? "✅" : "❌"
-              }\n\t💸 Spending Strategy: ${settings.skills.plans.preFinals.strategy ? "✅" : "❌"}`
+              }\n\t💸 Spending Strategy: ${settings.skills.plans.preFinals.strategy ? "✅" : "❌"}\n\t🚫 Blacklisted Skills: ${csvCount(
+                  settings.skills.plans.preFinals.blacklist
+              )}\n\t🎨 Excluded Categories: ${formatExcludedCategories(settings.skills.plans.preFinals)}`
             : ""
     }
 📅 CareerComplete Skill Plan: ${settings.skills.plans.careerComplete.enabled ? "✅" : "❌"}${
         settings.skills.plans.careerComplete.enabled
             ? `\n\t💲 Buy All Inherited Unique Skills: ${settings.skills.plans.careerComplete.enableBuyInheritedUniqueSkills ? "✅" : "❌"}\n\t💲 Buy All Negative Skills: ${
                   settings.skills.plans.careerComplete.enableBuyNegativeSkills ? "✅" : "❌"
-              }\n\t💸 Spending Strategy: ${settings.skills.plans.careerComplete.strategy ? "✅" : "❌"}`
+              }\n\t💸 Spending Strategy: ${settings.skills.plans.careerComplete.strategy ? "✅" : "❌"}\n\t🚫 Blacklisted Skills: ${csvCount(
+                  settings.skills.plans.careerComplete.blacklist
+              )}\n\t🎨 Excluded Categories: ${formatExcludedCategories(settings.skills.plans.careerComplete)}`
             : ""
     }
 

--- a/src/pages/SkillPlanSettings/index.tsx
+++ b/src/pages/SkillPlanSettings/index.tsx
@@ -75,10 +75,11 @@ const SkillPlanSettings: FC<SkillPlanSettingsProps> = ({ planKey, name, title, d
     // Merge current skills settings with defaults to handle missing properties.
     const combinedConfig = { ...defaultSettings.skills.plans, ...skills.plans }
 
-    const { enabled, strategy, enableBuyInheritedUniqueSkills, enableBuyNegativeSkills, plan } = combinedConfig[planKey]
+    const { enabled, strategy, enableBuyInheritedUniqueSkills, enableBuyNegativeSkills, plan, blacklist, excludeGreenSkills, excludeRedSkills } = combinedConfig[planKey]
 
     const [searchQuery, setSearchQuery] = useState("")
     const [showSelected, setShowSelected] = useState(false)
+    const [selectionMode, setSelectionMode] = useState<"plan" | "blacklist">("plan")
     const scrollViewRef = useRef<ScrollView>(null)
 
     // Parse skill plan from CSV string.
@@ -86,18 +87,25 @@ const SkillPlanSettings: FC<SkillPlanSettingsProps> = ({ planKey, name, title, d
         return plan && plan !== "" && typeof plan === "string" ? plan.split(",").map((s) => Number(s)) : []
     }, [plan])
 
-    // Set showSelected to False whenever we have no selected skills.
+    const blacklistIds: number[] = useMemo(() => {
+        return blacklist && blacklist !== "" && typeof blacklist === "string" ? blacklist.split(",").map((s) => Number(s)) : []
+    }, [blacklist])
+
+    // The currently active selection list, depending on whether the user is editing the plan or the blacklist.
+    const activeIds: number[] = selectionMode === "plan" ? planIds : blacklistIds
+
+    // Set showSelected to False whenever the active list has no entries.
     React.useEffect(() => {
-        if (planIds.length === 0) {
+        if (activeIds.length === 0) {
             setShowSelected(false)
         }
-    }, [planIds, setShowSelected])
+    }, [activeIds, setShowSelected])
 
     // Filter skills based on search and preferences.
     const filteredSkills = useMemo(() => {
-        const skills: Skill[] = showSelected ? skillData.filter((skill: Skill) => planIds.includes(skill.id)) : skillData
+        const skills: Skill[] = showSelected ? skillData.filter((skill: Skill) => activeIds.includes(skill.id)) : skillData
         return skills.filter((skill: Skill) => skill.name_en.toLowerCase().includes(searchQuery.toLowerCase()))
-    }, [searchQuery, planIds, showSelected])
+    }, [searchQuery, activeIds, showSelected])
 
     /**
      * Update a skill plan setting.
@@ -124,30 +132,23 @@ const SkillPlanSettings: FC<SkillPlanSettingsProps> = ({ planKey, name, title, d
      */
     const handleSkillPress = useCallback(
         (skill: Skill) => {
-            // Determine if this should be added to the skill plan or removed.
-            const isSelected = planIds.includes(skill.id)
+            const targetKey: "plan" | "blacklist" = selectionMode
+            const currentIds: number[] = selectionMode === "plan" ? planIds : blacklistIds
+            const isSelected = currentIds.includes(skill.id)
 
-            let newPlanIds: number[] = []
-            if (isSelected) {
-                // Remove the skill from the skill plan.
-                newPlanIds = planIds.filter((id) => id !== skill.id)
-            } else {
-                // Add the skill to the skill plan.
-                newPlanIds = [...planIds, skill.id]
-            }
+            const newIds: number[] = isSelected ? currentIds.filter((id) => id !== skill.id) : [...currentIds, skill.id]
 
-            // Update the racing plan with the changes.
-            updateSkillsSetting("plan", newPlanIds.join(","))
+            updateSkillsSetting(targetKey, newIds.join(","))
         },
-        [planIds, updateSkillsSetting]
+        [selectionMode, planIds, blacklistIds, updateSkillsSetting]
     )
 
     /**
-     * Remove all skills from the current skill plan.
+     * Remove all skills from the currently active list (plan or blacklist).
      */
-    const clearAllSkillsFromPlan = useCallback(() => {
-        updateSkillsSetting("plan", "")
-    }, [updateSkillsSetting])
+    const clearActiveList = useCallback(() => {
+        updateSkillsSetting(selectionMode, "")
+    }, [selectionMode, updateSkillsSetting])
 
     const styles = useMemo(
         () =>
@@ -223,6 +224,40 @@ const SkillPlanSettings: FC<SkillPlanSettingsProps> = ({ planKey, name, title, d
                 inputContainer: {
                     marginBottom: 16,
                 },
+                modeTab: {
+                    flex: 1,
+                    paddingVertical: 10,
+                    borderRadius: 8,
+                    borderWidth: 1,
+                    borderColor: colors.border,
+                    backgroundColor: colors.background,
+                    alignItems: "center",
+                },
+                modeTabActive: {
+                    backgroundColor: colors.primary,
+                    borderColor: colors.primary,
+                },
+                modeTabLabel: {
+                    fontSize: 14,
+                    fontWeight: "600",
+                    color: colors.foreground,
+                },
+                modeTabLabelActive: {
+                    color: colors.background,
+                },
+                summary: {
+                    fontSize: 14,
+                    color: colors.foreground,
+                    marginBottom: 4,
+                    lineHeight: 20,
+                },
+                summaryBullet: {
+                    fontSize: 14,
+                    color: colors.foreground,
+                    marginBottom: 2,
+                    marginLeft: 16,
+                    lineHeight: 20,
+                },
             }),
         [colors]
     )
@@ -246,6 +281,28 @@ const SkillPlanSettings: FC<SkillPlanSettingsProps> = ({ planKey, name, title, d
                         label="Purchase All Negative Skills"
                         description={"When enabled, the bot will attempt to purchase all negative skills (i.e. Firm Conditions ×)."}
                         style={{ marginTop: 16 }}
+                    />
+                </View>
+                <View style={styles.inputContainer}>
+                    <Text style={styles.inputLabel}>Skill Type Filters</Text>
+                    <Text style={[styles.inputDescription, { marginTop: 0, marginBottom: 8 }]}>
+                        Exclude entire skill color categories from purchase. Useful when "Best Skills First" or "Optimize Rank" is picking unwanted skills like debuffs or stat boosts.
+                    </Text>
+                    <CustomCheckbox
+                        searchId={`exclude-green-skills-${name}`}
+                        checked={excludeGreenSkills}
+                        onCheckedChange={(checked) => updateSkillsSetting("excludeGreenSkills", checked)}
+                        label="Skip All Green Skills"
+                        description={"When enabled, no green (stat-trigger) skills will be purchased by this plan."}
+                        style={{ marginTop: 8 }}
+                    />
+                    <CustomCheckbox
+                        searchId={`exclude-red-skills-${name}`}
+                        checked={excludeRedSkills}
+                        onCheckedChange={(checked) => updateSkillsSetting("excludeRedSkills", checked)}
+                        label="Skip All Red Skills (Debuffs)"
+                        description={"When enabled, no red skills (debuffs like Intimidate, Speed Eater, Tether, Intense Gaze) will be purchased by this plan."}
+                        style={{ marginTop: 8 }}
                     />
                 </View>
                 <View style={styles.inputContainer}>
@@ -278,14 +335,57 @@ const SkillPlanSettings: FC<SkillPlanSettingsProps> = ({ planKey, name, title, d
         )
     }
 
+    const renderConfigurationSummary = () => {
+        const strategyLabel: string =
+            strategy === "default" ? "Do Not Spend Remaining Points" : strategy === "optimize_skills" ? "Best Skills First" : strategy === "optimize_rank" ? "Optimize Rank" : strategy
+        const excludedCategories: string[] = []
+        if (excludeGreenSkills) excludedCategories.push("Green")
+        if (excludeRedSkills) excludedCategories.push("Red")
+        const categoryText: string = excludedCategories.length === 0 ? "None" : excludedCategories.join(", ")
+        const idsToNames = (ids: number[]): string[] => ids.map((id) => skillData.find((s) => s.id === id)?.name_en ?? `Unknown (ID ${id})`)
+        const renderSkillBulletList = (header: string, ids: number[]) => {
+            const names = idsToNames(ids)
+            return (
+                <>
+                    <Text style={styles.summary}>
+                        {header} ({ids.length}):
+                    </Text>
+                    {names.length === 0 ? (
+                        <Text style={styles.summaryBullet}>- None</Text>
+                    ) : (
+                        names.map((skillName, i) => (
+                            <Text key={`${header}-${ids[i]}`} style={styles.summaryBullet}>
+                                - {skillName}
+                            </Text>
+                        ))
+                    )}
+                </>
+            )
+        }
+        return (
+            <View style={styles.section}>
+                <Text style={styles.sectionTitle}>Configuration Summary</Text>
+                <Text style={styles.summary}>Strategy: {strategyLabel}</Text>
+                <Text style={styles.summary}>Buy Inherited Unique Skills: {enableBuyInheritedUniqueSkills ? "Yes" : "No"}</Text>
+                <Text style={styles.summary}>Buy Negative Skills: {enableBuyNegativeSkills ? "Yes" : "No"}</Text>
+                <Text style={styles.summary}>Excluded Categories: {categoryText}</Text>
+                {renderSkillBulletList("Planned Skills", planIds)}
+                {renderSkillBulletList("Blacklisted Skills", blacklistIds)}
+            </View>
+        )
+    }
+
     const renderSkillList = () => {
+        const isPlanMode = selectionMode === "plan"
+        const sectionTitle = isPlanMode ? "Planned Skills" : "Blacklisted Skills"
+        const helperText = isPlanMode ? "Select skills that the bot will always attempt to buy." : "Select skills the bot must never purchase, even when a strategy ranks them highly."
         return (
             <View style={styles.section}>
                 <View style={{ flexDirection: "row", alignItems: "center", marginBottom: 12, gap: 12 }}>
                     <View style={{ flex: 1 }}>
-                        <Text style={styles.sectionTitle}>Planned Skills</Text>
+                        <Text style={styles.sectionTitle}>{sectionTitle}</Text>
                         <Text style={[styles.inputDescription, { marginTop: 0 }]}>
-                            Selected {planIds.length} / {filteredSkills.length} skills
+                            Selected {activeIds.length} / {filteredSkills.length} skills
                         </Text>
                     </View>
                     <View style={{ flexDirection: "row", gap: 8 }}>
@@ -295,19 +395,28 @@ const SkillPlanSettings: FC<SkillPlanSettingsProps> = ({ planKey, name, title, d
                     </View>
                 </View>
 
+                <View style={{ flexDirection: "row", marginBottom: 12, gap: 8 }}>
+                    <TouchableOpacity onPress={() => setSelectionMode("plan")} style={[styles.modeTab, isPlanMode && styles.modeTabActive]}>
+                        <Text style={[styles.modeTabLabel, isPlanMode && styles.modeTabLabelActive]}>Plan ({planIds.length})</Text>
+                    </TouchableOpacity>
+                    <TouchableOpacity onPress={() => setSelectionMode("blacklist")} style={[styles.modeTab, !isPlanMode && styles.modeTabActive]}>
+                        <Text style={[styles.modeTabLabel, !isPlanMode && styles.modeTabLabelActive]}>Blacklist ({blacklistIds.length})</Text>
+                    </TouchableOpacity>
+                </View>
+
                 <View style={{ flexDirection: "row", alignItems: "center", marginBottom: 12 }}>
                     <CustomCheckbox
                         searchId={`show-selected-skills-${name}`}
-                        checked={planIds.length === 0 ? false : showSelected}
-                        disabled={planIds.length === 0}
-                        onCheckedChange={(checked) => setShowSelected(checked && planIds.length !== 0)}
+                        checked={activeIds.length === 0 ? false : showSelected}
+                        disabled={activeIds.length === 0}
+                        onCheckedChange={(checked) => setShowSelected(checked && activeIds.length !== 0)}
                         label="Show Only Selected Skills"
                     />
                 </View>
 
                 <View style={{ flexDirection: "row", marginBottom: 12 }}>
                     <View style={{ flex: 1 }}>
-                        <Text style={[styles.inputDescription, { marginTop: 0 }]}>Select skills that the bot will always attempt to buy.</Text>
+                        <Text style={[styles.inputDescription, { marginTop: 0 }]}>{helperText}</Text>
                     </View>
                 </View>
 
@@ -326,7 +435,7 @@ const SkillPlanSettings: FC<SkillPlanSettingsProps> = ({ planKey, name, title, d
                                                 <Text style={styles.skillDescription}>{skill.desc_en}</Text>
                                                 <Text style={styles.skillSubtext}>ID: {skill.id}</Text>
                                             </View>
-                                            {planIds.includes(skill.id) && <CircleCheckBig size={18} color={"green"} />}
+                                            {activeIds.includes(skill.id) && <CircleCheckBig size={18} color={selectionMode === "plan" ? "green" : "red"} />}
                                         </View>
                                     </TouchableOpacity>
                                 ),
@@ -370,6 +479,8 @@ const SkillPlanSettings: FC<SkillPlanSettingsProps> = ({ planKey, name, title, d
                                 {renderOptions()}
                                 <Divider style={{ marginBottom: 16 }} />
                                 {renderSkillList()}
+                                <Divider style={{ marginBottom: 16 }} />
+                                {renderConfigurationSummary()}
                             </>
                         )}
                     </View>


### PR DESCRIPTION
## Description
- This PR adds a per-skill blacklist and color-category exclusions (`Skip All Green Skills`, `Skip All Red Skills (Debuffs)`) to each skill plan so users can stop the bot from buying unwanted skills under "Best Skills First" or "Optimize Rank".
- Each plan page now has a Plan / Blacklist mode toggle that reuses the existing skill list, plus a Configuration Summary section listing the currently planned and blacklisted skills by name.
