### PR TITLE
Add Fans + Epitaphs optimization mode to Smart Race Solver

### DIFF
--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/solver/ScoringFunctions.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/solver/ScoringFunctions.kt
@@ -76,24 +76,21 @@ object ScoringFunctions {
         return weights.statWeight * stat + weights.spWeight * sp
     }
 
-    /** Sub-unit tiebreaker so equal-value races prefer the larger event without ever matching or
-     *  exceeding the smallest meaningful score increment of 1.0. With max fans ~30k and epsilon = 1e-6
-     *  the contribution caps at ~0.03 - well below the 1.0 anti-race bias on Train. */
-    private const val FANS_EPSILON: Double = 1e-6
-
     /**
      * Returns the value of running a single race, ignoring epithet contributions.
      *
-     * Direct port of the reference Trackblazer solver's `weightedRaceValue`:
+     * Direct port of the reference Trackblazer solver's `weightedRaceValue`, extended with a
+     * tunable per-fan term so users can opt into a fan-weighted optimization mode:
      *   gross = statWeight * floor(baseStat * (1 + raceBonus)) + spWeight * floor(baseSp * (1 + raceBonus))
      *   cost  = (raceCostPct / 100) * costBaseline(grade)
-     *   value = (gross - cost) * raceValue + fans * FANS_EPSILON
+     *   value = (gross - cost) * raceValue + fans * fanWeight
      *
-     * With defaults (raceBonus 50, raceCost 100) G2/G3 net to zero gross-cost - they tie with Train
-     * (which carries a tiny positive anti-race bias in [trainValue]) and are skipped unless an
-     * epithet pushes them positive. Maiden/Debut/Finale/EX have zero gross reward so they always
-     * score well below Train. Fans participate only as a microscopic tiebreaker between two races
-     * of identical grade on the same turn.
+     * With defaults (raceBonus 50, raceCost 100, fanWeight 0) G2/G3 net to zero gross-cost - they
+     * tie with Train (which carries a tiny positive anti-race bias in [trainValue]) and are skipped
+     * unless an epithet pushes them positive. Maiden/Debut/Finale/EX have zero gross reward so they
+     * always score well below Train. With `fanWeight = 0.0` the legacy "Stat Epitaphs" behavior is
+     * preserved; with a non-zero `fanWeight` (the "Fans + Epitaphs" preset uses 1e-3) fan-rich races
+     * such as G1s become more attractive without dominating epithet contributions.
      *
      * @param race Race candidate to score.
      * @param weights Active scoring weights.
@@ -106,14 +103,16 @@ object ScoringFunctions {
         val sp = Math.floor(baseSp(race.grade) * (1.0 + rb))
         val gross = weights.statWeight * stat + weights.spWeight * sp
         val cost = weights.raceCostPct / 100.0 * costBaseline(race.grade, weights)
-        return (gross - cost) * weights.raceValue + race.fans * FANS_EPSILON
+        return (gross - cost) * weights.raceValue + race.fans * weights.fanWeight
     }
 
     /**
-     * Training is the default action. Returns a tiny positive value (`1.0`, larger than the largest
-     * possible [FANS_EPSILON] contribution from the most popular race) so that whenever a race's
-     * gross reward equals its cost, Train wins the tie. The reference solver achieves the same
-     * effect via GLPK's MILP picking `NO_RACE` on ties.
+     * Training is the default action. Returns a constant `1.0` anti-race bias so that whenever a
+     * race's `(gross - cost) * raceValue + fans * fanWeight` equals zero, Train wins the tie. With
+     * the default Stat Epitaphs preset (`fanWeight = 0`) this matches legacy behavior; with a
+     * non-zero `fanWeight` the user has explicitly asked the solver to weigh fans, so Train no
+     * longer auto-wins fan-heavy ties. The reference solver achieves the same effect via GLPK's
+     * MILP picking `NO_RACE` on ties.
      *
      * @param weights Active weights (currently unused, reserved for future tuning).
      * @return Constant `1.0`.

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/solver/SmartRaceSolverIntegration.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/solver/SmartRaceSolverIntegration.kt
@@ -873,6 +873,7 @@ object SmartRaceSolverIntegration {
             summerPenalty = obj.optDouble("summerPenalty", 5.0),
             raceBonusPct = obj.optDouble("raceBonusPct", 50.0),
             raceCostPct = obj.optDouble("raceCostPct", 100.0),
+            fanWeight = obj.optDouble("fanWeight", 0.0),
             aptitudeThreshold = parseAptitude(obj.optString("aptitudeThreshold", "C")),
             includeOpAndPreOp = obj.optBoolean("includeOpAndPreOp", false),
             allowSummerRacing = obj.optBoolean("allowSummerRacing", false),

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/solver/SolverState.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/solver/SolverState.kt
@@ -81,6 +81,9 @@ data class Aptitudes(
  * @property summerPenalty Penalty for racing on a turn in [SolverState.summerBlockTurns].
  * @property raceBonusPct Percentage uplift applied to base stat/sp rewards before weighting.
  * @property raceCostPct Per-race cost expressed as a percentage of the weighted G2 baseline.
+ * @property fanWeight Per-fan score contribution applied to a race's reward fans. 0.0 means fans are ignored entirely (Stat Epitaphs preset default).
+ *   1e-3 (Fans + Epitaphs preset) makes a 25k-fan G1 contribute ~25 score points - meaningful but not dominant. Above 5e-3 the solver will
+ *   race almost every eligible turn.
  * @property aptitudeThreshold Minimum aptitude grade required for both distance and surface
  *   for a race to be eligible.
  * @property includeOpAndPreOp When true, OP/Pre-OP races are eligible (subject to the threshold).
@@ -96,6 +99,7 @@ data class Weights(
     val summerPenalty: Double = 5.0,
     val raceBonusPct: Double = 50.0,
     val raceCostPct: Double = 100.0,
+    val fanWeight: Double = 0.0,
     val aptitudeThreshold: Aptitude = Aptitude.C,
     val includeOpAndPreOp: Boolean = false,
     val allowSummerRacing: Boolean = false,
@@ -114,7 +118,7 @@ data class Weights(
  * @property terrain Track surface: Turf or Dirt.
  * @property distanceType Distance category: Sprint, Mile, Medium, or Long.
  * @property distanceMeters Race distance in meters.
- * @property fans Reward fans count. Participates in scoring as a microscopic tiebreaker.
+ * @property fans Reward fans count. Scaled by [Weights.fanWeight] in [ScoringFunctions.raceValue].
  * @property turnNumber Turn the race takes place on (1..72).
  */
 data class RaceCandidate(

--- a/android/app/src/test/java/com/steve1316/uma_android_automation/bot/solver/HeuristicTest.kt
+++ b/android/app/src/test/java/com/steve1316/uma_android_automation/bot/solver/HeuristicTest.kt
@@ -83,8 +83,8 @@ class HeuristicTest {
 
     @Test
     fun trainBeatsLowGradeRaceUnderDefaultWeights() {
-        // Pre-OP under default weights: gross 22, cost 49 → ~-27, plus 0.5 fans tiebreaker.
-        // Train is 0, so Train wins.
+        // Pre-OP under default weights (fanWeight = 0.0): gross 22, cost 49 -> ~ -27 net.
+        // Train is +1.0, so Train wins.
         val weak = race("Weak Pre-OP", 30, grade = RaceGrade.PRE_OP, fans = 500)
         val st = state(currentTurn = 30, races = listOf(weak), epithets = emptyList())
         val schedule = Heuristic.search(st)
@@ -93,13 +93,32 @@ class HeuristicTest {
 
     @Test
     fun highGradeRaceBeatsTrainUnderDefaultWeights() {
-        // G1 under default weights: gross 67, cost 49 → 18, plus 50 fans tiebreaker → ~68.
-        // Train is 0, so the race wins.
+        // G1 under default weights (fanWeight = 0.0): gross 67, cost 49 -> 18 net (no fan term).
+        // Train is +1.0, so the race wins.
         val g1 = race("Big G1", 30, grade = RaceGrade.G1, fans = 50000)
         val st = state(currentTurn = 30, races = listOf(g1), epithets = emptyList())
         val schedule = Heuristic.search(st)
         val pick = schedule.decisions[30]
         assertTrue(pick is Decision.RaceDecision && pick.raceKey == g1.key)
+    }
+
+    @Test
+    fun fansEpithPresetFlipsZeroNetG3FromTrainToRace() {
+        // G3 under default weights nets exactly zero gross-cost and loses to Train (+1.0). With the
+        // FANS_EPITAPH preset (fanWeight = 1e-3) a 5k-fan G3 contributes +5 from fans, beating Train.
+        val g3 = race("G3", 30, grade = RaceGrade.G3, fans = 5000)
+        val statMode = state(currentTurn = 30, races = listOf(g3), epithets = emptyList())
+        val fanMode =
+            state(
+                currentTurn = 30,
+                races = listOf(g3),
+                epithets = emptyList(),
+                weights = Weights(fanWeight = 1e-3),
+            )
+
+        assertEquals(Decision.Train, Heuristic.search(statMode).decisions[30])
+        val pick = Heuristic.search(fanMode).decisions[30]
+        assertTrue(pick is Decision.RaceDecision && pick.raceKey == g3.key)
     }
 
     @Test

--- a/android/app/src/test/java/com/steve1316/uma_android_automation/bot/solver/ScoringFunctionsTest.kt
+++ b/android/app/src/test/java/com/steve1316/uma_android_automation/bot/solver/ScoringFunctionsTest.kt
@@ -23,10 +23,42 @@ class ScoringFunctionsTest {
     }
 
     @Test
-    fun raceValueScalesWithFans() {
+    fun raceValueWithFanWeightZeroIgnoresFans() {
+        // Default fanWeight is 0.0 (Stat Epitaphs preset): two races of identical grade with
+        // very different fan counts must produce equal raceValue.
         val small = race("Small", 20, fans = 1000)
         val big = race("Big", 20, fans = 50000)
-        assertTrue(ScoringFunctions.raceValue(big, w) > ScoringFunctions.raceValue(small, w))
+        assertEquals(ScoringFunctions.raceValue(small, w), ScoringFunctions.raceValue(big, w), 1e-9)
+    }
+
+    @Test
+    fun raceValueScalesWithFansWhenFanWeightIsPositive() {
+        // With any positive fanWeight, a fan-rich race outscores a fan-poor race of the same grade.
+        val tunedWeights = Weights(fanWeight = 1e-6)
+        val small = race("Small", 20, fans = 1000)
+        val big = race("Big", 20, fans = 50000)
+        assertTrue(ScoringFunctions.raceValue(big, tunedWeights) > ScoringFunctions.raceValue(small, tunedWeights))
+    }
+
+    @Test
+    fun fansEpithPresetMakesG1MeaningfullyOutscoreG3() {
+        // FANS_EPITAPH preset (fanWeight = 1e-3): a 25k-fan G1 should outscore a 5k-fan G3 by a
+        // margin that survives Train's 1.0 anti-race bias even when their gross-cost happens to tie.
+        val tunedWeights = Weights(fanWeight = 1e-3)
+        val g1 = race("G1", 30, grade = RaceGrade.G1, fans = 25000)
+        val g3 = race("G3", 30, grade = RaceGrade.G3, fans = 5000)
+        val delta = ScoringFunctions.raceValue(g1, tunedWeights) - ScoringFunctions.raceValue(g3, tunedWeights)
+        assertTrue(delta > 1.0, "G1-G3 score delta under fanWeight=1e-3 should exceed Train's 1.0 floor; was $delta")
+    }
+
+    @Test
+    fun fansEpithPresetKeepsZeroRewardGradesBelowTrain() {
+        // Grades outside the BASE_REWARD table (Maiden, Debut, Finale, EX) have zero gross reward
+        // but are charged the G2 cost baseline (~49 score points). Even with the FANS_EPITAPH
+        // preset's fanWeight = 1e-3 and a fan-rich Maiden, raceValue stays well below Train.
+        val tunedWeights = Weights(fanWeight = 1e-3)
+        val maiden = race("Maiden", 30, grade = RaceGrade.MAIDEN, fans = 5000)
+        assertTrue(ScoringFunctions.raceValue(maiden, tunedWeights) < ScoringFunctions.trainValue(tunedWeights))
     }
 
     @Test
@@ -60,12 +92,14 @@ class ScoringFunctionsTest {
     }
 
     @Test
-    fun lowGradeRaceValueIsNegative() {
-        // Pre-OP / OP races should score below zero so Train (value 0) is preferred.
+    fun lowGradeRaceValueLosesToTrain() {
+        // OP/Pre-OP cost baselines equal their own gross reward, so net is exactly zero under
+        // default weights and `fanWeight = 0.0`. Train (+1.0) wins the tie.
         val preOp = race("PreOp", 20, grade = RaceGrade.PRE_OP, fans = 500)
         val op = race("Op", 20, grade = RaceGrade.OP, fans = 1000)
-        assertTrue(ScoringFunctions.raceValue(preOp, w) < 0.0)
-        assertTrue(ScoringFunctions.raceValue(op, w) < 0.0)
+        val trainValue = ScoringFunctions.trainValue(w)
+        assertTrue(ScoringFunctions.raceValue(preOp, w) < trainValue)
+        assertTrue(ScoringFunctions.raceValue(op, w) < trainValue)
     }
 
     @Test

--- a/src/context/BotStateContext.tsx
+++ b/src/context/BotStateContext.tsx
@@ -272,6 +272,7 @@ export const defaultSettings: Settings = {
             summerPenalty: 5.0,
             raceBonusPct: 50.0,
             raceCostPct: 100.0,
+            fanWeight: 0.0,
             aptitudeThreshold: "C",
             includeOpAndPreOp: false,
             allowSummerRacing: false,

--- a/src/context/searchConfig.ts
+++ b/src/context/searchConfig.ts
@@ -480,9 +480,16 @@ const searchConfig: SearchOption[] = [
         parentId: "enable-smart-race-solver",
     },
     {
+        id: "smart-solver-optimize-mode",
+        title: "Optimization Mode",
+        description: "Pick whether the Smart Race Solver chases stat epitaphs only or also emphasizes fan-heavy races (G1s, big G3s) alongside epitaphs. Switching modes snaps the editable weight sliders to a fresh preset; you can still tune each slider afterward.",
+        page: "SmartRaceSolverSettings",
+        parentId: "enable-smart-race-solver",
+    },
+    {
         id: "smart-solver-weights",
         title: "Scoring Weights",
-        description: "Advanced multipliers for how the solver balances race rewards, epithet completion, and penalties for racing too often or in summer.",
+        description: "Advanced multipliers for how the solver balances race rewards, epithet completion, fan rewards, and penalties for racing too often or in summer.",
         page: "SmartRaceSolverSettings",
         parentId: "enable-smart-race-solver",
     },

--- a/src/lib/messageLog/buildSettingsBanner.ts
+++ b/src/lib/messageLog/buildSettingsBanner.ts
@@ -45,11 +45,13 @@ export function buildSettingsBanner(settings: Settings): string {
     const smartRaceSolverLockCount = safeJsonLength(settings.racing.smartRaceSolverManualLocks)
     const smartRaceSolverWeightsObj = (() => {
         try {
-            return JSON.parse(settings.racing.smartRaceSolverWeights || "{}") as Record<string, number | string>
+            return JSON.parse(settings.racing.smartRaceSolverWeights || "{}") as Record<string, number | string | boolean>
         } catch {
-            return {} as Record<string, number | string>
+            return {} as Record<string, number | string | boolean>
         }
     })()
+    const smartRaceSolverFanWeight = typeof smartRaceSolverWeightsObj.fanWeight === "number" ? smartRaceSolverWeightsObj.fanWeight : 0
+    const smartRaceSolverOptimizeMode = smartRaceSolverFanWeight > 0 ? "Fans + Epitaphs" : "Stat Epitaphs"
     const smartRaceSolverAptitudesObj = (() => {
         try {
             return JSON.parse(settings.racing.smartRaceSolverAptitudes || "{}") as Record<string, string>
@@ -149,7 +151,8 @@ ${longTargetsString}
 🤖 Enable Smart Race Solver: ${settings.racing.enableSmartRaceSolver ? "✅" : "❌"}
 🎭 Solver Character Preset: ${settings.racing.smartRaceSolverCharacterPreset || "(none)"}
 🐎 Solver Aptitudes: Spr ${smartRaceSolverAptitudesObj.Sprint ?? "?"}, Mile ${smartRaceSolverAptitudesObj.Mile ?? "?"}, Med ${smartRaceSolverAptitudesObj.Medium ?? "?"}, Lng ${smartRaceSolverAptitudesObj.Long ?? "?"}, Trf ${smartRaceSolverAptitudesObj.Turf ?? "?"}, Drt ${smartRaceSolverAptitudesObj.Dirt ?? "?"}
-⚖️ Solver Weights: race ${smartRaceSolverWeightsObj.raceValue ?? "?"}, epithet ${smartRaceSolverWeightsObj.epithetValue ?? "?"}, hint ${smartRaceSolverWeightsObj.hintWeight ?? "?"}, consec −${smartRaceSolverWeightsObj.consecutiveRacePenalty ?? "?"}, summer −${smartRaceSolverWeightsObj.summerPenalty ?? "?"}, raceBonus ${smartRaceSolverWeightsObj.raceBonusPct ?? "?"}%, raceCost ${smartRaceSolverWeightsObj.raceCostPct ?? "?"}%, threshold ${smartRaceSolverWeightsObj.aptitudeThreshold ?? "?"}, includeOP ${smartRaceSolverWeightsObj.includeOpAndPreOp ? "✅" : "❌"}, summerRacing ${smartRaceSolverWeightsObj.allowSummerRacing ? "✅" : "❌"}
+🎯 Solver Optimize Mode: ${smartRaceSolverOptimizeMode}
+⚖️ Solver Weights: race ${smartRaceSolverWeightsObj.raceValue ?? "?"}, epithet ${smartRaceSolverWeightsObj.epithetValue ?? "?"}, fans ${smartRaceSolverWeightsObj.fanWeight ?? 0}, hint ${smartRaceSolverWeightsObj.hintWeight ?? "?"}, consec −${smartRaceSolverWeightsObj.consecutiveRacePenalty ?? "?"}, summer −${smartRaceSolverWeightsObj.summerPenalty ?? "?"}, raceBonus ${smartRaceSolverWeightsObj.raceBonusPct ?? "?"}%, raceCost ${smartRaceSolverWeightsObj.raceCostPct ?? "?"}%, threshold ${smartRaceSolverWeightsObj.aptitudeThreshold ?? "?"}, includeOP ${smartRaceSolverWeightsObj.includeOpAndPreOp ? "✅" : "❌"}, summerRacing ${smartRaceSolverWeightsObj.allowSummerRacing ? "✅" : "❌"}
 🎯 Solver Target Epithets: ${smartRaceSolverTargetCount} selected
 🚨 Solver Forced Epithets: ${smartRaceSolverForcedCount} selected
 🔒 Solver Manual Turn Locks: ${smartRaceSolverLockCount} locked turn(s)

--- a/src/lib/solver/constants.ts
+++ b/src/lib/solver/constants.ts
@@ -86,6 +86,9 @@ export interface WeightsMap {
     raceBonusPct: number
     /** Cost subtracted from each race's reward, expressed as a percentage of a G2 baseline. */
     raceCostPct: number
+    /** Per-fan score contribution applied to a race's reward fans. 0.0 ignores fans entirely (Stat Epitaphs preset default).
+     *  1e-3 (Fans + Epitaphs preset) makes a 25k-fan G1 contribute ~25 score points - meaningful but not dominant. */
+    fanWeight: number
     /** Minimum aptitude rank (S..G) a race needs in BOTH its distance type and surface to be eligible. */
     aptitudeThreshold: string
     /** When true, OP and Pre-OP races are also considered alongside G1 / G2 / G3. */
@@ -116,6 +119,8 @@ export interface PreviewStats {
     epithetStats: number
     /** Number of skill hints earned via hint-reward epithets. */
     hints: number
+    /** Sum of reward fans across all scheduled races. */
+    fans: number
 }
 
 // //////////////////////////////////////////////////////////////////////////////////////////////////
@@ -160,9 +165,28 @@ export const DEFAULT_WEIGHTS: WeightsMap = {
     summerPenalty: 5.0,
     raceBonusPct: 50.0,
     raceCostPct: 100.0,
+    fanWeight: 0.0,
     aptitudeThreshold: "C",
     includeOpAndPreOp: false,
     allowSummerRacing: false,
+}
+
+/** Named optimization-mode presets for the Smart Race Solver. Selecting a mode in the UI snaps the
+ *  editable weight sliders to the corresponding bundle; the user can still override individual
+ *  sliders afterward. The mode itself is not persisted as a separate setting - it is derived from
+ *  `weights.fanWeight > 0`, which keeps the stored state and UI in sync. */
+export const OPTIMIZE_MODE_PRESETS: Record<"STAT_EPITAPH" | "FANS_EPITAPH", Partial<WeightsMap>> = {
+    STAT_EPITAPH: { raceValue: 1.0, epithetValue: 1.0, fanWeight: 0.0 },
+    FANS_EPITAPH: { raceValue: 1.0, epithetValue: 1.0, fanWeight: 1.0e-3 },
+}
+
+/** Key identifying which optimization-mode preset is active. */
+export type OptimizeModeKey = keyof typeof OPTIMIZE_MODE_PRESETS
+
+/** Display labels for each optimization mode (used by the radio toggle in SmartRaceSolverSettings and the MessageLog banner). */
+export const OPTIMIZE_MODE_LABELS: Record<OptimizeModeKey, string> = {
+    STAT_EPITAPH: "Stat Epitaphs",
+    FANS_EPITAPH: "Fans + Epitaphs",
 }
 
 /** The sentinel a manual-lock entry takes to lock a turn to Train / no race. The Kotlin parser understands this as `Decision.Train`.

--- a/src/lib/solver/preview.ts
+++ b/src/lib/solver/preview.ts
@@ -38,6 +38,8 @@ export interface SolverConfigSnapshot {
         raceBonusPct: number
         /** Cost subtracted from each race's reward, expressed as a percentage of a G2 baseline. */
         raceCostPct: number
+        /** Per-fan score contribution applied to a race's reward fans. 0.0 ignores fans entirely (Stat Epitaphs preset default). */
+        fanWeight: number
         /** Minimum aptitude rank (S..G) a race needs in BOTH its distance type and surface to be eligible. */
         aptitudeThreshold: string
         /** When true, OP and Pre-OP races are also considered alongside G1 / G2 / G3. */

--- a/src/lib/solver/scoring.ts
+++ b/src/lib/solver/scoring.ts
@@ -602,6 +602,7 @@ export const computePreviewStats = (preview: SchedulePreview, weights: Pick<Weig
     let races = 0
     let raceStats = 0
     let raceSp = 0
+    let fans = 0
     for (const [, entry] of Object.entries(preview.decisions)) {
         if (entry.type !== "Race") continue
         races += 1
@@ -609,6 +610,7 @@ export const computePreviewStats = (preview: SchedulePreview, weights: Pick<Weig
         const grade = (race?.grade ?? entry.grade ?? "").replace("-", "_")
         raceStats += Math.floor((BASE_STAT_BY_GRADE[grade] ?? 0) * (1 + rb))
         raceSp += Math.floor((BASE_SP_BY_GRADE[grade] ?? 0) * (1 + rb))
+        fans += race?.fans ?? 0
     }
     let epithetStats = 0
     let hints = 0
@@ -619,5 +621,5 @@ export const computePreviewStats = (preview: SchedulePreview, weights: Pick<Weig
         if (kind === "stat") epithetStats += amount
         else if (kind === "hint") hints += 1
     }
-    return { races, epithets: preview.projectedEpithets.length, raceStats, raceSp, epithetStats, hints }
+    return { races, epithets: preview.projectedEpithets.length, raceStats, raceSp, epithetStats, hints, fans }
 }

--- a/src/pages/SmartRaceSolverSettings/index.tsx
+++ b/src/pages/SmartRaceSolverSettings/index.tsx
@@ -10,6 +10,9 @@ import {
     DEFAULT_WEIGHTS,
     EpithetEntry,
     GRADE_COLORS,
+    OPTIMIZE_MODE_LABELS,
+    OPTIMIZE_MODE_PRESETS,
+    OptimizeModeKey,
     RaceEntry,
     shortenRaceName,
     TRAIN_LOCK_SENTINEL,
@@ -183,6 +186,7 @@ const SmartRaceSolverSettings = () => {
     const [summerPenaltyInput, setSummerPenaltyInput] = useState(weights.summerPenalty.toString())
     const [raceBonusPctInput, setRaceBonusPctInput] = useState(weights.raceBonusPct.toString())
     const [raceCostPctInput, setRaceCostPctInput] = useState(weights.raceCostPct.toString())
+    const [fanWeightInput, setFanWeightInput] = useState(weights.fanWeight.toString())
 
     useEffect(() => setRaceValueInput(weights.raceValue.toString()), [weights.raceValue])
     useEffect(() => setEpithetValueInput(weights.epithetValue.toString()), [weights.epithetValue])
@@ -191,6 +195,10 @@ const SmartRaceSolverSettings = () => {
     useEffect(() => setSummerPenaltyInput(weights.summerPenalty.toString()), [weights.summerPenalty])
     useEffect(() => setRaceBonusPctInput(weights.raceBonusPct.toString()), [weights.raceBonusPct])
     useEffect(() => setRaceCostPctInput(weights.raceCostPct.toString()), [weights.raceCostPct])
+    useEffect(() => setFanWeightInput(weights.fanWeight.toString()), [weights.fanWeight])
+
+    /** Derived optimization mode. Mode is not persisted - it falls out of the weights so the radio toggle and the slider can never disagree. */
+    const currentOptimizeMode: OptimizeModeKey = weights.fanWeight > 0.0 ? "FANS_EPITAPH" : "STAT_EPITAPH"
 
     const [presetSearch, setPresetSearch] = useState("")
     const [epithetSearch, setEpithetSearch] = useState("")
@@ -384,6 +392,17 @@ const SmartRaceSolverSettings = () => {
      */
     const updateWeight = (key: keyof WeightsMap, value: number | string | boolean) => {
         updateRacingSetting("smartRaceSolverWeights", JSON.stringify({ ...weights, [key]: value }))
+    }
+
+    /**
+     * Snap the editable weight sliders to the named optimization-mode preset. The user can still override individual sliders afterward
+     * (the radio is derived from `weights.fanWeight > 0`, so manually tuning fanWeight back to 0 flips the radio without an extra click).
+     *
+     * @param mode Optimization mode key whose preset bundle should be applied.
+     */
+    const setOptimizeMode = (mode: OptimizeModeKey) => {
+        const preset = OPTIMIZE_MODE_PRESETS[mode]
+        updateRacingSetting("smartRaceSolverWeights", JSON.stringify({ ...weights, ...preset }))
     }
 
     // //////////////////////////////////////////////////////////////////////////////////////////////////
@@ -737,9 +756,9 @@ const SmartRaceSolverSettings = () => {
                 epithetCardReward: { fontSize: 11, color: colors.foreground, marginBottom: 1 },
                 epithetCardCondition: { fontSize: 11, color: colors.mutedForeground, fontStyle: "italic" },
                 epithetCardConditionItem: { fontSize: 11, color: colors.mutedForeground, fontStyle: "italic", marginLeft: 8 },
-                statsRow: { flexDirection: "row", alignItems: "center", justifyContent: "space-between", flexWrap: "nowrap", marginVertical: 6, paddingHorizontal: 2 },
-                statsCell: { flexDirection: "row", alignItems: "baseline", flexShrink: 1, paddingHorizontal: 2 },
-                statsLabel: { fontSize: 13, color: colors.mutedForeground, marginRight: 4 },
+                statsRow: { flexDirection: "row", flexWrap: "wrap", alignItems: "flex-start", marginVertical: 6, paddingHorizontal: 2, columnGap: 12, rowGap: 8 },
+                statsCell: { flexDirection: "column", alignItems: "flex-start", minWidth: 70, flexShrink: 1 },
+                statsLabel: { fontSize: 11, color: colors.mutedForeground, marginBottom: 2 },
                 statsValue: { fontSize: 16, color: colors.foreground, fontWeight: "700" },
                 popoverTitle: { fontSize: 15, fontWeight: "700", color: colors.foreground },
                 popoverMeta: { fontSize: 12, color: colors.mutedForeground, marginTop: 4 },
@@ -994,7 +1013,7 @@ const SmartRaceSolverSettings = () => {
             <PageHeader title="Smart Race Solver" />
 
             <SearchPageProvider page="SmartRaceSolverSettings" scrollViewRef={scrollViewRef}>
-                <ScrollView ref={scrollViewRef} nestedScrollEnabled={true} showsVerticalScrollIndicator={false} contentContainerStyle={{ flexGrow: 1, paddingBottom: 80 }}>
+                <ScrollView ref={scrollViewRef} nestedScrollEnabled={true} showsVerticalScrollIndicator={false} contentContainerStyle={{ flexGrow: 1, paddingBottom: dirty ? 80 : 24 }}>
                     <View className="m-1">
                         {/* Master toggle */}
                         <SearchableItem
@@ -1225,13 +1244,42 @@ const SmartRaceSolverSettings = () => {
                                     </View>
                                 </SearchableItem>
 
+                                {/* Optimization mode */}
+                                <SearchableItem
+                                    id="smart-solver-optimize-mode"
+                                    condition={enableSmartRaceSolver}
+                                    parentId="enable-smart-race-solver"
+                                    title="Optimization Mode"
+                                    description="Pick whether the solver chases stat epitaphs or also emphasizes fan-heavy races."
+                                    style={styles.section}
+                                >
+                                    <View style={sectionsDisabledStyle}>
+                                        <Text style={styles.sectionTitle}>Optimize for</Text>
+                                        <View style={styles.aptButtons}>
+                                            {(Object.keys(OPTIMIZE_MODE_PRESETS) as OptimizeModeKey[]).map((mode) => {
+                                                const active = currentOptimizeMode === mode
+                                                return (
+                                                    <TouchableOpacity key={mode} style={[styles.aptBtn, active && styles.aptBtnActive]} onPress={() => setOptimizeMode(mode)}>
+                                                        <Text style={active ? styles.aptBtnTextActive : styles.aptBtnText}>{OPTIMIZE_MODE_LABELS[mode]}</Text>
+                                                    </TouchableOpacity>
+                                                )
+                                            })}
+                                        </View>
+                                        <Text style={[styles.inputDescription, { marginBottom: 0, marginTop: 8 }]}>
+                                            Stat Epitaphs (default) optimizes purely for stat-bearing epithets and ignores reward fans. Fans + Epitaphs adds a per-fan score so fan-rich races (G1s, big
+                                            G3s) become more attractive alongside epithets. Switching modes snaps the editable Race Value, Epithet Value, and Fan Weight sliders to a fresh preset; you
+                                            can still tune each slider afterward, and tapping the active mode again resets back to the preset.
+                                        </Text>
+                                    </View>
+                                </SearchableItem>
+
                                 {/* Weights */}
                                 <SearchableItem
                                     id="smart-solver-weights"
                                     condition={enableSmartRaceSolver}
                                     parentId="enable-smart-race-solver"
                                     title="Scoring Weights"
-                                    description="Tune how the solver balances race value, epithet completion, and penalties."
+                                    description="Tune how the solver balances race value, epithet completion, fan rewards, and penalties."
                                     style={styles.section}
                                 >
                                     <View style={sectionsDisabledStyle}>
@@ -1273,6 +1321,20 @@ const SmartRaceSolverSettings = () => {
                                                             <Text style={styles.inputDescription}>
                                                                 Multiplier on epithet stat rewards. Default 1.0 weights an epithet's stats equally with race stats. Raise to 5.0 if you want the solver
                                                                 to chase epithets even at the cost of fewer total races.
+                                                            </Text>
+
+                                                            <Text style={styles.inputLabel}>Fan Weight</Text>
+                                                            <Input
+                                                                style={styles.input}
+                                                                value={fanWeightInput}
+                                                                onChangeText={(t) => /^-?\d*\.?\d*$/.test(t) && setFanWeightInput(t)}
+                                                                onBlur={() => updateWeight("fanWeight", parseFloat(fanWeightInput) || 0)}
+                                                                keyboardType="decimal-pad"
+                                                                placeholder="0.0"
+                                                            />
+                                                            <Text style={styles.inputDescription}>
+                                                                Score per fan earned from a race. Default 0.0 ignores fans entirely (Stat Epitaphs preset). 0.001 (Fans + Epitaphs preset) makes a
+                                                                25k-fan G1 worth ~25 score points - meaningful but not dominant. Above 0.005 the solver will race almost every eligible turn.
                                                             </Text>
 
                                                             <Text style={styles.inputLabel}>Hint Reward Weight</Text>
@@ -1369,6 +1431,11 @@ const SmartRaceSolverSettings = () => {
                                             Preview of the schedule the solver would start with. Tap a cell to lock it, delete its pick, or switch to an alternative race. Does not reflect mid-run
                                             dynamic re-planning.
                                         </Text>
+                                        {!previewLoading && !previewError && preview && previewStats && (
+                                            <Text style={[styles.inputDescription, { fontStyle: "italic", marginTop: 2 }]}>
+                                                Note: Projected Fan Gain is the raw sum of each scheduled race's base fan reward and does not factor in in-game fan bonuses and other fan sources. Actual fans earned during a run will be higher.
+                                            </Text>
+                                        )}
                                         {dirty && (
                                             <WarningContainer>Settings have changed - the calendar needs to be regenerated. Tap Recalculate to refresh the preview and apply changes.</WarningContainer>
                                         )}
@@ -1404,6 +1471,10 @@ const SmartRaceSolverSettings = () => {
                                                 <View style={styles.statsCell}>
                                                     <Text style={styles.statsLabel}>Hints</Text>
                                                     <Text style={styles.statsValue}>{previewStats.hints}</Text>
+                                                </View>
+                                                <View style={styles.statsCell}>
+                                                    <Text style={styles.statsLabel}>Projected Fan Gain</Text>
+                                                    <Text style={styles.statsValue}>{previewStats.fans.toLocaleString()}</Text>
                                                 </View>
                                                 <View style={styles.statsCell}>
                                                     <Text style={styles.statsLabel}>Score</Text>
@@ -1541,9 +1612,10 @@ const SmartRaceSolverSettings = () => {
                                                       .map(([t, r]) => `T${t}→${r}`)
                                                       .join(" · ")}
                                         </Text>
+                                        <Text style={styles.summary}>Mode: {OPTIMIZE_MODE_LABELS[currentOptimizeMode]}</Text>
                                         <Text style={styles.summary}>
-                                            Weights: race {weights.raceValue}, epithet {weights.epithetValue}, hint {weights.hintWeight}, consec −{weights.consecutiveRacePenalty}, summer −
-                                            {weights.summerPenalty}, raceBonus {weights.raceBonusPct}%, raceCost {weights.raceCostPct}%
+                                            Weights: race {weights.raceValue}, epithet {weights.epithetValue}, fans {weights.fanWeight}, hint {weights.hintWeight}, consec -
+                                            {weights.consecutiveRacePenalty}, summer -{weights.summerPenalty}, raceBonus {weights.raceBonusPct}%, raceCost {weights.raceCostPct}%
                                         </Text>
                                     </View>
                                 </SearchableItem>


### PR DESCRIPTION
## Description

- This PR adds a new `Fans + Epitaphs` optimization mode to the `Smart Race Solver` so users can bias the 72-turn schedule toward fan-heavy races like G1s alongside stat-epitaph completion.
- The schedule preview now also shows a `Projected Fan Gain` total (raw race-card sums; in-game fan bonuses from supports / characters / events are not factored in).
