### PR TITLE
Fix bot proceeding with stale state when injury heal races with loading screen

### DIFF
--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Campaign.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Campaign.kt
@@ -1078,11 +1078,10 @@ abstract class Campaign(game: Game) : Task(game) {
 
                     if (IconInfirmaryEventHeader.check(game.imageUtils)) {
                         MessageLog.v(TAG, "[INJURY] Injury detected and attempted to heal.")
-                        true
                     } else {
-                        MessageLog.w(TAG, "[WARN] checkInjury:: Injury detected but failed to detect Infirmary event.")
-                        false
+                        MessageLog.v(TAG, "[INJURY] Injury detected and no follow-up Infirmary event appeared.")
                     }
+                    true
                 } else {
                     MessageLog.w(TAG, "[WARN] checkInjury:: Injury detected but failed to click Infirmary button.")
                     false


### PR DESCRIPTION
## Description
- This PR fixes a bug where `checkInjury()` returned `false` after a successful heal because the post-click `IconInfirmaryEventHeader` check raced with a "Connecting" loading screen, causing `getMainScreenAction()` to skip its `MainScreenAction.NONE` early-exit and fall through to racing/training with stale screen state. The click success is now the authoritative signal that an injury was handled, and the header check is retained as a log-only diagnostic.

```
00:39:39.142 [INFO] [INJURY] Checking if there is an injury that needs healing on SENIOR YEAR EARLY FEBRUARY (Turn 51).
00:39:39.171 [VERBOSE] [INJURY] Injury detected. Attempting to heal...
00:39:39.830 [INFO] [LOADING] Detected that the game is awaiting a response from the server from the "Connecting" text at the top of the screen. Waiting...
00:39:40.727 [WARN] [WARN] checkInjury:: Injury detected but failed to detect Infirmary event.
00:39:40.727 [INFO] [RACE] Now determining eligibility to start the extra racing process...
00:39:41.612 [ERROR] [ERROR] handleRaceEvents:: Failed to click Races button.
```
