### PR TITLE
Fix Trackblazer megaphone counter not decrementing on mandatory races

### DIFF
--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/Trackblazer.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/Trackblazer.kt
@@ -884,7 +884,13 @@ class Trackblazer(game: Game) : Campaign(game) {
             // If we are, we should treat it as a mandatory race and NOT an extra race.
             if (IconRaceDayRibbon.check(game.imageUtils, sourceBitmap = sourceBitmap) || IconGoalRibbon.check(game.imageUtils, sourceBitmap = sourceBitmap)) {
                 MessageLog.i(TAG, "[TRACKBLAZER] Mandatory race ribbon detected. Processing as mandatory race.")
-                return super.handleRaceEvents(true)
+                val result = super.handleRaceEvents(true)
+                // Mandatory races bypass executeAction(), so decrement the megaphone counter here to match the per-turn decrement applied to other actions.
+                if (result && trainee.megaphoneTurnCounter > 0) {
+                    trainee.megaphoneTurnCounter--
+                    MessageLog.i(TAG, "[TRACKBLAZER] Megaphone duration reduced. Turns remaining: ${trainee.megaphoneTurnCounter}.")
+                }
+                return result
             }
 
             MessageLog.i(TAG, "[TRACKBLAZER] Checking for suitable races.")


### PR DESCRIPTION
## Description
- This PR fixes a bug where the `megaphoneTurnCounter` in Trackblazer was only decremented after trainings and voluntary races, but never after mandatory races, leaving the counter stuck higher than the buff's true remaining duration.
- The mandatory-race branch in `handleRaceEvents()` now captures the result of `super.handleRaceEvents(true)` and applies the same per-turn decrement that `executeAction()` already applies for trainings and voluntary races, so any subsequent megaphone queue decision is made against an accurate counter.

Before the fix, a Coaching Megaphone (4-turn buff) queued on Turn 73 produced only 3 decrements over 5 turn-advancing actions because the two mandatory races silently skipped the decrement:

```
01:02:44.103 [INFO] [TRACKBLAZER] Megaphone duration reduced. Turns remaining: 3.   <-- Turn 73 WIT training
(Turn 73 Finale Qualifier mandatory race ran here, no decrement logged)
01:03:43.907 [INFO] [TRACKBLAZER] Megaphone duration reduced. Turns remaining: 2.   <-- Turn 74 WIT training
(Turn 74 Finale Semi-Final mandatory race ran here, no decrement logged)
01:04:38.204 [INFO] [TRACKBLAZER] Megaphone duration reduced. Turns remaining: 1.   <-- Turn 75 POWER training
```
