### PR TITLE
Detect mandatory race distance to enable per-distance strategy resolution

### DIFF
--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Racing.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Racing.kt
@@ -1590,6 +1590,27 @@ class Racing(private val game: Game, private val campaign: Campaign) {
             // Distance is unknown for Finale races; per-distance strategy will fall back to blanket.
         }
 
+        // OCR the mandatory race name via the on-screen double-star prediction icon so per-distance strategy uses the actual race distance. Without this,
+        // lastRaceDistance stays null and per-distance strategy falls back to the user's blanket strategy for every mandatory race. Gated on
+        // enablePerDistanceStrategy so users not using per-distance don't pay the OCR + DB lookup overhead.
+        if (enablePerDistanceStrategy && lastRaceDistance == null) {
+            val predictionLocations = IconRaceListPredictionDoubleStar.findAll(game.imageUtils)
+            if (predictionLocations.isNotEmpty()) {
+                val raceName = game.imageUtils.extractRaceName(predictionLocations[0])
+                val raceDataList = lookupRaceInDatabase(campaign.date.day, raceName)
+                if (raceDataList.isNotEmpty()) {
+                    val raceData = raceDataList[0]
+                    lastRaceDistance = raceData.trackDistance
+                    // Preserve any grade/fans already set above (e.g. by the Finale block).
+                    if (lastRaceGrade == null) lastRaceGrade = raceData.grade
+                    if (lastRaceFans == 0) lastRaceFans = raceData.fans
+                    MessageLog.i(TAG, "[RACE] Detected mandatory race \"${raceData.name}\" (Grade: ${raceData.grade}, Distance: ${raceData.trackDistance}).")
+                }
+            } else {
+                MessageLog.i(TAG, "[RACE] No double-star prediction found on mandatory race screen. Per-distance strategy will fall back to blanket.")
+            }
+        }
+
         // Let the campaign handle any pre-race logic (e.g. using race items in Trackblazer).
         campaign.onScheduledRacePrepScreen()
 


### PR DESCRIPTION
## Description

- This PR fixes per-distance strategy falling back to the user's blanket strategy on mandatory races. `handleMandatoryRace()` never populated `lastRaceDistance`, so `resolveStrategyForCurrentRace()` logged the warning below and used the old blanket strategy ("End" in this case) instead of the per-distance entry. When `enablePerDistanceStrategy` is on, the bot now OCRs the race name via the on-screen `IconRaceListPredictionDoubleStar`, looks it up with `lookupRaceInDatabase()`, and sets `lastRaceDistance` (plus `lastRaceGrade` / `lastRaceFans` if the Finale block didn't already set them).

```
00:05:16.804 [INFO] [RACE] Detected ButtonChangeRunningStyle. Handling race prep screen...
00:05:16.805 [INFO] [RACE] Per-distance strategy enabled. Setting strategy for current race.
00:05:17.663 [WARN] [RACE] Per-distance strategy enabled but race distance unknown. Falling back to blanket strategy.
00:05:17.664 [INFO] [DIALOG] Using user-specified running style: End
```