### PR TITLE
Suppress extra-race fallback when Smart Race Solver is enabled

### DIFF
--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Racing.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Racing.kt
@@ -732,6 +732,19 @@ class Racing(private val game: Game, private val campaign: Campaign) {
             return true
         }
 
+        // When the Smart Race Solver is enabled, its schedule is authoritative for extra races. If the solver did not plan a race for
+        // this turn, suppress every extra-race fallback (including the scenario fan-farm bypass and the racing-interval cadence) so the
+        // bot trains or rests instead of racing as filler. Hard requirements above still short-circuit to true before this guard.
+        if (enableSmartRaceSolver) {
+            val plannedKey = SmartRaceSolverIntegration.peekRaceKeyForTurn(currentTurn = campaign.date.day, scenario = game.scenario)
+            if (plannedKey == null) {
+                MessageLog.i(TAG, "[RACE] Smart Race Solver has no race planned for turn ${campaign.date.day}. Skipping the extra-race fallback.")
+                return false
+            }
+            MessageLog.i(TAG, "[RACE] Smart Race Solver has \"$plannedKey\" planned for turn ${campaign.date.day}. Proceeding to racing screen.")
+            return !raceRepeatWarningCheck
+        }
+
         // For scenarios that race as often as possible, bypass most checks.
         if (campaign.shouldBypassSmartRacing()) {
             MessageLog.i(TAG, "[RACE] Bypassing smart racing and interval checks.")
@@ -1902,8 +1915,8 @@ class Racing(private val game: Game, private val campaign: Campaign) {
                     // Use smart racing for all years except Year 1 (Junior Year).
                     campaign.date.year != DateYear.JUNIOR
                 } else if (enableSmartRaceSolver && campaign.date.year != DateYear.JUNIOR) {
-                    // Year 2 and 3: Use the Smart Race Solver if Farming Fans is on and Force Racing is off.
-                    enableFarmingFans && !enableForceRacing
+                    // Year 2 and 3: Use the Smart Race Solver as long as Force Racing is off. Farming Fans is no longer required.
+                    !enableForceRacing
                 } else {
                     false
                 }
@@ -1917,9 +1930,8 @@ class Racing(private val game: Game, private val campaign: Campaign) {
                         MessageLog.i(TAG, "[RACE] Smart Race Solver conditions not met, using traditional racing logic...")
                         if (campaign.date.year == DateYear.JUNIOR) {
                             MessageLog.i(TAG, "[RACE]   - It is currently the Junior Year.")
-                        } else {
-                            if (!enableFarmingFans) MessageLog.i(TAG, "[RACE]   - enableFarmingFans is false")
-                            if (enableForceRacing) MessageLog.i(TAG, "[RACE]   - enableForceRacing is true")
+                        } else if (enableForceRacing) {
+                            MessageLog.i(TAG, "[RACE]   - enableForceRacing is true")
                         }
                     }
 

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/Trackblazer.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/Trackblazer.kt
@@ -504,7 +504,7 @@ class Trackblazer(game: Game) : Campaign(game) {
 
         // Peek the Solver's planned race so the scrollList scan can short-circuit as soon as it surfaces.
         val solverPlannedKey =
-            if (racing.enableSmartRaceSolver && racing.enableFarmingFans && !racing.enableForceRacing) {
+            if (racing.enableSmartRaceSolver && !racing.enableForceRacing) {
                 SmartRaceSolverIntegration.peekRaceKeyForTurn(currentTurn = date.day, scenario = game.scenario)
             } else {
                 null
@@ -1071,9 +1071,9 @@ class Trackblazer(game: Game) : Campaign(game) {
         }
 
         // Smart Race Solver pre-check: the solver's role is binary - either "race race-X today" or "no race today". When the solver picks
-        // a race we defer to the racing flow. Otherwise we fall through to the legacy main-screen loop, which decides between training,
-        // resting, fan-farming, etc. The solver no longer dictates Train vs Rest on no-race turns.
-        if (racing.enableSmartRaceSolver && racing.enableFarmingFans && !racing.enableForceRacing) {
+        // a race we defer to the racing flow. Otherwise we fall through to the legacy main-screen loop for training / rest decisions only;
+        // the extra-race fallback is suppressed downstream in checkEligibilityToStartExtraRacingProcess() so unscheduled turns never race.
+        if (racing.enableSmartRaceSolver && !racing.enableForceRacing) {
             val solverRaceKey = SmartRaceSolverIntegration.peekRaceKeyForTurn(currentTurn = date.day, scenario = game.scenario)
             if (solverRaceKey != null) {
                 MessageLog.i(TAG, "[TRACKBLAZER] Smart Race Solver has \"$solverRaceKey\" planned for turn ${date.day}; deferring to racing flow.")

--- a/src/pages/RacingSettings/index.tsx
+++ b/src/pages/RacingSettings/index.tsx
@@ -423,9 +423,9 @@ const RacingSettings = () => {
 
                         <NavigationLink
                             title="Go to Smart Race Solver Settings"
-                            description="Plans every turn of the career to maximize score by targeting epithet rewards. The bot only races when the solver picks a race; other turns become training or rest."
-                            disabled={!enableFarmingFans || enableForceRacing || enableUserInGameRaceAgenda}
-                            disabledDescription="Farming Fans must be enabled and Force Racing and User In-Game Race Agenda settings must be disabled in order to use the Smart Race Solver."
+                            description="Plans every turn of the career to maximize score by targeting epithet rewards. The bot only races when the solver picks a race; other turns become training or rest, even when Farming Fans would otherwise add an extra race."
+                            disabled={enableForceRacing || enableUserInGameRaceAgenda}
+                            disabledDescription="Force Racing and User In-Game Race Agenda settings must be disabled in order to use the Smart Race Solver."
                             onPress={() => navigation.navigate("SmartRaceSolverSettings" as never)}
                             style={{ ...styles.section, marginTop: 0 }}
                         />

--- a/src/pages/SmartRaceSolverSettings/index.tsx
+++ b/src/pages/SmartRaceSolverSettings/index.tsx
@@ -1024,7 +1024,7 @@ const SmartRaceSolverSettings = () => {
                         >
                             <CustomCheckbox
                                 label="Enable Smart Race Solver"
-                                description="Plans every turn of the 72-turn career to maximize score, deciding for each turn whether to race, train, or rest. The bot only runs the races the solver currently plans and never adds extra ones, even when Farming Fans would otherwise pick one up; the plan itself re-solves each turn so wins and losses reshape the remaining schedule. Activates when Farming Fans is on and Force Racing is off."
+                                description="Plans every turn of the 72-turn career to maximize score, deciding for each turn whether to race, train, or rest. The bot only runs the races the solver currently plans and never adds extra ones, even when Farming Fans would otherwise pick one up; the plan itself re-solves each turn so wins and losses reshape the remaining schedule. Activates whenever Force Racing and User In-Game Race Agenda are off."
                                 checked={enableSmartRaceSolver}
                                 onCheckedChange={(checked) => updateRacingSetting("enableSmartRaceSolver", checked)}
                             />
@@ -1046,7 +1046,9 @@ const SmartRaceSolverSettings = () => {
                                             <Text style={styles.infoLabel}>How it works</Text>
                                             <Text style={styles.infoDescription}>
                                                 The solver searches the entire 72-turn career and picks, for every turn, the best decision (Race / Train / Rest) that maximizes your projected score
-                                                against the target epithet rewards. The bot only runs the races the solver currently plans and treats the rest of the schedule as training or rest.
+                                                against the target epithet rewards. The bot only races on the turns the solver has chosen in the calculated schedule - every other turn becomes training
+                                                or rest, even when Farming Fans would otherwise add an extra race. Hard goal requirements (fan / trophy / goal-points) and the Force Racing setting are
+                                                the only things that can override the schedule.
                                             </Text>
 
                                             <View style={styles.infoBlock}>


### PR DESCRIPTION
## Description
- This PR makes the Smart Race Solver's schedule authoritative: when `enableSmartRaceSolver` is on and `peekRaceKeyForTurn()` returns `null` for the current turn, `checkEligibilityToStartExtraRacingProcess()` now returns `false` so the bot trains or rests instead of falling back to an extra race (this was previously slipping through Trackblazer's `shouldBypassSmartRacing()` bypass).
- The Farming Fans prerequisite has been dropped from every SRS gate in Kotlin (`Trackblazer.kt`, `Racing.kt`) and the frontend, since the solver now manages the entire schedule on its own; hard goal requirements and `enableForceRacing` still override.
- The Smart Race Solver "How it works" informational section now makes the strict-schedule behavior explicit so users know unscheduled turns will train or rest, not race.
