### PR TITLE
Add training-level scoring and stat-target override toggles to improve stat prioritization

### DIFF
--- a/android/app/src/main/assets/log_viewer.html
+++ b/android/app/src/main/assets/log_viewer.html
@@ -2015,16 +2015,18 @@
             function showTrainingTooltip(event) {
                 let content = '<div style="display: flex; flex-direction: column; gap: 4px;">'
                 const stats = ["Speed", "Stamina", "Power", "Guts", "Wit"]
-                
+
                 stats.forEach(stat => {
                     const count = trainingBreakdown[stat] || 0
+                    const level = trainingLevels[stat]
+                    const levelText = level != null ? ` <span style="opacity: 0.7;">(Lvl ${level})</span>` : ""
                     content += `
                         <div class="tooltip-row">
                             <span class="tooltip-label">${stat}</span>
-                            <span class="tooltip-value">${count}</span>
+                            <span class="tooltip-value">${count}${levelText}</span>
                         </div>`
                 })
-                
+
                 content += "</div>"
                 showTooltip(event, "Training Breakdown", content)
             }
@@ -2180,6 +2182,8 @@
 
             // Granular breakdowns state.
             let trainingBreakdown = { Speed: 0, Stamina: 0, Power: 0, Guts: 0, Wit: 0 }
+            // Most-recent OCR-detected training level (1-5) per stat. null when the Weight by Training Level feature is off or before any detection.
+            let trainingLevels = { Speed: null, Stamina: null, Power: null, Guts: null, Wit: null }
             let raceBreakdown = { Finale: 0, G1: 0, G2: 0, G3: 0, OP: 0, "Pre-OP": 0, Maiden: 0, Mandatory: 0, Standalone: 0 }
             let moodBreakdown = { Standard: 0, Date: 0, Summer: 0 }
             let energyBreakdown = { Rest: 0, Date: 0, Summer: 0 }
@@ -2486,6 +2490,7 @@
                         energy: 0
                     },
                     trainingBreakdown: { Speed: 0, Stamina: 0, Power: 0, Guts: 0, Wit: 0 },
+                    trainingLevels: { Speed: null, Stamina: null, Power: null, Guts: null, Wit: null },
                     raceBreakdown: { Finale: 0, G1: 0, G2: 0, G3: 0, OP: 0, "Pre-OP": 0, Maiden: 0, Mandatory: 0, Standalone: 0 },
                     moodBreakdown: { Standard: 0, Date: 0, Summer: 0 },
                     energyBreakdown: { Rest: 0, Date: 0, Summer: 0 }
@@ -2575,11 +2580,12 @@
                         energy: 0
                     },
                     trainingBreakdown: { Speed: 0, Stamina: 0, Power: 0, Guts: 0, Wit: 0 },
+                    trainingLevels: { Speed: null, Stamina: null, Power: null, Guts: null, Wit: null },
                     raceBreakdown: { Finale: 0, G1: 0, G2: 0, G3: 0, OP: 0, "Pre-OP": 0, Maiden: 0, Mandatory: 0, Standalone: 0 },
                     moodBreakdown: { Standard: 0, Date: 0, Summer: 0 },
                     energyBreakdown: { Rest: 0, Date: 0, Summer: 0 }
                 }
-                
+
                 // allMessages is guaranteed to be in chronological order at this point.
                 allMessages.forEach(function (msg) {
                     processSpecialLogs(msg.parsed, batchState)
@@ -2798,6 +2804,7 @@
 
                 // Reset granular breakdowns.
                 trainingBreakdown = { Speed: 0, Stamina: 0, Power: 0, Guts: 0, Wit: 0 }
+                trainingLevels = { Speed: null, Stamina: null, Power: null, Guts: null, Wit: null }
                 raceBreakdown = { Finale: 0, G1: 0, G2: 0, G3: 0, OP: 0, "Pre-OP": 0, Maiden: 0, Mandatory: 0, Standalone: 0 }
                 moodBreakdown = { Standard: 0, Date: 0, Summer: 0 }
                 energyBreakdown = { Rest: 0, Date: 0, Summer: 0 }
@@ -3286,6 +3293,24 @@
                 handleTraineeUpdates(parsed, stateTarget)
                 handleDateUpdates(parsed, stateTarget)
                 handleEnergyInfo(parsed, stateTarget)
+                handleTrainingLevel(parsed, stateTarget)
+            }
+
+            /**
+             * Updates the per-stat training level state from a `parsed.trainingLevel` payload.
+             * Emitted by LogStreamServer when analyzeTrainings detects a training level via OCR.
+             */
+            function handleTrainingLevel(parsed, stateTarget) {
+                const tl = parsed.trainingLevel
+                if (!tl || !tl.stat) return
+
+                if (stateTarget) {
+                    if (stateTarget.trainingLevels && stateTarget.trainingLevels.hasOwnProperty(tl.stat)) {
+                        stateTarget.trainingLevels[tl.stat] = tl.level
+                    }
+                } else if (trainingLevels.hasOwnProperty(tl.stat)) {
+                    trainingLevels[tl.stat] = tl.level
+                }
             }
 
             /**
@@ -3502,6 +3527,12 @@
                     if (state.trainingBreakdown) {
                         for (const [stat, count] of Object.entries(state.trainingBreakdown)) {
                             trainingBreakdown[stat] = count
+                        }
+                    }
+                    // Batch update training levels.
+                    if (state.trainingLevels) {
+                        for (const [stat, level] of Object.entries(state.trainingLevels)) {
+                            trainingLevels[stat] = level
                         }
                     }
                     // Batch update race breakdown.

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Training.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Training.kt
@@ -22,6 +22,7 @@ import com.steve1316.uma_android_automation.components.IconTrainingHeaderPower
 import com.steve1316.uma_android_automation.components.IconTrainingHeaderSpeed
 import com.steve1316.uma_android_automation.components.IconTrainingHeaderStamina
 import com.steve1316.uma_android_automation.components.IconTrainingHeaderWit
+import com.steve1316.uma_android_automation.components.LabelEnergy
 import com.steve1316.uma_android_automation.components.LabelStatTableHeaderSkillPoints
 import com.steve1316.uma_android_automation.components.LabelTrainingCannotPerform
 import com.steve1316.uma_android_automation.components.LabelTrainingFailureChance
@@ -127,6 +128,12 @@ open class Training(protected val game: Game, protected val campaign: Campaign) 
     /** Whether to prioritize skill hints. */
     private val enablePrioritizeSkillHints: Boolean = SettingsHelper.getBooleanSetting("training", "enablePrioritizeSkillHints")
 
+    /** Whether to weight training scores by the OCR-detected training level (1-5) of the priority-list stats. */
+    internal val enableTrainingLevelWeighting: Boolean = SettingsHelper.getBooleanSetting("training", "enableTrainingLevelWeighting", false)
+
+    /** Cached screen location of the Energy label, used as the anchor for training level OCR. Resolved lazily on first use, reused for the rest of the bot session. */
+    private var cachedEnergyLocation: Point? = null
+
     /** Whether to enable validation of training analysis. */
     private val enableTrainingAnalysisValidation: Boolean = SettingsHelper.getBooleanSetting("training", "enableTrainingAnalysisValidation")
 
@@ -193,6 +200,9 @@ open class Training(protected val game: Game, protected val campaign: Campaign) 
         /** Total number of detected skill hints. */
         var numSkillHints: Int = 0
 
+        /** The OCR-detected training level (1-5) for this stat, or null if the feature is disabled or OCR failed. */
+        var trainingLevel: Int? = null
+
         /** Scenario-specific extra data populated by [runExtraTrainingAnalysis]. */
         val extras: MutableMap<String, Any?> = mutableMapOf()
     }
@@ -208,6 +218,7 @@ open class Training(protected val game: Game, protected val campaign: Campaign) 
      * @property numRainbow Total number of rainbow trainings detected.
      * @property numSkillHints Total number of detected skill hints.
      * @property extras Scenario-specific extra data from [runExtraTrainingAnalysis].
+     * @property trainingLevel OCR-detected training level (1-5) for this option's primary stat, or null if unknown.
      * @property skipReason Optional reason if this training was skipped during recommendation.
      */
     data class TrainingOption(
@@ -219,6 +230,7 @@ open class Training(protected val game: Game, protected val campaign: Campaign) 
         val numRainbow: Int,
         val numSkillHints: Int = 0,
         val extras: Map<String, Any?> = emptyMap(),
+        val trainingLevel: Int? = null,
         val skipReason: String? = null,
     ) {
         override fun equals(other: Any?): Boolean {
@@ -235,6 +247,7 @@ open class Training(protected val game: Game, protected val campaign: Campaign) 
             if (numRainbow != other.numRainbow) return false
             if (numSkillHints != other.numSkillHints) return false
             if (extras != other.extras) return false
+            if (trainingLevel != other.trainingLevel) return false
             if (skipReason != other.skipReason) return false
 
             return true
@@ -249,6 +262,7 @@ open class Training(protected val game: Game, protected val campaign: Campaign) 
             result = 31 * result + numRainbow
             result = 31 * result + numSkillHints
             result = 31 * result + extras.hashCode()
+            result = 31 * result + (trainingLevel ?: 0)
             result = 31 * result + (skipReason?.hashCode() ?: 0)
             return result
         }
@@ -271,6 +285,7 @@ open class Training(protected val game: Game, protected val campaign: Campaign) 
      * @property trainingOptions List of all analyzed training options.
      * @property skillHintsPerLocation Map of detected skill hints for each training.
      * @property enablePrioritizeSkillHints Whether to prioritize skill hints.
+     * @property enableTrainingLevelWeighting Whether to amplify priority-list stat scores by their OCR-detected training level (1-5).
      * @property statsTrainedOverBuffer Set of stats that have already exceeded their cap buffer.
      */
     data class TrainingConfig(
@@ -289,6 +304,7 @@ open class Training(protected val game: Game, protected val campaign: Campaign) 
         val trainingOptions: List<TrainingOption>,
         val skillHintsPerLocation: Map<StatName, Int> = StatName.entries.associateWith { 0 },
         val enablePrioritizeSkillHints: Boolean = false,
+        val enableTrainingLevelWeighting: Boolean = false,
         val statsTrainedOverBuffer: Set<StatName> = emptySet(),
     ) {
         override fun equals(other: Any?): Boolean {
@@ -311,6 +327,7 @@ open class Training(protected val game: Game, protected val campaign: Campaign) 
             if (trainingOptions != other.trainingOptions) return false
             if (skillHintsPerLocation != other.skillHintsPerLocation) return false
             if (enablePrioritizeSkillHints != other.enablePrioritizeSkillHints) return false
+            if (enableTrainingLevelWeighting != other.enableTrainingLevelWeighting) return false
             if (statsTrainedOverBuffer != other.statsTrainedOverBuffer) return false
 
             return true
@@ -331,6 +348,7 @@ open class Training(protected val game: Game, protected val campaign: Campaign) 
             result = 31 * result + trainingOptions.hashCode()
             result = 31 * result + skillHintsPerLocation.hashCode()
             result = 31 * result + enablePrioritizeSkillHints.hashCode()
+            result = 31 * result + enableTrainingLevelWeighting.hashCode()
             result = 31 * result + statsTrainedOverBuffer.hashCode()
             return result
         }
@@ -597,6 +615,32 @@ open class Training(protected val game: Game, protected val campaign: Campaign) 
         }
 
         /**
+         * Compute the level-based amplifier for a stat's priority weight.
+         *
+         * Returns 1.0 when the feature is disabled or has no effect; values > 1.0 amplify the priority weight of stats that are both
+         * high in the user's priority list and have a high training level (1-5). Only ranks 1-3 receive any boost; rank 4-5 and
+         * training level 1 always return 1.0. At Lvl 5: rank 1 = 1.75x, rank 2 = 1.25x, rank 3 = 1.10x. The fade keeps the boost
+         * heavily concentrated on the user's top priority while still rewarding investment in their secondary.
+         *
+         * @param priorityRank The 1-indexed position of the stat in the active priority list (1 = highest priority).
+         * @param trainingLevel The detected training level (1-5), or null if OCR was unavailable.
+         * @return Multiplier in [1.0, 1.75].
+         */
+        fun levelBoostMultiplier(priorityRank: Int, trainingLevel: Int?): Double {
+            val level = trainingLevel ?: 1
+            if (level <= 1) return 1.0
+            val priorityFactor =
+                when (priorityRank) {
+                    1 -> 0.75
+                    2 -> 0.25
+                    3 -> 0.10
+                    else -> 0.0
+                }
+            val levelFactor = (level - 1) / 4.0
+            return 1.0 + priorityFactor * levelFactor
+        }
+
+        /**
          * Calculate the stat efficiency score based on the ratio completion toward targets.
          *
          * This method treats stat targets as desired ratios and scores training based on how well it balances the overall stat distribution.
@@ -666,6 +710,15 @@ open class Training(protected val game: Game, protected val campaign: Campaign) 
                             1.0
                         }
 
+                    // Level-based amplifier: when the feature is enabled, scale up the contribution from this training's primary stat
+                    // based on its OCR-detected training level (1-5) and its position in the priority list. See [levelBoostMultiplier].
+                    val levelMultiplier =
+                        if (config.enableTrainingLevelWeighting && statName == training.name && priorityIndex != -1) {
+                            levelBoostMultiplier(priorityIndex + 1, training.trainingLevel)
+                        } else {
+                            1.0
+                        }
+
                     // Main stat gain bonus: If training improves its MAIN stat by a large amount, it is most likely an undetected rainbow.
                     val isMainStat = training.name == statName
                     val mainStatBonus =
@@ -688,19 +741,21 @@ open class Training(protected val game: Game, protected val campaign: Campaign) 
 
                     val bonusNote = if (isMainStat && statGain >= 30) " [HIGH MAIN STAT]" else ""
                     val sparkNote = if (isSparkStat && canTriggerSpark) " [SPARK PRIORITY]" else ""
+                    val levelNote = if (levelMultiplier > 1.0) " [LVL ${training.trainingLevel} BOOST ${String.format("%.2f", levelMultiplier)}x]" else ""
                     val completionString: String = String.format("%.2f", completionPercent)
                     val ratioMultiplierString: String = String.format("%.2f", ratioMultiplier)
                     val priorityMultiplierString: String = String.format("%.2f", priorityMultiplier)
                     Log.d(
                         TAG,
                         "$statName: gain=$statGain, completion=$completionString%, " +
-                            "ratioMultiplierString=$ratioMultiplierString, priorityMultiplierString=${priorityMultiplierString}$bonusNote$sparkNote",
+                            "ratioMultiplierString=$ratioMultiplierString, priorityMultiplierString=${priorityMultiplierString}$bonusNote$sparkNote$levelNote",
                     )
 
                     // Calculate final score for this stat.
                     var statScore = statGain.toDouble()
                     statScore *= ratioMultiplier
                     statScore *= priorityMultiplier
+                    statScore *= levelMultiplier
                     statScore *= mainStatBonus
                     statScore *= sparkBonus
 
@@ -1278,6 +1333,31 @@ open class Training(protected val game: Game, protected val campaign: Campaign) 
                 // In parallel mode, this runs synchronously. In singleTraining mode, the scenario may start a thread.
                 runExtraTrainingAnalysis(result, sourceBitmap, singleTraining)
 
+                // OCR the displayed training level (1-5) for this stat while its panel is on screen.
+                // Skipped during Pre-Debut, Junior, and Summer since the level boost only fires in Year 2+ Stat Efficiency scoring,
+                // and Summer forces every training to Lvl 5 (the boost would equalize across stats).
+                if (enableTrainingLevelWeighting && !campaign.date.bIsPreDebut && campaign.date.year != DateYear.JUNIOR && !campaign.date.isSummer()) {
+                    val energyAnchor =
+                        cachedEnergyLocation ?: run {
+                            val located = LabelEnergy.find(game.imageUtils).first
+                            if (located != null) {
+                                cachedEnergyLocation = located
+                            }
+                            located
+                        }
+                    if (energyAnchor != null) {
+                        val detectedLevel = game.imageUtils.extractTrainingLevel(sourceBitmap, energyAnchor)
+                        result.trainingLevel = detectedLevel
+                        if (detectedLevel == null) {
+                            MessageLog.w(TAG, "[WARN] analyzeTrainings:: Training level OCR failed for $statName. Falling back to no level boost.")
+                        } else {
+                            MessageLog.i(TAG, "[TRAINING] $statName training level detected as Lvl $detectedLevel.")
+                        }
+                    } else {
+                        MessageLog.w(TAG, "[WARN] analyzeTrainings:: Failed to locate Energy label anchor for training level OCR. Falling back to no level boost.")
+                    }
+                }
+
                 // Check if bot is still running before starting parallel threads.
                 if (!BotService.isRunning) {
                     return
@@ -1434,6 +1514,7 @@ open class Training(protected val game: Game, protected val campaign: Campaign) 
                             numRainbow = result.numRainbow,
                             extras = result.extras,
                             numSkillHints = result.numSkillHints,
+                            trainingLevel = result.trainingLevel,
                         )
                     trainingMap[result.name] = newTraining
                     break
@@ -1564,6 +1645,7 @@ open class Training(protected val game: Game, protected val campaign: Campaign) 
                         numRainbow = result.numRainbow,
                         extras = result.extras,
                         numSkillHints = result.numSkillHints,
+                        trainingLevel = result.trainingLevel,
                         skipReason = skipReason,
                     )
                 skippedTrainingMap[result.name] = skippedTraining
@@ -1587,6 +1669,7 @@ open class Training(protected val game: Game, protected val campaign: Campaign) 
                         numRainbow = result.numRainbow,
                         extras = result.extras,
                         numSkillHints = result.numSkillHints,
+                        trainingLevel = result.trainingLevel,
                         skipReason = "low gain with charm",
                     )
                 skippedTrainingMap[result.name] = skippedTraining
@@ -1608,6 +1691,7 @@ open class Training(protected val game: Game, protected val campaign: Campaign) 
                             numRainbow = result.numRainbow,
                             extras = result.extras,
                             numSkillHints = result.numSkillHints,
+                            trainingLevel = result.trainingLevel,
                             skipReason = "low irregular gain",
                         )
                     skippedTrainingMap[result.name] = skippedTraining
@@ -1625,6 +1709,7 @@ open class Training(protected val game: Game, protected val campaign: Campaign) 
                     numRainbow = result.numRainbow,
                     extras = result.extras,
                     numSkillHints = result.numSkillHints,
+                    trainingLevel = result.trainingLevel,
                 )
             trainingMap[result.name] = newTraining
         }
@@ -1961,6 +2046,7 @@ open class Training(protected val game: Game, protected val campaign: Campaign) 
                 trainingOptions = trainingMap.values.toList(),
                 skillHintsPerLocation = skillHintsPerLocation,
                 enablePrioritizeSkillHints = enablePrioritizeSkillHints,
+                enableTrainingLevelWeighting = enableTrainingLevelWeighting,
                 statsTrainedOverBuffer = statsTrainedOverBuffer,
             )
 
@@ -2301,7 +2387,8 @@ open class Training(protected val game: Game, protected val campaign: Campaign) 
                 }
             }.joinToString(", ", "{", "}")
 
-        val basicInfo = "${training.name} Training: stats=$formattedStatGains, fail=${training.failureChance}%, rainbows=${training.numRainbow}$skippedIndicator$selectedIndicator"
+        val levelInfo = training.trainingLevel?.let { ", level=Lvl $it" } ?: ""
+        val basicInfo = "${training.name} Training: stats=$formattedStatGains, fail=${training.failureChance}%, rainbows=${training.numRainbow}$levelInfo$skippedIndicator$selectedIndicator"
         sb.appendLine(basicInfo)
 
         // Print relationship bars if any.

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Training.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Training.kt
@@ -131,6 +131,9 @@ open class Training(protected val game: Game, protected val campaign: Campaign) 
     /** Whether to weight training scores by the OCR-detected training level (1-5) of the priority-list stats. */
     internal val enableTrainingLevelWeighting: Boolean = SettingsHelper.getBooleanSetting("training", "enableTrainingLevelWeighting", false)
 
+    /** Whether to ignore per-distance stat targets and treat every stat's target as the scenario stat cap. When ON, the bot keeps the ratio multiplier in the "encourage training" band for every stat. */
+    internal val disableStatTargets: Boolean = SettingsHelper.getBooleanSetting("training", "disableStatTargets", false)
+
     /** Cached screen location of the Energy label, used as the anchor for training level OCR. Resolved lazily on first use, reused for the rest of the bot session. */
     private var cachedEnergyLocation: Point? = null
 
@@ -286,6 +289,7 @@ open class Training(protected val game: Game, protected val campaign: Campaign) 
      * @property skillHintsPerLocation Map of detected skill hints for each training.
      * @property enablePrioritizeSkillHints Whether to prioritize skill hints.
      * @property enableTrainingLevelWeighting Whether to amplify priority-list stat scores by their OCR-detected training level (1-5).
+     * @property disableStatTargets Whether per-distance stat targets are overridden by the scenario stat cap for all stats.
      * @property statsTrainedOverBuffer Set of stats that have already exceeded their cap buffer.
      */
     data class TrainingConfig(
@@ -305,6 +309,7 @@ open class Training(protected val game: Game, protected val campaign: Campaign) 
         val skillHintsPerLocation: Map<StatName, Int> = StatName.entries.associateWith { 0 },
         val enablePrioritizeSkillHints: Boolean = false,
         val enableTrainingLevelWeighting: Boolean = false,
+        val disableStatTargets: Boolean = false,
         val statsTrainedOverBuffer: Set<StatName> = emptySet(),
     ) {
         override fun equals(other: Any?): Boolean {
@@ -328,6 +333,7 @@ open class Training(protected val game: Game, protected val campaign: Campaign) 
             if (skillHintsPerLocation != other.skillHintsPerLocation) return false
             if (enablePrioritizeSkillHints != other.enablePrioritizeSkillHints) return false
             if (enableTrainingLevelWeighting != other.enableTrainingLevelWeighting) return false
+            if (disableStatTargets != other.disableStatTargets) return false
             if (statsTrainedOverBuffer != other.statsTrainedOverBuffer) return false
 
             return true
@@ -349,6 +355,7 @@ open class Training(protected val game: Game, protected val campaign: Campaign) 
             result = 31 * result + skillHintsPerLocation.hashCode()
             result = 31 * result + enablePrioritizeSkillHints.hashCode()
             result = 31 * result + enableTrainingLevelWeighting.hashCode()
+            result = 31 * result + disableStatTargets.hashCode()
             result = 31 * result + statsTrainedOverBuffer.hashCode()
             return result
         }
@@ -2036,7 +2043,12 @@ open class Training(protected val game: Game, protected val campaign: Campaign) 
                 statPrioritization = statPrioritization,
                 eventChoiceStatPriority = eventChoiceStatPriority,
                 summerTrainingStatPriority = summerTrainingStatPriority,
-                statTargets = campaign.trainee.getPhaseStatTargets(campaign.date.year),
+                statTargets =
+                    if (disableStatTargets) {
+                        StatName.entries.associateWith { getScenarioStatCap(game.scenario, it) }
+                    } else {
+                        campaign.trainee.getPhaseStatTargets(campaign.date.year)
+                    },
                 currentDate = campaign.date,
                 scenario = game.scenario,
                 enableRainbowTrainingBonus = enableRainbowTrainingBonus,
@@ -2047,6 +2059,7 @@ open class Training(protected val game: Game, protected val campaign: Campaign) 
                 skillHintsPerLocation = skillHintsPerLocation,
                 enablePrioritizeSkillHints = enablePrioritizeSkillHints,
                 enableTrainingLevelWeighting = enableTrainingLevelWeighting,
+                disableStatTargets = disableStatTargets,
                 statsTrainedOverBuffer = statsTrainedOverBuffer,
             )
 
@@ -2153,7 +2166,12 @@ open class Training(protected val game: Game, protected val campaign: Campaign) 
             statNames.joinToString(", ") {
                 "${it.name.lowercase().replaceFirstChar { char -> char.titlecase() }}=${targets[it]}"
             }
-        sb.appendLine("Stat Targets ($preferredDistance) [$phaseLabel]: $targetsFormatted")
+        if (config.disableStatTargets) {
+            val cap = getScenarioStatCap(config.scenario, StatName.SPEED)
+            sb.appendLine("Stat Targets: Disabled (treating cap=$cap as the target for all stats)")
+        } else {
+            sb.appendLine("Stat Targets ($preferredDistance) [$phaseLabel]: $targetsFormatted")
+        }
 
         // Compute completion percentages for each stat.
         val completionPercentages =

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/utils/CustomImageUtils.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/utils/CustomImageUtils.kt
@@ -2528,6 +2528,40 @@ class CustomImageUtils(context: Context, private val game: Game) : ImageUtils(co
         )
     }
 
+    /**
+     * Extract the displayed training level (1-5) from the currently selected training panel.
+     *
+     * The label appears as "Speed Lvl 4", "Stamina Lvl 2", etc., in white characters on a solid colored
+     * background at a fixed offset from the Energy label.
+     *
+     * @param sourceBitmap The current screenshot.
+     * @param energyAnchor The Point returned by `LabelEnergy.find().first` for the same bitmap.
+     * @return The parsed level (1-5), or null if OCR or parsing failed.
+     */
+    fun extractTrainingLevel(sourceBitmap: Bitmap, energyAnchor: Point): Int? {
+        val x = relX(energyAnchor.x, -140)
+        val y = relY(energyAnchor.y, 65)
+        val width = relWidth(240)
+        val height = relHeight(40)
+        val rawText =
+            findTextByColor(
+                sourceBitmap = sourceBitmap,
+                x = x,
+                y = y,
+                width = width,
+                height = height,
+                targetR = 255,
+                targetG = 255,
+                targetB = 255,
+                tolerance = 30,
+                scale = 2.0,
+                debugName = "trainingLevel",
+            )
+        if (rawText.isEmpty()) return null
+        val match = Regex("""Lvl\s*([1-5])""", RegexOption.IGNORE_CASE).find(rawText) ?: return null
+        return match.groupValues.getOrNull(1)?.toIntOrNull()
+    }
+
     // //////////////////////////////////////////////////////////////////////////////////////////////////
     // //////////////////////////////////////////////////////////////////////////////////////////////////
     // Misc Helper Functions

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/utils/LogStreamServer.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/utils/LogStreamServer.kt
@@ -99,6 +99,9 @@ object LogStreamServer {
     /** Regex pattern to detect the start of a training session. */
     private val actionTrainingPattern = Pattern.compile("\\[TRAINING] Now starting process to execute (\\w+) training")
 
+    /** Regex pattern to detect the OCR-derived training level (1-5) for a specific stat. Emitted by analyzeTrainings when the Weight by Training Level feature is on. */
+    private val trainingLevelPattern = Pattern.compile("\\[TRAINING] (\\w+) training level detected as Lvl ([1-5])\\.")
+
     /** Regex pattern to detect the completion of a race. */
     private val actionRacePattern = Pattern.compile("\\[RACE] Racing process for .*? is completed\\. Grade: (.*)", Pattern.CASE_INSENSITIVE)
 
@@ -158,6 +161,7 @@ object LogStreamServer {
      * @property trainee Trainee detailed info (category and raw data).
      * @property dateInfo Extracted date and turn information.
      * @property energyInfo Extracted energy level update (from/to percentages).
+     * @property trainingLevel Per-stat training level detection emitted during training analysis, shape: {stat, level}.
      */
     private data class LogEntry(
         val newline: String,
@@ -168,6 +172,7 @@ object LogStreamServer {
         val trainee: JSONObject? = null,
         val dateInfo: JSONObject? = null,
         val energyInfo: JSONObject? = null,
+        val trainingLevel: JSONObject? = null,
     ) {
         /** Converts the log entry into a JSON object for WebSocket transmission. */
         fun toJSON(): JSONObject {
@@ -180,6 +185,7 @@ object LogStreamServer {
                 trainee?.let { put("trainee", it) }
                 dateInfo?.let { put("dateInfo", it) }
                 energyInfo?.let { put("energyInfo", it) }
+                trainingLevel?.let { put("trainingLevel", it) }
             }
         }
     }
@@ -516,8 +522,9 @@ object LogStreamServer {
                 }
 
             val energyInfo = parseEnergyInfo(text)
+            val trainingLevel = parseTrainingLevel(text)
 
-            LogEntry(newline, timestamp, level, text, action, trainee, dateInfo, energyInfo).toJSON()
+            LogEntry(newline, timestamp, level, text, action, trainee, dateInfo, energyInfo, trainingLevel).toJSON()
         } else {
             // Fallback: detect level and treat entire message as text.
             val level =
@@ -719,6 +726,29 @@ object LogStreamServer {
                         put("moodTo", toMood)
                     }
                 }
+            }
+        } else {
+            null
+        }
+    }
+
+    /**
+     * Parses a "training level detected" log line into a structured dashboard payload.
+     *
+     * Emitted by analyzeTrainings when the Weight Score by Training Level feature is enabled. The stat is normalized to title case
+     * to match the action-counter sub-type format ("Speed", "Stamina", "Power", "Guts", "Wit").
+     *
+     * @param text The log message text to check.
+     * @return A [JSONObject] with `stat` (String) and `level` (Int 1-5) if detected, otherwise null.
+     */
+    private fun parseTrainingLevel(text: String): JSONObject? {
+        val matcher = trainingLevelPattern.matcher(text)
+        return if (matcher.find()) {
+            val stat = matcher.group(1)?.lowercase()?.replaceFirstChar { it.uppercase() } ?: return null
+            val level = matcher.group(2)?.toIntOrNull() ?: return null
+            JSONObject().apply {
+                put("stat", stat)
+                put("level", level)
             }
         } else {
             null

--- a/android/app/src/test/java/com/steve1316/uma_android_automation/bot/TrainingScoringTest.kt
+++ b/android/app/src/test/java/com/steve1316/uma_android_automation/bot/TrainingScoringTest.kt
@@ -1261,4 +1261,95 @@ class TrainingScoringTest {
         // Rank 0 (out of priority list) returns 1.0 since the when branch falls through to else.
         assertEquals(1.0, levelBoostMultiplier(0, 5), 1e-9)
     }
+
+    // //////////////////////////////////////////////////////////////////////////////////////////////////
+    // //////////////////////////////////////////////////////////////////////////////////////////////////
+    // disableStatTargets override
+
+    /**
+     * Builds the post-override statTargets map that recommendTraining() applies when disableStatTargets is true.
+     * Mirrors the production branch so tests stay aligned with real behavior.
+     */
+    private fun cappedStatTargets(cap: Int = 1200): Map<StatName, Int> {
+        return StatName.entries.associateWith { cap }
+    }
+
+    @Test
+    @DisplayName("disableStatTargets override: over-target stat regains ratio bonus when targets are pinned to the cap")
+    fun testDisableStatTargetsLiftsOverTargetPenalty() {
+        // Scenario from the Tokai Teio run: Wit at 828, normally targeted at 600 (Medium), heavily penalized by ratioMultiplier.
+        val currentStats =
+            mapOf(
+                StatName.SPEED to 998,
+                StatName.STAMINA to 685,
+                StatName.POWER to 725,
+                StatName.GUTS to 361,
+                StatName.WIT to 828,
+            )
+        val witTraining =
+            createDefaultTrainingOption(
+                name = StatName.WIT,
+                statGains = statGainsToMap(intArrayOf(9, 0, 0, 0, 21)),
+                numRainbow = 0,
+            )
+
+        val baseConfig =
+            createDefaultConfig(
+                trainingOptions = listOf(witTraining),
+                currentStats = currentStats,
+                statPrioritization = listOf(StatName.WIT, StatName.SPEED, StatName.POWER, StatName.STAMINA, StatName.GUTS),
+                preferredDistance = "Medium",
+                currentDate = GameDate(year = DateYear.SENIOR, month = DateMonth.AUGUST, phase = DatePhase.EARLY),
+            )
+        val overrideConfig = baseConfig.copy(statTargets = cappedStatTargets(), disableStatTargets = true)
+
+        val baseScore = calculateStatEfficiencyScore(baseConfig, witTraining)
+        val overrideScore = calculateStatEfficiencyScore(overrideConfig, witTraining)
+
+        // With the override, Wit drops from 138% completion (target=600) to 69% completion (target=1200). The lower band gives a much higher ratio multiplier,
+        // so the score must rise noticeably.
+        assertTrue(overrideScore > baseScore * 2.0, "Override should at least double Wit's score (base=$baseScore, override=$overrideScore)")
+    }
+
+    @Test
+    @DisplayName("disableStatTargets override: under-target stat is not penalized by the override")
+    fun testDisableStatTargetsLeavesUnderTargetUntouched() {
+        // Speed at 998 vs Medium target 800 -> 124% (mild over-target penalty); at cap=1200 -> 83% (mild under-target bonus).
+        // The override must not REDUCE the score for an already-strong priority stat.
+        val currentStats =
+            mapOf(
+                StatName.SPEED to 998,
+                StatName.STAMINA to 685,
+                StatName.POWER to 725,
+                StatName.GUTS to 361,
+                StatName.WIT to 828,
+            )
+        val speedTraining =
+            createDefaultTrainingOption(
+                name = StatName.SPEED,
+                statGains = statGainsToMap(intArrayOf(44, 0, 18, 0, 0)),
+                numRainbow = 1,
+            )
+        val baseConfig =
+            createDefaultConfig(
+                trainingOptions = listOf(speedTraining),
+                currentStats = currentStats,
+                statPrioritization = listOf(StatName.WIT, StatName.SPEED, StatName.POWER, StatName.STAMINA, StatName.GUTS),
+                preferredDistance = "Medium",
+                currentDate = GameDate(year = DateYear.SENIOR, month = DateMonth.AUGUST, phase = DatePhase.EARLY),
+            )
+        val overrideConfig = baseConfig.copy(statTargets = cappedStatTargets(), disableStatTargets = true)
+
+        val baseScore = calculateStatEfficiencyScore(baseConfig, speedTraining)
+        val overrideScore = calculateStatEfficiencyScore(overrideConfig, speedTraining)
+
+        assertTrue(overrideScore >= baseScore, "Override must not penalize an under-target priority stat (base=$baseScore, override=$overrideScore)")
+    }
+
+    @Test
+    @DisplayName("disableStatTargets defaults to false on TrainingConfig")
+    fun testDisableStatTargetsDefault() {
+        val config = createDefaultConfig()
+        assertEquals(false, config.disableStatTargets, "TrainingConfig.disableStatTargets should default to false")
+    }
 }

--- a/android/app/src/test/java/com/steve1316/uma_android_automation/bot/TrainingScoringTest.kt
+++ b/android/app/src/test/java/com/steve1316/uma_android_automation/bot/TrainingScoringTest.kt
@@ -6,6 +6,7 @@ import com.steve1316.uma_android_automation.bot.Training.Companion.calculateRela
 import com.steve1316.uma_android_automation.bot.Training.Companion.calculateStatEfficiencyScore
 import com.steve1316.uma_android_automation.bot.Training.Companion.getFinaleStatBonus
 import com.steve1316.uma_android_automation.bot.Training.Companion.getRemainingFinaleRaces
+import com.steve1316.uma_android_automation.bot.Training.Companion.levelBoostMultiplier
 import com.steve1316.uma_android_automation.bot.Training.Companion.scoreFriendshipTraining
 import com.steve1316.uma_android_automation.bot.Training.Companion.scoreUnityCupTraining
 import com.steve1316.uma_android_automation.bot.Training.TrainingConfig
@@ -1196,5 +1197,68 @@ class TrainingScoringTest {
         val score = calculateRawTrainingScore(config, training)
 
         assertTrue(score > 0.0, "Stat at 1060 should be allowed on turn 75 with no finale adjustment (effective cap = 1100)")
+    }
+
+    // //////////////////////////////////////////////////////////////////////////////////////////////////
+    // //////////////////////////////////////////////////////////////////////////////////////////////////
+    // Level Boost Multiplier
+
+    @Test
+    @DisplayName("levelBoostMultiplier: Lvl 1 returns 1.0 regardless of rank")
+    fun testLevelBoostMultiplier_lvl1NeverBoosts() {
+        for (rank in 1..5) {
+            assertEquals(1.0, levelBoostMultiplier(rank, 1), 1e-9, "Rank $rank, Lvl 1 should never boost")
+        }
+    }
+
+    @Test
+    @DisplayName("levelBoostMultiplier: null level treated as Lvl 1")
+    fun testLevelBoostMultiplier_nullLevelNoBoost() {
+        for (rank in 1..5) {
+            assertEquals(1.0, levelBoostMultiplier(rank, null), 1e-9, "Rank $rank, null level should never boost")
+        }
+    }
+
+    @Test
+    @DisplayName("levelBoostMultiplier: priority ranks 4 and 5 are never boosted")
+    fun testLevelBoostMultiplier_lowPriorityNeverBoosts() {
+        for (level in 1..5) {
+            assertEquals(1.0, levelBoostMultiplier(4, level), 1e-9, "Rank 4 should never boost (Lvl $level)")
+            assertEquals(1.0, levelBoostMultiplier(5, level), 1e-9, "Rank 5 should never boost (Lvl $level)")
+        }
+    }
+
+    @Test
+    @DisplayName("levelBoostMultiplier: rank 1 at Lvl 5 returns 1.75x")
+    fun testLevelBoostMultiplier_rank1Lvl5() {
+        assertEquals(1.75, levelBoostMultiplier(1, 5), 1e-9)
+    }
+
+    @Test
+    @DisplayName("levelBoostMultiplier: rank 2 at Lvl 5 returns 1.25x")
+    fun testLevelBoostMultiplier_rank2Lvl5() {
+        assertEquals(1.25, levelBoostMultiplier(2, 5), 1e-9)
+    }
+
+    @Test
+    @DisplayName("levelBoostMultiplier: rank 3 at Lvl 5 returns 1.10x")
+    fun testLevelBoostMultiplier_rank3Lvl5() {
+        assertEquals(1.10, levelBoostMultiplier(3, 5), 1e-9)
+    }
+
+    @Test
+    @DisplayName("levelBoostMultiplier: rank 1 at Lvl 3 scales linearly to 1.375x")
+    fun testLevelBoostMultiplier_rank1Lvl3() {
+        // levelFactor = (3 - 1) / 4.0 = 0.5; rank 1 factor = 0.75; boost = 1 + 0.75 * 0.5 = 1.375
+        assertEquals(1.375, levelBoostMultiplier(1, 3), 1e-9)
+    }
+
+    @Test
+    @DisplayName("levelBoostMultiplier: out-of-range level above 5 caps via formula (Lvl 5 effectively)")
+    fun testLevelBoostMultiplier_levelClampedBehavior() {
+        // The helper does not clamp; callers are expected to feed 1..5. Verify the formula is well-defined for boundary inputs.
+        assertEquals(1.75, levelBoostMultiplier(1, 5), 1e-9)
+        // Rank 0 (out of priority list) returns 1.0 since the when branch falls through to else.
+        assertEquals(1.0, levelBoostMultiplier(0, 5), 1e-9)
     }
 }

--- a/src/context/BotStateContext.tsx
+++ b/src/context/BotStateContext.tsx
@@ -127,6 +127,7 @@ export interface Settings {
         trainWitDuringFinale: boolean
         enablePrioritizeSkillHints: boolean
         enableTrainingLevelWeighting: boolean
+        disableStatTargets: boolean
         enableTrainingAnalysisValidation: boolean
         enableYoloStatDetection: boolean
         classicMilestonePercent: number
@@ -385,6 +386,7 @@ export const defaultSettings: Settings = {
         trainWitDuringFinale: false,
         enablePrioritizeSkillHints: false,
         enableTrainingLevelWeighting: true,
+        disableStatTargets: false,
         enableTrainingAnalysisValidation: false,
         enableYoloStatDetection: false,
         classicMilestonePercent: 33,

--- a/src/context/BotStateContext.tsx
+++ b/src/context/BotStateContext.tsx
@@ -126,6 +126,7 @@ export interface Settings {
         riskyTrainingMaxFailureChance: number
         trainWitDuringFinale: boolean
         enablePrioritizeSkillHints: boolean
+        enableTrainingLevelWeighting: boolean
         enableTrainingAnalysisValidation: boolean
         enableYoloStatDetection: boolean
         classicMilestonePercent: number
@@ -383,6 +384,7 @@ export const defaultSettings: Settings = {
         riskyTrainingMaxFailureChance: 30,
         trainWitDuringFinale: false,
         enablePrioritizeSkillHints: false,
+        enableTrainingLevelWeighting: true,
         enableTrainingAnalysisValidation: false,
         enableYoloStatDetection: false,
         classicMilestonePercent: 33,

--- a/src/context/searchConfig.ts
+++ b/src/context/searchConfig.ts
@@ -146,6 +146,13 @@ const searchConfig: SearchOption[] = [
         page: "TrainingSettings",
     },
     {
+        id: "enable-training-level-weighting",
+        title: "Weight Score by Training Level",
+        description:
+            "When enabled (Year 2+), the bot reads each training's level (1-5) via OCR and boosts the score for trainings whose stat sits in the top 3 of your Stat Prioritization list. Helps the bot stick with stats you have invested in. OCR is skipped during Pre-Debut, Junior, and Summer.",
+        page: "TrainingSettings",
+    },
+    {
         id: "must-rest-before-summer",
         title: "Must Rest before Summer",
         description: "Forces the bot to rest during June Late Phase in Classic and Senior Years to ensure enough energy for Summer Training in July.",

--- a/src/context/searchConfig.ts
+++ b/src/context/searchConfig.ts
@@ -185,6 +185,13 @@ const searchConfig: SearchOption[] = [
         page: "TrainingSettings",
     },
     {
+        id: "disable-stat-targets",
+        title: "Disable Stat Targets",
+        description:
+            "When enabled, all per-distance stat targets are ignored. Every stat is treated as having a target equal to the in-game stat cap (1200), so the bot keeps pushing your top priority stats even after they would normally be considered done. Useful when you want strict adherence to your Stat Prioritization list.",
+        page: "TrainingSettings",
+    },
+    {
         id: "stat-targets-by-distance",
         title: "Stat Targets by Distance",
         description:

--- a/src/lib/messageLog/buildSettingsBanner.ts
+++ b/src/lib/messageLog/buildSettingsBanner.ts
@@ -116,14 +116,15 @@ export function buildSettingsBanner(settings: Settings): string {
 📏 Preferred Distance Override: ${settings.training.preferredDistanceOverride === "Default" ? "Default" : settings.training.preferredDistanceOverride}
 🌈 Enable Rainbow Training Bonus: ${settings.training.enableRainbowTrainingBonus ? "✅" : "❌"}
 💡 Prioritize Skill Hints: ${settings.training.enablePrioritizeSkillHints ? "✅" : "❌"}
+📈 Weight Score by Training Level: ${settings.training.enableTrainingLevelWeighting ? "✅" : "❌"}
 ☀️ Must Rest Before Summer: ${settings.training.mustRestBeforeSummer ? "✅" : "❌"}
 🎯 Train Wit During Finale: ${settings.training.trainWitDuringFinale ? "✅" : "❌"}
 🔍 Training Analysis Validation: ${settings.training.enableTrainingAnalysisValidation ? "✅" : "❌"}
 🤖 Enable YOLO Stat Detection: ${settings.training.enableYoloStatDetection ? "✅" : "❌"}
-🎯 Classic Year Milestone: ${settings.training.classicMilestonePercent}%
-🎯 Senior Year Milestone: ${settings.training.seniorMilestonePercent}%
 
 ---------- Training Stat Targets by Distance ----------
+🎯 Classic Year Milestone: ${settings.training.classicMilestonePercent}%
+🎯 Senior Year Milestone: ${settings.training.seniorMilestonePercent}%
 ${sprintTargetsString}
 ${mileTargetsString}
 ${mediumTargetsString}

--- a/src/lib/messageLog/buildSettingsBanner.ts
+++ b/src/lib/messageLog/buildSettingsBanner.ts
@@ -123,6 +123,7 @@ export function buildSettingsBanner(settings: Settings): string {
 🤖 Enable YOLO Stat Detection: ${settings.training.enableYoloStatDetection ? "✅" : "❌"}
 
 ---------- Training Stat Targets by Distance ----------
+🛑 Disable Stat Targets: ${settings.training.disableStatTargets ? "✅ (all stats treated as cap=1200)" : "❌"}
 🎯 Classic Year Milestone: ${settings.training.classicMilestonePercent}%
 🎯 Senior Year Milestone: ${settings.training.seniorMilestonePercent}%
 ${sprintTargetsString}

--- a/src/pages/TrainingSettings/index.tsx
+++ b/src/pages/TrainingSettings/index.tsx
@@ -110,6 +110,7 @@ const TrainingSettings = () => {
         trainWitDuringFinale,
         enablePrioritizeSkillHints,
         enableTrainingLevelWeighting,
+        disableStatTargets,
         enableTrainingAnalysisValidation,
         enableYoloStatDetection,
     } = trainingSettings
@@ -748,8 +749,19 @@ const TrainingSettings = () => {
                                     </Text>
                                 </View>
 
-                                {/* Stat Target Settings */}
                                 <View style={styles.section}>
+                                    <CustomCheckbox
+                                        checked={disableStatTargets}
+                                        onCheckedChange={(checked) => updateTrainingSetting("disableStatTargets", checked)}
+                                        label="Disable Stat Targets"
+                                        description="When enabled, all per-distance stat targets below are ignored. Every stat is treated as having a target equal to the in-game stat cap (1200), so the bot will keep pushing your top priority stats even after they would normally be considered 'done.' Useful when you want strict adherence to your Stat Prioritization list."
+                                        className="my-2"
+                                        searchId="disable-stat-targets"
+                                    />
+                                </View>
+
+                                {/* Stat Target Settings */}
+                                <View style={[styles.section, disableStatTargets && { opacity: 0.5, pointerEvents: "none" }]}>
                                     <CustomTitle
                                         title="Stat Targets by Distance"
                                         description="Set target values for each stat based on race distance. These stat targets are derived from past Champion Meetings. The bot will prioritize training stats that are below these targets."

--- a/src/pages/TrainingSettings/index.tsx
+++ b/src/pages/TrainingSettings/index.tsx
@@ -109,6 +109,7 @@ const TrainingSettings = () => {
         riskyTrainingMaxFailureChance,
         trainWitDuringFinale,
         enablePrioritizeSkillHints,
+        enableTrainingLevelWeighting,
         enableTrainingAnalysisValidation,
         enableYoloStatDetection,
     } = trainingSettings
@@ -645,6 +646,17 @@ const TrainingSettings = () => {
                                         description="When enabled, the bot will prioritize acquiring skill hints, bypassing stat prioritization and blacklist, while still being constrained by the failure chance thresholds."
                                         className="my-2"
                                         searchId="enable-prioritize-skill-hints"
+                                    />
+                                </View>
+
+                                <View style={styles.section}>
+                                    <CustomCheckbox
+                                        checked={enableTrainingLevelWeighting}
+                                        onCheckedChange={(checked) => updateTrainingSetting("enableTrainingLevelWeighting", checked)}
+                                        label="Weight Score by Training Level"
+                                        description="When enabled (Year 2+), the bot reads each training's level (1-5) via OCR and boosts the score for trainings whose stat sits in the top 3 of your Stat Prioritization list. Helps the bot stick with stats you've invested in. OCR is skipped during Pre-Debut, Junior, and Summer."
+                                        className="my-2"
+                                        searchId="enable-training-level-weighting"
                                     />
                                 </View>
 


### PR DESCRIPTION
## Description

- Detect each training's level (1-5) via OCR and weight the stat-efficiency score so trainings whose stat sits in the top 3 of the Stat Prioritization list get a level-proportional boost - gated by a new `Weight Score by Training Level` toggle.
- Add a `Disable Stat Targets` toggle that overrides per-distance stat targets with the in-game stat cap (1200) so a priority stat staying past its user-defined target no longer collapses its `ratioMultiplier` and keeps competing for picks.
