### PR TITLE
Add DecisionTracer for per-turn decision logging

### DIFF
--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Campaign.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Campaign.kt
@@ -123,6 +123,9 @@ abstract class Campaign(game: Game) : Task(game) {
     /** Required instance of the GameDate class. */
     var date: GameDate = GameDate(day = 1)
 
+    /** Per-turn structured decision logger. Subclasses populate snapshots and reasoning via the various record... methods; the consolidated block is emitted at the end of `executeAction`. */
+    val decisionTracer: DecisionTracer = DecisionTracer()
+
     /** Flag to track whether the bot should force Wit training during the pre-summer turn. */
     var bForcedWitTraining: Boolean = false
 
@@ -814,6 +817,25 @@ abstract class Campaign(game: Game) : Task(game) {
     open fun onMainScreenEntry() {
         return
     }
+
+    /**
+     * Decision-relevant inventory snapshot for the current turn. Subclasses with inventory tracking (e.g. Trackblazer) should override to
+     * return the items that drive their decisions (charms, whistles, megaphones, energy/mood items). Empty map by default for campaigns
+     * without inventory.
+     */
+    open fun gatherDecisionInventory(): Map<String, Int> = emptyMap()
+
+    /**
+     * Decision-relevant settings snapshot for the current turn. Subclasses should populate the snapshot with the user-configurable knobs
+     * that most often drive "why" questions (failure-chance limits, energy thresholds, charm minimums, agenda gating, etc.).
+     */
+    open fun gatherDecisionSettings(): DecisionTracer.SettingsSnapshot = DecisionTracer.SettingsSnapshot()
+
+    /**
+     * Campaign-specific extra state that does not live on `Trainee` itself (for example Trackblazer's `consecutiveRaceCount`). Returned as
+     * a display-friendly key/value map appended to the State section of the Decision Report.
+     */
+    open fun gatherDecisionExtraState(): Map<String, String> = emptyMap()
 
     /**
      * Determines whether item-based mood recovery should override the default mood recovery logic.
@@ -1685,6 +1707,15 @@ abstract class Campaign(game: Game) : Task(game) {
         // Scenario-specific main screen entry hook (e.g. for item usage).
         onMainScreenEntry()
 
+        // Open the per-turn structured decision log. Snapshots state after onMainScreenEntry so item-consumption effects are visible.
+        decisionTracer.startTurn(
+            date = date,
+            trainee = trainee,
+            inventorySnapshot = gatherDecisionInventory(),
+            settings = gatherDecisionSettings(),
+            extraState = gatherDecisionExtraState(),
+        )
+
         // Decision-making process.
         val action = decideNextAction()
         val bIsScheduledRaceDay = LabelScheduledRace.check(game.imageUtils)
@@ -1846,34 +1877,42 @@ abstract class Campaign(game: Game) : Task(game) {
         val bIsMandatoryRaceDay = IconRaceDayRibbon.check(game.imageUtils, sourceBitmap = sourceBitmap)
 
         if (bIsMandatoryRaceDay || bIsScheduledRaceDay) {
+            val reason = if (bIsMandatoryRaceDay) "Mandatory race day" else "Scheduled race day"
+            decisionTracer.recordActionChoice(MainScreenAction.RACE, reason)
             return MainScreenAction.RACE
         }
 
         if (racing.encounteredRacingPopup) {
+            decisionTracer.recordActionChoice(MainScreenAction.RACE, "Racing popup already on screen from prior turn")
             return MainScreenAction.RACE
         }
 
         if (racing.enableForceRacing) {
             MessageLog.i(TAG, "[INFO] Force racing enabled - skipping all other activities and going straight to racing.")
+            decisionTracer.recordActionChoice(MainScreenAction.RACE, "Force racing setting enabled")
             return MainScreenAction.RACE
         }
 
         if (!bHasCheckedForMaidenRaceToday && !date.bIsPreDebut && !trainee.bHasCompletedMaidenRace) {
             MessageLog.i(TAG, "[INFO] Bot has not yet completed maiden race. Checking for valid maiden race...")
+            decisionTracer.recordActionChoice(MainScreenAction.RACE, "Maiden race not yet completed")
             return MainScreenAction.RACE
         }
 
         if (mustRestBeforeSummer && (date.year == DateYear.CLASSIC || date.year == DateYear.SENIOR) && date.month == DateMonth.JUNE && date.phase == DatePhase.LATE) {
             if (trainee.energy < 70) {
                 MessageLog.i(TAG, "[INFO] Energy is low (${trainee.energy}% < 70%). Forcing rest during $date in preparation for Summer Training.")
+                decisionTracer.recordActionChoice(MainScreenAction.REST, "Pre-summer prep (energy ${trainee.energy}% < 70%)")
                 return MainScreenAction.REST
             } else if (trainee.mood < Mood.GREAT && !training.firstTrainingCheck) {
                 MessageLog.i(TAG, "[INFO] Energy is sufficient (>= 70%) but Mood is not Great (${trainee.mood}). Forcing mood recovery during $date in preparation for Summer Training.")
                 forcedTargetMood = Mood.GREAT
+                decisionTracer.recordActionChoice(MainScreenAction.RECOVER_MOOD, "Pre-summer prep (energy >= 70%, mood ${trainee.mood} < GREAT)")
                 return MainScreenAction.RECOVER_MOOD
             } else {
                 MessageLog.i(TAG, "[INFO] Energy is sufficient (>= 70%) and mood is Great. Performing Wit training during $date in preparation for Summer Training.")
                 bForcedWitTraining = true
+                decisionTracer.recordActionChoice(MainScreenAction.TRAIN, "Pre-summer prep (energy and mood sufficient; forced Wit training)")
                 return MainScreenAction.TRAIN
             }
         }
@@ -1881,6 +1920,7 @@ abstract class Campaign(game: Game) : Task(game) {
         val isRacingRequirementActive = racing.hasFanRequirement || racing.hasTrophyRequirement
         if (isRacingRequirementActive) {
             MessageLog.i(TAG, "[INFO] Racing requirement is active. Bypassing health and mood checks.")
+            decisionTracer.recordActionChoice(MainScreenAction.RACE, "Racing requirement (fans or trophy) active")
             return MainScreenAction.RACE
         }
 
@@ -1895,18 +1935,22 @@ abstract class Campaign(game: Game) : Task(game) {
 
         if (hasInjury) {
             // Injury handled internally in checkInjury, but returning NONE as turn is likely over or needs re-evaluation.
+            decisionTracer.recordActionChoice(MainScreenAction.NONE, "Injury detected and handled internally; turn aborted for re-evaluation")
             return MainScreenAction.NONE
         }
 
         if (shouldRecoverMood(sourceBitmap)) {
+            decisionTracer.recordActionChoice(MainScreenAction.RECOVER_MOOD, "shouldRecoverMood returned true (mood ${trainee.mood})")
             return MainScreenAction.RECOVER_MOOD
         }
 
         if (racing.checkEligibilityToStartExtraRacingProcess()) {
             MessageLog.i(TAG, "[INFO] Bot has no injuries, mood is sufficient and extra races can be run today. Setting the action to RACE.")
+            decisionTracer.recordActionChoice(MainScreenAction.RACE, "Extra-race eligible (no injury, sufficient mood, eligible day)")
             return MainScreenAction.RACE
         }
 
+        decisionTracer.recordActionChoice(MainScreenAction.TRAIN, "Default fallback after racing/mood/injury checks did not trigger")
         return MainScreenAction.TRAIN
     }
 
@@ -1924,6 +1968,7 @@ abstract class Campaign(game: Game) : Task(game) {
             training.handleTraining(StatName.WIT)
             bForcedWitTraining = false
             bHasCheckedDateThisTurn = false
+            decisionTracer.emit()
             return true
         }
 
@@ -1961,6 +2006,7 @@ abstract class Campaign(game: Game) : Task(game) {
                 return false
             }
         }
+        decisionTracer.emit()
         return true
     }
 

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/DecisionTracer.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/DecisionTracer.kt
@@ -1,0 +1,512 @@
+package com.steve1316.uma_android_automation.bot
+
+import com.steve1316.automation_library.utils.MessageLog
+import com.steve1316.uma_android_automation.types.GameDate
+import com.steve1316.uma_android_automation.types.Mood
+import com.steve1316.uma_android_automation.types.StatName
+import com.steve1316.uma_android_automation.types.Trainee
+
+/**
+ * Per-turn structured decision logger.
+ *
+ * Captures every notable decision the bot makes during a main-screen turn (action choice, item use, training selection, race eligibility, etc.) and
+ * emits a single consolidated block at turn end via `MessageLog.i`. The block is modeled on the existing `Item Usage Summary` and `Training Analysis
+ * Results` blocks so users have a single greppable section that answers "why did the bot do X this turn?".
+ *
+ * `startTurn(...)` snapshots state at the beginning of a main-screen decision. The various `record...` methods append events as the decision tree is
+ * walked. `emit()` flushes the formatted block once and clears the buffer. Existing `MessageLog.i/v/w/e` lines are left untouched so chronological tracing is unaffected.
+ */
+class DecisionTracer {
+    /** Header for the current turn's Decision Report block (e.g. "Turn 25 (CLASSIC EARLY JANUARY)"). */
+    private var turnLabel: String = ""
+
+    /** Snapshot of trainee and campaign state captured by `startTurn`. */
+    private var stateSnapshot: StateSnapshot? = null
+
+    /** Snapshot of decision-relevant settings captured by `startTurn`. */
+    private var settingsSnapshot: SettingsSnapshot? = null
+
+    /** Ordered list of decision events recorded this turn. */
+    private val events: MutableList<DecisionEvent> = mutableListOf()
+
+    /** True once `emit()` has flushed this turn's block, so subsequent calls become no-ops. */
+    private var hasEmitted: Boolean = false
+
+    // //////////////////////////////////////////////////////////////////////////////////////////////////
+    // //////////////////////////////////////////////////////////////////////////////////////////////////
+    // Data types
+
+    /** Snapshot of trainee and campaign state at the start of a turn. */
+    data class StateSnapshot(
+        /** Trainee's current energy percentage (0-100). */
+        val energy: Int,
+        /** Trainee's current mood at decision time. */
+        val mood: Mood,
+        /** Active negative status names. Empty when none. */
+        val negativeStatuses: List<String>,
+        /** Map of decision-relevant inventory item names to counts. May be empty for campaigns without inventory tracking. */
+        val inventory: Map<String, Int>,
+        /** Campaign-specific extra state (e.g. `consecutiveRaceCount` for Trackblazer) as displayable key/value pairs. */
+        val extra: Map<String, String>,
+    )
+
+    /** Settings that influence this turn's decision tree. Subclasses populate via the builder. */
+    class SettingsSnapshot {
+        /** Ordered map of setting display name to formatted value. */
+        val entries: LinkedHashMap<String, String> = LinkedHashMap()
+
+        /**
+         * Append a setting to the snapshot in insertion order.
+         *
+         * @param key Display name of the setting (e.g. "Max Failure Chance").
+         * @param value Setting value. Coerced to string via `toString()`. Null renders as "(unset)".
+         * @return This snapshot for chained `.add(...)` calls.
+         */
+        fun add(key: String, value: Any?): SettingsSnapshot {
+            entries[key] = value?.toString() ?: "(unset)"
+            return this
+        }
+    }
+
+    /** An action that was considered but not chosen, plus the short reason it was rejected. */
+    data class RejectedAlternative(
+        /** Display name of the rejected action (e.g. "REST", "RACE", "RECOVER_MOOD"). */
+        val action: String,
+        /** One-line reason this action was not chosen. */
+        val reason: String,
+    )
+
+    /** A training that lost the scoring contest, with its score and rejection reason for the Decision Report's runner-ups list. */
+    data class TrainingRunnerUp(
+        /** The stat whose training was scored. */
+        val stat: StatName,
+        /** True if this training was filtered out (blacklist, failure-chance gate, etc.). False if simply outscored. */
+        val rejected: Boolean,
+        /** Short reason explaining the verdict. */
+        val reason: String,
+        /** Optional numeric score from the scoring function. Null when scoring data was not captured at the call site. */
+        val score: Double? = null,
+        /** Optional failure chance percentage for this training, when available. */
+        val failureChance: Int? = null,
+        /** Optional full stat-gain map for this training (gain per `StatName`). Renders as `gains=[SPD:N STA:N PWR:N GUTS:N WIT:N]` when present. */
+        val statGains: Map<StatName, Int>? = null,
+    )
+
+    /** Verdict for an inventory item considered during a turn. */
+    enum class ItemVerdict { USED, SKIPPED, CONSERVED, NOT_PRESENT }
+
+    /** Verdict for the Reset Whistle path. */
+    enum class WhistleVerdict { USED, BLOCKED, NOT_ELIGIBLE, NOT_IN_INVENTORY }
+
+    /** Internal event record produced by the various `record...` methods. */
+    sealed class DecisionEvent {
+        /** Event recording the main-screen action chosen for this turn. */
+        data class ActionChoice(
+            /** The action the bot will execute. */
+            val chosen: MainScreenAction,
+            /** Short human-readable explanation of why this action won. */
+            val reason: String,
+            /** Alternatives that were considered and ruled out, in evaluation order. */
+            val rejected: List<RejectedAlternative>,
+        ) : DecisionEvent()
+
+        /** Event recording a decision about a specific inventory item. */
+        data class ItemDecision(
+            /** Display name of the item considered (e.g. "Empowering Megaphone"). */
+            val item: String,
+            /** What the bot decided to do with the item. */
+            val verdict: ItemVerdict,
+            /** Short explanation supporting the verdict. */
+            val reason: String,
+        ) : DecisionEvent()
+
+        /** Event recording the outcome of the Good-Luck Charm gating decision. */
+        data class CharmGate(
+            /** True if the charm was queued for use this turn. */
+            val queued: Boolean,
+            /** When `queued=false`, the short name of the gate that blocked it (e.g. "min stat gain not met"). */
+            val blockingGate: String?,
+        ) : DecisionEvent()
+
+        /** Event recording the outcome of the Reset Whistle decision. */
+        data class WhistleOutcome(
+            /** The Whistle's final disposition. */
+            val verdict: WhistleVerdict,
+            /** Short explanation of the verdict. */
+            val reason: String,
+            /** When the Whistle was used, the new training selected by the re-analysis pass. */
+            val postRollSelection: StatName?,
+        ) : DecisionEvent()
+
+        /** Event recording the final training selection plus runner-up breakdown. */
+        data class TrainingSelection(
+            /** The picked stat, or null when no training was chosen this turn. */
+            val selected: StatName?,
+            /** Code path that produced the pick (analysis, forced-default, forced-from-skipped, etc.). */
+            val source: SelectionSource?,
+            /** Short explanation of why this pick won. */
+            val reason: String,
+            /** Other trainings the analyzer evaluated this turn, with their scores and rejection reasons. */
+            val runnerUps: List<TrainingRunnerUp>,
+            /** Failure chance percentage for the picked training, when available. Rendered as a `Pick:` line in the report. */
+            val pickedFailureChance: Int? = null,
+            /** Full stat-gain map for the picked training, when available. Rendered alongside `pickedFailureChance` on the `Pick:` line. */
+            val pickedStatGains: Map<StatName, Int>? = null,
+        ) : DecisionEvent()
+
+        /** Event recording whether the bot is eligible to race this turn. */
+        data class RaceEligibility(
+            /** True if the bot may race. False if a gate blocked it. */
+            val eligible: Boolean,
+            /** Short explanation of the eligibility decision. */
+            val reason: String,
+        ) : DecisionEvent()
+
+        /** Free-form note for context that doesn't fit any other event type. */
+        data class Note(
+            /** Note text to display in the Decision Report. */
+            val message: String,
+        ) : DecisionEvent()
+
+        /** Event recording that the bot abandoned its original action and executed a recovery instead. */
+        data class RecoveryExecuted(
+            /** The recovery action that executed (e.g. "RECOVER_ENERGY", "RECOVER_MOOD"). */
+            val action: String,
+            /** Short explanation of why recovery happened. */
+            val reason: String,
+        ) : DecisionEvent()
+    }
+
+    companion object {
+        /** Log tag prepended to every Decision Report block emitted via `MessageLog.i`. */
+        private const val TAG: String = "[DECISION]"
+    }
+
+    // //////////////////////////////////////////////////////////////////////////////////////////////////
+    // //////////////////////////////////////////////////////////////////////////////////////////////////
+    // Lifecycle
+
+    /**
+     * Open a new decision-tracing window for the current turn. Resets all per-turn buffers.
+     *
+     * @param date Current game date used for the turn label.
+     * @param trainee Live trainee whose state is snapshotted (shallow copy of relevant fields).
+     * @param inventorySnapshot Decision-relevant inventory counts. Pass an empty map when the campaign has no inventory concept.
+     * @param settings Settings values that drive decisions this turn.
+     * @param extraState Optional map of campaign-specific state values (e.g. Trackblazer's `consecutiveRaceCount`) that the base trainee snapshot does not carry.
+     */
+    fun startTurn(date: GameDate, trainee: Trainee, inventorySnapshot: Map<String, Int> = emptyMap(), settings: SettingsSnapshot = SettingsSnapshot(), extraState: Map<String, String> = emptyMap()) {
+        turnLabel = formatTurnLabel(date)
+        stateSnapshot =
+            StateSnapshot(
+                energy = trainee.energy,
+                mood = trainee.mood,
+                negativeStatuses = trainee.currentNegativeStatuses.toList(),
+                inventory = inventorySnapshot.toMap(),
+                extra = extraState.toMap(),
+            )
+        settingsSnapshot = settings
+        events.clear()
+        hasEmitted = false
+    }
+
+    /**
+     * Emit the consolidated Decision Report block for the current turn and clear the buffer. No-op if `startTurn` was never called or if the block has
+     * already been emitted for this turn (subsequent re-emits during the same turn are silently dropped).
+     */
+    fun emit() {
+        if (hasEmitted || stateSnapshot == null) return
+        MessageLog.i(TAG, formatReport())
+        hasEmitted = true
+    }
+
+    // //////////////////////////////////////////////////////////////////////////////////////////////////
+    // //////////////////////////////////////////////////////////////////////////////////////////////////
+    // Recording methods
+
+    /**
+     * Record the main-screen action chosen this turn and any alternatives that were considered but rejected.
+     *
+     * @param chosen The action the bot will execute.
+     * @param reason Short human-readable explanation of why this action won.
+     * @param rejected Alternatives that were considered and ruled out, in evaluation order.
+     */
+    fun recordActionChoice(chosen: MainScreenAction, reason: String, rejected: List<RejectedAlternative> = emptyList()) {
+        events.add(DecisionEvent.ActionChoice(chosen, reason, rejected))
+    }
+
+    /**
+     * Append a free-form note for context that doesn't fit any other event type.
+     *
+     * @param message Note text to display in the Decision Report.
+     */
+    fun recordNote(message: String) {
+        events.add(DecisionEvent.Note(message))
+    }
+
+    /**
+     * Record that the bot abandoned its original action and executed a recovery instead (REST or RECOVER_MOOD). Used by training-backout branches that
+     * fall through to `recoverEnergy()` / `recoverMood()` after the analyzer fails to pick a training, so the report shows the real final action.
+     *
+     * @param action The recovery action that executed (e.g. "RECOVER_ENERGY", "RECOVER_MOOD").
+     * @param reason Short explanation of why recovery happened.
+     */
+    fun recordRecoveryExecuted(action: String, reason: String) {
+        events.add(DecisionEvent.RecoveryExecuted(action, reason))
+    }
+
+    /**
+     * Record a decision about a specific inventory item (used, skipped, conserved for later, or not present).
+     *
+     * @param item Display name of the item considered (e.g. "Empowering Megaphone", "Plain Cupcake").
+     * @param verdict What the bot decided to do with the item.
+     * @param reason Short explanation supporting the verdict.
+     */
+    fun recordItemDecision(item: String, verdict: ItemVerdict, reason: String) {
+        events.add(DecisionEvent.ItemDecision(item, verdict, reason))
+    }
+
+    /**
+     * Record the outcome of the Good-Luck Charm gating decision.
+     *
+     * @param queued True if the charm was queued for use this turn.
+     * @param blockingGate When `queued=false`, the short name of the gate that blocked it (e.g. "min stat gain not met").
+     */
+    fun recordCharmGate(queued: Boolean, blockingGate: String? = null) {
+        events.add(DecisionEvent.CharmGate(queued, blockingGate))
+    }
+
+    /**
+     * Record the outcome of the Reset Whistle decision (used, blocked, not eligible, or absent from inventory).
+     *
+     * @param verdict The Whistle's final disposition.
+     * @param reason Short explanation of the verdict.
+     * @param postRollSelection When the Whistle was used, the new training selected by the re-analysis pass.
+     */
+    fun recordWhistleOutcome(verdict: WhistleVerdict, reason: String, postRollSelection: StatName? = null) {
+        events.add(DecisionEvent.WhistleOutcome(verdict, reason, postRollSelection))
+    }
+
+    /**
+     * Record the final training selection plus runner-up data for the Decision Report's training breakdown.
+     *
+     * @param selected The picked stat, or null when no training was chosen and the bot backed out for recovery.
+     * @param source Code path that produced the pick (analysis, forced-default, forced-from-skipped, etc.).
+     * @param reason Short explanation of why this pick won.
+     * @param runnerUps Other trainings the analyzer evaluated this turn, with their scores and rejection reasons.
+     * @param pickedFailureChance Failure chance percentage for the picked training, when available.
+     * @param pickedStatGains Full stat-gain map for the picked training, when available.
+     */
+    fun recordTrainingSelection(
+        selected: StatName?,
+        source: SelectionSource?,
+        reason: String,
+        runnerUps: List<TrainingRunnerUp> = emptyList(),
+        pickedFailureChance: Int? = null,
+        pickedStatGains: Map<StatName, Int>? = null,
+    ) {
+        events.add(DecisionEvent.TrainingSelection(selected, source, reason, runnerUps, pickedFailureChance, pickedStatGains))
+    }
+
+    /**
+     * Record whether the bot is eligible to race this turn based on consecutive-race rules.
+     *
+     * @param eligible True if the bot may race. False if a gate blocked it.
+     * @param reason Short explanation of the eligibility decision.
+     */
+    fun recordRaceEligibility(eligible: Boolean, reason: String) {
+        events.add(DecisionEvent.RaceEligibility(eligible, reason))
+    }
+
+    // //////////////////////////////////////////////////////////////////////////////////////////////////
+    // //////////////////////////////////////////////////////////////////////////////////////////////////
+    // Formatting
+
+    /**
+     * Build the consolidated Decision Report string for the current turn.
+     *
+     * @return Multi-line report block ready to be passed to `MessageLog.i`. Empty when no state was snapshotted.
+     */
+    private fun formatReport(): String {
+        val state = stateSnapshot ?: return ""
+        val settings = settingsSnapshot ?: SettingsSnapshot()
+        val sb = StringBuilder()
+        sb.append("\n============== $turnLabel Decision Report ==============\n")
+        sb.append(formatStateSection(state))
+        sb.append(formatSettingsSection(settings))
+        sb.append(formatItemsUsedSection())
+        sb.append(formatEventsSection())
+        sb.append("==============================================================")
+        return sb.toString()
+    }
+
+    /**
+     * Render the State and Inventory sections of the report.
+     *
+     * @param state The state snapshot to render.
+     * @return Formatted State and Inventory lines.
+     */
+    private fun formatStateSection(state: StateSnapshot): String {
+        val sb = StringBuilder()
+        sb.append("State:\n")
+        sb.append("  Energy = ${state.energy}%\n")
+        sb.append("  Mood = ${state.mood}\n")
+        sb.append("  Negative Statuses = ${if (state.negativeStatuses.isEmpty()) "[]" else state.negativeStatuses.joinToString(", ", "[", "]")}\n")
+        state.extra.forEach { (key, value) -> sb.append("  $key = $value\n") }
+        if (state.inventory.isNotEmpty()) {
+            sb.append("Inventory (decision-relevant):\n")
+            state.inventory.toSortedMap().forEach { (name, count) -> sb.append("  $name = $count\n") }
+        }
+        return sb.toString()
+    }
+
+    /**
+     * Render the Settings section of the report, or an empty string when no settings were captured.
+     *
+     * @param settings The settings snapshot to render.
+     * @return Formatted Settings lines, or empty string when there is nothing to show.
+     */
+    private fun formatSettingsSection(settings: SettingsSnapshot): String {
+        if (settings.entries.isEmpty()) return ""
+        val sb = StringBuilder()
+        sb.append("Settings (decision-relevant):\n")
+        settings.entries.forEach { (key, value) -> sb.append("  $key = $value\n") }
+        return sb.toString()
+    }
+
+    /**
+     * Render the consolidated "Items Used" summary that mirrors the existing `Item Usage Summary` block. Lists every inventory item the bot actually
+     * consumed this turn (Megaphones, energy/mood items, Good-Luck Charm, Reset Whistle). The per-event lines below still carry the full reasoning. This
+     * section is the quick "what got used?" reference at the top of the report.
+     *
+     * @return Formatted Items Used section, or "Items Used: None" when nothing was consumed.
+     */
+    private fun formatItemsUsedSection(): String {
+        data class UsedItem(val name: String, val reason: String?)
+        val used = mutableListOf<UsedItem>()
+        events.forEach { event ->
+            when (event) {
+                is DecisionEvent.ItemDecision ->
+                    if (event.verdict == ItemVerdict.USED) used.add(UsedItem(event.item, event.reason))
+                is DecisionEvent.CharmGate ->
+                    if (event.queued) used.add(UsedItem("Good-Luck Charm", "Charm gate passed; setting failure chance to 0%"))
+                is DecisionEvent.WhistleOutcome ->
+                    if (event.verdict == WhistleVerdict.USED) used.add(UsedItem("Reset Whistle", event.reason))
+                else -> Unit
+            }
+        }
+        if (used.isEmpty()) return "Items Used: None\n"
+        val sb = StringBuilder()
+        sb.append("Items Used:\n")
+        used.forEach { item ->
+            if (item.reason.isNullOrBlank()) {
+                sb.append("  - ${item.name}\n")
+            } else {
+                sb.append("  - ${item.name}: ${item.reason}\n")
+            }
+        }
+        return sb.toString()
+    }
+
+    /**
+     * Render the per-event section that walks through each decision event in recording order.
+     *
+     * @return Formatted event lines, or "No decision events recorded." when the event list is empty.
+     */
+    private fun formatEventsSection(): String {
+        if (events.isEmpty()) {
+            return "No decision events recorded.\n"
+        }
+        val sb = StringBuilder()
+        events.forEach { event ->
+            when (event) {
+                is DecisionEvent.ActionChoice -> {
+                    sb.append("\nAction: ${event.chosen}\n")
+                    sb.append("  Reason: ${event.reason}\n")
+                    if (event.rejected.isNotEmpty()) {
+                        sb.append("  Rejected alternatives:\n")
+                        event.rejected.forEach { sb.append("    - ${it.action}: ${it.reason}\n") }
+                    }
+                }
+                is DecisionEvent.ItemDecision -> {
+                    // USED items are already listed in the top-level Items Used section, so suppress the per-event render to avoid duplication.
+                    if (event.verdict != ItemVerdict.USED) {
+                        sb.append("\nItem: ${event.item} -> ${event.verdict}\n")
+                        sb.append("  Reason: ${event.reason}\n")
+                    }
+                }
+                is DecisionEvent.CharmGate -> {
+                    // Queued charm uses are already in the Items Used section. Render only when the charm was blocked, so the gate explanation surfaces.
+                    if (!event.queued) {
+                        sb.append("\nCharm: NOT QUEUED\n")
+                        event.blockingGate?.let { sb.append("  Gate: $it\n") }
+                    }
+                }
+                is DecisionEvent.WhistleOutcome -> {
+                    sb.append("\nWhistle: ${event.verdict}\n")
+                    sb.append("  Reason: ${event.reason}\n")
+                    event.postRollSelection?.let { sb.append("  Post-roll selection: $it\n") }
+                }
+                is DecisionEvent.TrainingSelection -> {
+                    val pick = event.selected?.name ?: "NONE"
+                    sb.append("\nTraining selected: $pick (source=${event.source ?: "unset"})\n")
+                    sb.append("  Reason: ${event.reason}\n")
+                    if (event.pickedFailureChance != null || event.pickedStatGains != null) {
+                        val pieces =
+                            listOfNotNull(
+                                event.pickedFailureChance?.let { "fail=$it%" },
+                                event.pickedStatGains?.let { "gains=${formatStatGains(it)}" },
+                            )
+                        if (pieces.isNotEmpty()) sb.append("  Pick: ${pieces.joinToString(", ")}\n")
+                    }
+                    if (event.runnerUps.isNotEmpty()) {
+                        sb.append("  Runner-ups:\n")
+                        event.runnerUps.forEach { ru ->
+                            val verdict = if (ru.rejected) "REJECTED" else "considered"
+                            val scoreFragment = ru.score?.let { "score=${"%.2f".format(it)}, " } ?: ""
+                            val failFragment = ru.failureChance?.let { "fail=$it%, " } ?: ""
+                            val gainFragment = ru.statGains?.let { gains -> "gains=${formatStatGains(gains)}, " } ?: ""
+                            sb.append("    - ${ru.stat} ($verdict): $scoreFragment$failFragment$gainFragment${ru.reason}\n")
+                        }
+                    }
+                }
+                is DecisionEvent.RaceEligibility -> {
+                    sb.append("\nRace eligibility: ${if (event.eligible) "ELIGIBLE" else "NOT ELIGIBLE"}\n")
+                    sb.append("  Reason: ${event.reason}\n")
+                }
+                is DecisionEvent.Note -> {
+                    sb.append("\nNote: ${event.message}\n")
+                }
+                is DecisionEvent.RecoveryExecuted -> {
+                    sb.append("\nRecovery executed: ${event.action}\n")
+                    sb.append("  Reason: ${event.reason}\n")
+                }
+            }
+        }
+        return sb.toString()
+    }
+
+    /**
+     * Render a stat-gain map as a fixed-order bracketed list (`[SPD:2 STA:11 PWR:1 GUTS:0 WIT:0]`). Missing keys render as 0 so every line has the same width.
+     *
+     * @param gains Stat-gain values keyed by stat.
+     * @return Bracketed string showing each stat in the canonical SPD/STA/PWR/GUTS/WIT order.
+     */
+    private fun formatStatGains(gains: Map<StatName, Int>): String {
+        val order = listOf(StatName.SPEED to "SPD", StatName.STAMINA to "STA", StatName.POWER to "PWR", StatName.GUTS to "GUTS", StatName.WIT to "WIT")
+        return order.joinToString(separator = " ", prefix = "[", postfix = "]") { (stat, label) -> "$label:${gains[stat] ?: 0}" }
+    }
+
+    /**
+     * Build the turn label header (e.g. "Turn 25 (CLASSIC EARLY JANUARY)") used at the top of every Decision Report block.
+     *
+     * @param date The current game date.
+     * @return Formatted turn label string.
+     */
+    private fun formatTurnLabel(date: GameDate): String {
+        val year = date.year.toString().replace('_', ' ')
+        val month = date.month.toString().replace('_', ' ')
+        val phase = date.phase.toString().replace('_', ' ')
+        return "Turn ${date.day} ($year $phase $month)"
+    }
+}

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Racing.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Racing.kt
@@ -717,18 +717,28 @@ class Racing(private val game: Game, private val campaign: Campaign) {
         // Don't bother looking for races on Junior Year Early July (Turn 13) since they only start showing up on Turn 14.
         if (campaign.date.day == 13) {
             MessageLog.i(TAG, "[RACE] Junior Year Early July (Turn 13) detected. No races available until Turn 14. Skipping extra race check.")
+            campaign.decisionTracer.recordRaceEligibility(eligible = false, reason = "Junior Year Early July (Turn 13) - no races available until Turn 14")
             return false
         }
 
         // If the user wants to limit extra races to ONLY those scheduled in their in-game racing agenda.
         if (enableUserInGameRaceAgenda && limitRacesToInGameAgenda) {
             MessageLog.i(TAG, "[RACE] Skipping extra race check due to 'Limit Extra Races to Agenda' setting in favor of those scheduled by the user's in-game racing agenda.")
+            campaign.decisionTracer.recordRaceEligibility(eligible = false, reason = "Limit Extra Races to Agenda setting is on; no agenda race scheduled for this turn")
             return false
         }
 
         // If the setting to force racing extra races is enabled or we have a specific requirement, always return true.
         if (enableForceRacing || hasFanRequirement || hasTrophyRequirement || hasInsufficientGoalRacePtsRequirement) {
             Log.d(TAG, "[DEBUG] checkEligibilityToStartExtraRacingProcess:: Force racing or requirement is active so eligibility will be true.")
+            val activeReason =
+                listOf(
+                    if (enableForceRacing) "force-racing" else null,
+                    if (hasFanRequirement) "fan-requirement" else null,
+                    if (hasTrophyRequirement) "trophy-requirement" else null,
+                    if (hasInsufficientGoalRacePtsRequirement) "insufficient-goal-pts" else null,
+                ).filterNotNull().joinToString(", ")
+            campaign.decisionTracer.recordRaceEligibility(eligible = true, reason = "Hard requirement active: $activeReason")
             return true
         }
 
@@ -739,10 +749,13 @@ class Racing(private val game: Game, private val campaign: Campaign) {
             val plannedKey = SmartRaceSolverIntegration.peekRaceKeyForTurn(currentTurn = campaign.date.day, scenario = game.scenario)
             if (plannedKey == null) {
                 MessageLog.i(TAG, "[RACE] Smart Race Solver has no race planned for turn ${campaign.date.day}. Skipping the extra-race fallback.")
+                campaign.decisionTracer.recordRaceEligibility(eligible = false, reason = "Smart Race Solver has no race planned for this turn")
                 return false
             }
             MessageLog.i(TAG, "[RACE] Smart Race Solver has \"$plannedKey\" planned for turn ${campaign.date.day}. Proceeding to racing screen.")
-            return !raceRepeatWarningCheck
+            val result = !raceRepeatWarningCheck
+            campaign.decisionTracer.recordRaceEligibility(eligible = result, reason = "Smart Race Solver planned race \"$plannedKey\" (raceRepeatWarning=$raceRepeatWarningCheck)")
+            return result
         }
 
         // For scenarios that race as often as possible, bypass most checks.
@@ -752,23 +765,30 @@ class Racing(private val game: Game, private val campaign: Campaign) {
             // Still check for finals and summer as they are hard restrictions.
             if (campaign.checkFinals()) {
                 MessageLog.i(TAG, "[RACE] It is UMA Finals right now so there will be no extra races. Stopping extra race check.")
+                campaign.decisionTracer.recordRaceEligibility(eligible = false, reason = "UMA Finals - no extra races")
                 return false
             } else if (campaign.date.isSummer() && !(skipSummerTrainingForAgenda && enableUserInGameRaceAgenda)) {
                 MessageLog.i(TAG, "[RACE] It is currently Summer right now. Stopping extra race check.")
+                campaign.decisionTracer.recordRaceEligibility(eligible = false, reason = "Summer - no extra races (skipSummerTrainingForAgenda not active)")
                 return false
             } else if (ButtonRaces.checkDisabled(game.imageUtils) == true) {
                 MessageLog.i(TAG, "[RACE] Extra Races button is currently locked. Stopping extra race check.")
+                campaign.decisionTracer.recordRaceEligibility(eligible = false, reason = "Extra Races button is currently locked / disabled")
                 return false
             }
 
-            return !raceRepeatWarningCheck
+            val result = !raceRepeatWarningCheck
+            campaign.decisionTracer.recordRaceEligibility(eligible = result, reason = "Scenario bypasses smart racing (raceRepeatWarning=$raceRepeatWarningCheck)")
+            return result
         }
 
         // If fan or trophy requirement is detected, bypass smart racing logic to force racing.
         // Both requirements are independent of racing plan and farming fans settings.
         if (hasFanRequirement) {
             MessageLog.i(TAG, "[RACE] Fan requirement detected. Bypassing smart racing logic to fulfill requirement.")
-            return !raceRepeatWarningCheck
+            val result = !raceRepeatWarningCheck
+            campaign.decisionTracer.recordRaceEligibility(eligible = result, reason = "Fan requirement active (raceRepeatWarning=$raceRepeatWarningCheck)")
+            return result
         } else if (hasTrophyRequirement) {
             if (hasPreOpOrAboveRequirement || hasG3OrAboveRequirement) {
                 if (hasPreOpOrAboveRequirement) {
@@ -776,7 +796,9 @@ class Racing(private val game: Game, private val campaign: Campaign) {
                 } else {
                     MessageLog.i(TAG, "[RACE] Trophy requirement with G3 or above criteria detected. Proceeding to racing screen.")
                 }
-                return !raceRepeatWarningCheck
+                val result = !raceRepeatWarningCheck
+                campaign.decisionTracer.recordRaceEligibility(eligible = result, reason = "Trophy requirement with Pre-OP/G3+ criteria (raceRepeatWarning=$raceRepeatWarningCheck)")
+                return result
             }
 
             // Check if G1 races exist at current turn before proceeding.
@@ -788,17 +810,32 @@ class Racing(private val game: Game, private val campaign: Campaign) {
                     MessageLog.i(TAG, "[RACE] Trophy requirement detected but no G1 races at turn ${campaign.date.day}. Allowing regular racing on eligible day.")
                 } else {
                     MessageLog.i(TAG, "[RACE] Trophy requirement detected but no G1 races available at turn ${campaign.date.day} and not a regular racing day. Skipping racing.")
+                    campaign.decisionTracer.recordRaceEligibility(eligible = false, reason = "Trophy requirement: no G1 races at this turn and not a regular racing day")
                     return false
                 }
             } else {
                 MessageLog.i(TAG, "[RACE] Trophy requirement detected. G1 races available at turn ${campaign.date.day}. Proceeding to racing screen.")
             }
 
-            return !raceRepeatWarningCheck
+            val result = !raceRepeatWarningCheck
+            campaign.decisionTracer.recordRaceEligibility(
+                eligible = result,
+                reason = "Trophy requirement: G1 races available or eligible regular racing day (raceRepeatWarning=$raceRepeatWarningCheck)",
+            )
+            return result
         }
 
         // Standard racing fallback: race on every Nth day of the racing interval.
-        return enableFarmingFans && (turnsRemaining % daysToRunExtraRaces == 0) && !raceRepeatWarningCheck
+        val result = enableFarmingFans && (turnsRemaining % daysToRunExtraRaces == 0) && !raceRepeatWarningCheck
+        val fallbackReason =
+            when {
+                !enableFarmingFans -> "Farming Fans setting is off"
+                (turnsRemaining % daysToRunExtraRaces) != 0 -> "Not a racing-interval day ($turnsRemaining turns remaining, every $daysToRunExtraRaces days)"
+                raceRepeatWarningCheck -> "Race repeat warning is active"
+                else -> "Standard fallback: every-$daysToRunExtraRaces-day racing window matched"
+            }
+        campaign.decisionTracer.recordRaceEligibility(eligible = result, reason = fallbackReason)
+        return result
     }
 
     /**
@@ -1505,8 +1542,13 @@ class Racing(private val game: Game, private val campaign: Campaign) {
             campaign.handleDialogs(args = mapOf("overrideIgnoreConsecutiveRaceWarning" to true))
             return handleMaidenRace()
         } else if ((!campaign.date.bIsPreDebut && ButtonRaces.click(game.imageUtils)) || isScheduledRace) {
+            // SRS-planned races bypass the consecutive-race limit. SRS owns the schedule, so its picks must not be gated by the local limit.
+            val isSrsScheduledRace =
+                enableSmartRaceSolver &&
+                    !enableForceRacing &&
+                    SmartRaceSolverIntegration.peekRaceKeyForTurn(currentTurn = campaign.date.day, scenario = game.scenario) != null
             var overrideIgnore = false
-            if (isScheduledRace || hasFanRequirement || hasTrophyRequirement || hasInsufficientGoalRacePtsRequirement) {
+            if (isScheduledRace || hasFanRequirement || hasTrophyRequirement || hasInsufficientGoalRacePtsRequirement || isSrsScheduledRace) {
                 MessageLog.v(TAG, "[RACE] Racing requirement is active. Ignoring consecutive race warning.")
                 overrideIgnore = true
             }
@@ -1872,7 +1914,12 @@ class Racing(private val game: Game, private val campaign: Campaign) {
         // If there is a scheduled race pending, proceed to run it immediately.
         if (!isScheduledRace) {
             // Check for the consecutive race dialog before proceeding.
-            val overrideIgnore: Boolean = isScheduledRace || enableForceRacing || hasInsufficientGoalRacePtsRequirement
+            // SRS-planned races bypass the consecutive-race limit because the solver owns the racing schedule.
+            val isSrsScheduledRace =
+                enableSmartRaceSolver &&
+                    !enableForceRacing &&
+                    SmartRaceSolverIntegration.peekRaceKeyForTurn(currentTurn = campaign.date.day, scenario = game.scenario) != null
+            val overrideIgnore: Boolean = isScheduledRace || enableForceRacing || hasInsufficientGoalRacePtsRequirement || isSrsScheduledRace
             val result: DialogHandlerResult = campaign.handleDialogs(args = mapOf("overrideIgnoreConsecutiveRaceWarning" to overrideIgnore))
             if (result is DialogHandlerResult.Handled &&
                 result.dialog.name == "consecutive_race_warning" &&

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Training.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Training.kt
@@ -2467,21 +2467,40 @@ open class Training(protected val game: Game, protected val campaign: Campaign) 
                 // Check if we should force Wit training during the Finale instead of recovering energy.
                 // Always force Wit on turn 75 since recovering energy on the very last turn is completely useless.
                 if ((trainWitDuringFinale && campaign.date.day > 72) || campaign.date.day == 75) {
-                    if (campaign.date.day == 75) {
-                        MessageLog.v(TAG, "[TRAINING] It is the final turn. Forcing Wit training instead of recovering energy since resting provides zero benefit now.")
-                    } else {
-                        MessageLog.v(TAG, "[TRAINING] There is not enough energy for training to be done but the setting to train Wit during the Finale is enabled. Forcing Wit training...")
-                    }
+                    val finaleReason =
+                        if (campaign.date.day == 75) {
+                            MessageLog.v(TAG, "[TRAINING] It is the final turn. Forcing Wit training instead of recovering energy since resting provides zero benefit now.")
+                            "Finale Turn 75: forcing WIT via direct button click (resting on final turn is wasteful)"
+                        } else {
+                            MessageLog.v(TAG, "[TRAINING] There is not enough energy for training to be done but the setting to train Wit during the Finale is enabled. Forcing Wit training...")
+                            "Finale forced WIT (trainWitDuringFinale enabled and day>72, no other training viable)"
+                        }
                     // Directly attempt to tap Wit training.
                     if (ButtonTrainingWit.click(game.imageUtils, taps = 3)) {
                         game.waitForLoading()
                         MessageLog.v(TAG, "[TRAINING] Successfully forced Wit training during the Finale instead of recovering energy.")
+                        campaign.decisionTracer.recordTrainingSelection(
+                            selected = StatName.WIT,
+                            source = SelectionSource.FORCED_DEFAULT,
+                            reason = finaleReason,
+                            runnerUps = buildRunnerUps(StatName.WIT),
+                        )
                         firstTrainingCheck = false
                     } else {
                         MessageLog.w(TAG, "[WARN] handleTraining:: Could not find Wit training button. Falling back to recovering energy...")
+                        campaign.decisionTracer.recordTrainingSelection(
+                            selected = null,
+                            source = lastSelectionSource,
+                            reason = "$finaleReason - but WIT button click failed; falling back to energy recovery",
+                            runnerUps = buildRunnerUps(null),
+                        )
                         ButtonBack.click(game.imageUtils)
                         game.wait(1.0)
                         if (campaign.checkMainScreen()) {
+                            campaign.decisionTracer.recordRecoveryExecuted(
+                                action = "RECOVER_ENERGY",
+                                reason = "Finale forced WIT button click failed; calling recoverEnergy() as fallback",
+                            )
                             campaign.recoverEnergy()
                         } else {
                             MessageLog.w(TAG, "[WARN] handleTraining:: Could not head back to the Main screen in order to recover energy.")
@@ -2493,11 +2512,26 @@ open class Training(protected val game: Game, protected val campaign: Campaign) 
                     game.wait(1.0)
 
                     if (campaign.checkMainScreen()) {
-                        if (restrictedTrainingNames.size == StatName.entries.size || (restrictedTrainingNames.size + blacklist.size) >= StatName.entries.size) {
-                            MessageLog.v(TAG, "[TRAINING] Will recover energy due to all available trainings being restricted or blacklisted.")
-                        } else {
-                            MessageLog.v(TAG, "[TRAINING] Will recover energy due to either failure chance was high enough to do so or no failure chances were detected via OCR.")
-                        }
+                        val recoverReason =
+                            if (restrictedTrainingNames.size == StatName.entries.size ||
+                                (restrictedTrainingNames.size + blacklist.size) >= StatName.entries.size
+                            ) {
+                                MessageLog.v(TAG, "[TRAINING] Will recover energy due to all available trainings being restricted or blacklisted.")
+                                "All trainings restricted or blacklisted"
+                            } else {
+                                MessageLog.v(TAG, "[TRAINING] Will recover energy due to either failure chance was high enough to do so or no failure chances were detected via OCR.")
+                                "Failure chance too high, or OCR detected no failure chances"
+                            }
+                        campaign.decisionTracer.recordTrainingSelection(
+                            selected = null,
+                            source = lastSelectionSource,
+                            reason = "Empty training map ($recoverReason); recovering energy instead",
+                            runnerUps = buildRunnerUps(null),
+                        )
+                        campaign.decisionTracer.recordRecoveryExecuted(
+                            action = "RECOVER_ENERGY",
+                            reason = recoverReason,
+                        )
                         campaign.recoverEnergy()
                     } else {
                         MessageLog.w(TAG, "[WARN] handleTraining:: Could not head back to the Main screen in order to recover energy.")
@@ -2505,6 +2539,17 @@ open class Training(protected val game: Game, protected val campaign: Campaign) 
                 }
             } else {
                 // Now select the training option with the highest weight.
+                campaign.decisionTracer.recordTrainingSelection(
+                    selected = trainingSelected,
+                    source = if (forceStat != null) SelectionSource.FORCED_DEFAULT else lastSelectionSource,
+                    reason =
+                        if (forceStat != null) {
+                            "Caller-supplied forceStat override - executing $forceStat without analyzer re-evaluation"
+                        } else {
+                            "Selected by Training.handleTraining base flow (analyzer pick)"
+                        },
+                    runnerUps = buildRunnerUps(trainingSelected),
+                )
                 executeTraining(trainingSelected)
                 firstTrainingCheck = false
             }
@@ -2515,6 +2560,49 @@ open class Training(protected val game: Game, protected val campaign: Campaign) 
         }
         MessageLog.v(TAG, "********************")
         return trainingSelected
+    }
+
+    /**
+     * Builds the runner-up training list for the Decision Report from live analyzer state.
+     * Mirrors the Trackblazer-private snapshot-based version, but reads `cachedAnalysisResults` / `skippedTrainingMap` directly
+     * since the base flow (URA Finale, Unity Cup) does not re-analyze mid-turn the way Trackblazer does (no Reset Whistle path).
+     *
+     * @param picked The stat selected this turn (excluded from the runner-up list). Null when no training was picked.
+     * @return One entry per non-picked, non-blacklisted training that the analyzer evaluated this turn.
+     */
+    fun buildRunnerUps(picked: StatName?): List<DecisionTracer.TrainingRunnerUp> {
+        val analyzed = cachedAnalysisResults.orEmpty()
+        val runnerUps = mutableListOf<DecisionTracer.TrainingRunnerUp>()
+        StatName.entries.forEach { stat ->
+            if (stat == picked) return@forEach
+            // Blacklisted trainings are intentional user config, not a per-turn decision - omit so the report stays focused.
+            if (stat in blacklist) return@forEach
+            val skipEntry = skippedTrainingMap[stat]
+            val analyzedEntry = analyzed.firstOrNull { it.name == stat }
+            when {
+                skipEntry != null ->
+                    runnerUps.add(
+                        DecisionTracer.TrainingRunnerUp(
+                            stat = stat,
+                            rejected = true,
+                            reason = skipEntry.skipReason ?: "skipped (no reason recorded)",
+                            failureChance = skipEntry.failureChance,
+                            statGains = skipEntry.statGains,
+                        ),
+                    )
+                analyzedEntry != null ->
+                    runnerUps.add(
+                        DecisionTracer.TrainingRunnerUp(
+                            stat = stat,
+                            rejected = false,
+                            reason = "considered by analyzer but lost to selection",
+                            failureChance = analyzedEntry.failureChance.takeIf { it >= 0 },
+                            statGains = analyzedEntry.statGains,
+                        ),
+                    )
+            }
+        }
+        return runnerUps
     }
 
     /**

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/Trackblazer.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/Trackblazer.kt
@@ -5,11 +5,13 @@ import android.util.Log
 import com.steve1316.automation_library.utils.MessageLog
 import com.steve1316.automation_library.utils.SettingsHelper
 import com.steve1316.uma_android_automation.bot.Campaign
+import com.steve1316.uma_android_automation.bot.DecisionTracer
 import com.steve1316.uma_android_automation.bot.DialogHandlerResult
 import com.steve1316.uma_android_automation.bot.Game
 import com.steve1316.uma_android_automation.bot.MainScreenAction
 import com.steve1316.uma_android_automation.bot.Racing
 import com.steve1316.uma_android_automation.bot.SelectionSource
+import com.steve1316.uma_android_automation.bot.Training
 import com.steve1316.uma_android_automation.bot.solver.SmartRaceSolverIntegration
 import com.steve1316.uma_android_automation.components.ButtonBack
 import com.steve1316.uma_android_automation.components.ButtonCancel
@@ -184,6 +186,15 @@ class Trackblazer(game: Game) : Campaign(game) {
 
     /** Flag indicating if the bot has checked for Irregular Training during the current turn. */
     private var bHasCheckedIrregularTrainingThisTurn: Boolean = false
+
+    /**
+     * Snapshot of the most recent analyzer pass results, captured eagerly because `confirmAndCloseItemDialog` clears `Training.cachedAnalysisResults`
+     * before `recordTrainingSelection` runs. Used by `buildTrainingRunnerUps` so the Decision Report always carries the analyzer's runner-up data.
+     */
+    private var analysisSnapshotForReport: List<Training.TrainingAnalysisResult> = emptyList()
+
+    /** Companion snapshot of `Training.skippedTrainingMap` taken alongside `analysisSnapshotForReport`. */
+    private var skippedSnapshotForReport: Map<StatName, Training.TrainingOption> = emptyMap()
 
     /** Mapping of energy-restoring items to their gain values. */
     private val energyGains =
@@ -768,6 +779,9 @@ class Trackblazer(game: Game) : Campaign(game) {
                     TAG,
                     "[WARN] shouldAllowConsecutiveRace:: Energy critically low (${trainee.energy}%) with $consecutiveRaceCount consecutive races, but ignoreLowEnergyRacingBlock is enabled. Allowing race.",
                 )
+                decisionTracer.recordNote(
+                    "shouldAllowConsecutiveRace: critical energy ${trainee.energy}% with $consecutiveRaceCount consec races; ignoreLowEnergyRacingBlock setting allowed it through (-30 stat risk)",
+                )
             } else {
                 val conserveItem = energyItemConservationOrder.firstOrNull { (currentInventory[it] ?: 0) > 0 }
                 if (conserveItem != null) {
@@ -775,10 +789,18 @@ class Trackblazer(game: Game) : Campaign(game) {
                         TAG,
                         "[WARN] shouldAllowConsecutiveRace:: Energy critically low but $conserveItem exists in inventory. This should have been used in decideNextAction(). Blocking race as safety net.",
                     )
+                    decisionTracer.recordRaceEligibility(
+                        eligible = false,
+                        reason = "Consecutive-race safety net: critical energy with $conserveItem still in inventory (should have been used); blocked",
+                    )
                 } else {
                     MessageLog.w(
                         TAG,
                         "[WARN] shouldAllowConsecutiveRace:: Energy is critically low (${trainee.energy}%) with $consecutiveRaceCount consecutive races. Blocking to avoid possible -30 stat penalty.",
+                    )
+                    decisionTracer.recordRaceEligibility(
+                        eligible = false,
+                        reason = "Consecutive-race safety net: energy ${trainee.energy}% with $consecutiveRaceCount races, no energy item available; blocked to avoid -30 stat penalty",
                     )
                 }
                 racing.encounteredRacingPopup = false
@@ -800,22 +822,31 @@ class Trackblazer(game: Game) : Campaign(game) {
         val isLateDecember = date.month == DateMonth.DECEMBER && date.phase == DatePhase.LATE
 
         if (consecutiveRaceCount < (consecutiveRacesLimit + 1) || onlyOneTurnLeft || isLateDecember) {
+            val allowReason: String
             if (isLateDecember && consecutiveRaceCount >= (consecutiveRacesLimit + 1)) {
                 MessageLog.i(
                     TAG,
                     "[TRACKBLAZER] Consecutive race count $consecutiveRaceCount >= ${consecutiveRacesLimit + 1}, but it is Late December. Ignoring limit to maximize races before mandatory goal race.",
                 )
+                allowReason = "Late December override: ignoring limit to max races before goal ($consecutiveRaceCount >= ${consecutiveRacesLimit + 1})"
             } else if (onlyOneTurnLeft && consecutiveRaceCount >= (consecutiveRacesLimit + 1)) {
                 MessageLog.i(
                     TAG,
                     "[TRACKBLAZER] Consecutive race count $consecutiveRaceCount >= ${consecutiveRacesLimit + 1}, but only 1 turn remains before mandatory race. Racing is safe. Continuing.",
                 )
+                allowReason = "Only 1 turn left before mandatory race - racing past limit is safe ($consecutiveRaceCount >= ${consecutiveRacesLimit + 1})"
             } else {
                 MessageLog.i(TAG, "[TRACKBLAZER] Consecutive race count $consecutiveRaceCount < ${consecutiveRacesLimit + 1}. Continuing.")
+                allowReason = "Under consecutive-race limit ($consecutiveRaceCount < ${consecutiveRacesLimit + 1})"
             }
+            decisionTracer.recordRaceEligibility(eligible = true, reason = "Consecutive-race check: $allowReason")
             return true
         } else {
             MessageLog.w(TAG, "[WARN] shouldAllowConsecutiveRace:: Consecutive race count $consecutiveRaceCount >= ${consecutiveRacesLimit + 1}. Aborting racing.")
+            decisionTracer.recordRaceEligibility(
+                eligible = false,
+                reason = "Consecutive-race limit hit: $consecutiveRaceCount >= ${consecutiveRacesLimit + 1}, not Late December, more than 1 turn before mandatory",
+            )
             racing.encounteredRacingPopup = false
             return false
         }
@@ -987,6 +1018,113 @@ class Trackblazer(game: Game) : Campaign(game) {
         }
     }
 
+    override fun gatherDecisionInventory(): Map<String, Int> {
+        // Only the items that drive Trackblazer's decision tree this turn. Energy items are aggregated under their displayable name.
+        val keys = listOf("Good-Luck Charm", "Empowering Megaphone", "Motivating Megaphone", "Coaching Megaphone", "Reset Whistle", "Royal Kale Juice", "Berry Sweet Cupcake", "Plain Cupcake")
+        val snapshot = mutableMapOf<String, Int>()
+        keys.forEach { name -> snapshot[name] = currentInventory[name] ?: 0 }
+        return snapshot
+    }
+
+    override fun gatherDecisionSettings(): DecisionTracer.SettingsSnapshot =
+        DecisionTracer
+            .SettingsSnapshot()
+            .add("Trackblazer Energy Threshold", energyThresholdToUseEnergyItems)
+            .add("Min Stat Gain for Charm", minCharmGain)
+            .add("Consecutive Races Limit", consecutiveRacesLimit)
+            .add("Low Main Stat Gain Floor", lowMainStatGainItemFloor)
+            .add("Whistle Forces Training", whistleForcesTraining)
+            .add("Irregular Training", if (enableIrregularTraining) "on (min main $minIrregularGain)" else "off")
+            .add("Enable In-Game Race Agenda", racing.enableUserInGameRaceAgenda)
+            .add("Max Failure Chance", "${SettingsHelper.getIntSetting("training", "maximumFailureChance")}%")
+            .add(
+                "Riskier Training",
+                if (SettingsHelper.getBooleanSetting("training", "enableRiskyTraining")) {
+                    "on (max fail ${SettingsHelper.getIntSetting("training", "riskyTrainingMaxFailureChance")}%, min main ${SettingsHelper.getIntSetting("training", "riskyTrainingMinStatGain")})"
+                } else {
+                    "off"
+                },
+            )
+
+    override fun gatherDecisionExtraState(): Map<String, String> =
+        mapOf(
+            "Megaphone Turns" to trainee.megaphoneTurnCounter.toString(),
+            "Consecutive Races" to consecutiveRaceCount.toString(),
+            "Used Charm Today" to bUsedCharmToday.toString(),
+            "Used Whistle Today" to bUsedWhistleToday.toString(),
+        )
+
+    /**
+     * Build the runner-up list for the Decision Report from the analyzer's cached scoring data. Trainings that the analyzer scored but did
+     * not select are surfaced with their failure chance and main-stat gain. Trainings that were filtered out (`skippedTrainingMap`) come
+     * through with their skip reason. The caller passes in the picked stat so the runner-up list excludes it.
+     *
+     * @param picked The stat that was selected this turn (omitted from the runner-up list); null when no training was selected.
+     * @return Up to 5 runner-up entries representing the non-picked options analyzed this turn.
+     */
+
+    /**
+     * Snapshot the analyzer's current results into `analysisSnapshotForReport` / `skippedSnapshotForReport` so the Decision Report's runner-ups
+     * survive the cache clear performed by `confirmAndCloseItemDialog` later in the turn. Call this right after every `recommendTraining()` pass.
+     */
+    private fun captureRunnerUpsSnapshot() {
+        analysisSnapshotForReport = training.cachedAnalysisResults?.toList() ?: emptyList()
+        skippedSnapshotForReport = training.skippedTrainingMap.toMap()
+    }
+
+    /**
+     * Pulls the picked stat's failure-chance and stat-gain map out of the snapshot so the Decision Report's `Pick:` line can show them. Returns
+     * (null, null) when the pick is null or absent from both snapshots. `failureChance < 0` is treated as "OCR did not measure" and surfaced as null.
+     */
+    private fun pickedStatDetails(picked: StatName?): Pair<Int?, Map<StatName, Int>?> {
+        if (picked == null) return null to null
+        analysisSnapshotForReport.firstOrNull { it.name == picked }?.let { return it.failureChance.takeIf { fc -> fc >= 0 } to it.statGains }
+        skippedSnapshotForReport[picked]?.let { return it.failureChance.takeIf { fc -> fc >= 0 } to it.statGains }
+        return null to null
+    }
+
+    private fun buildTrainingRunnerUps(picked: StatName?): List<DecisionTracer.TrainingRunnerUp> {
+        val analyzed = analysisSnapshotForReport
+        val skipped = skippedSnapshotForReport
+        val runnerUps = mutableListOf<DecisionTracer.TrainingRunnerUp>()
+
+        StatName.entries.forEach { stat ->
+            if (stat == picked) return@forEach
+            // Blacklisted trainings are intentional user configuration, not a decision the bot made this turn - skip them entirely
+            // so the Runner-ups list focuses on trainings that were actually evaluated.
+            if (stat in training.blacklist) return@forEach
+            val skipEntry = skipped[stat]
+            val analyzedEntry = analyzed.firstOrNull { it.name == stat }
+            when {
+                skipEntry != null -> {
+                    runnerUps.add(
+                        DecisionTracer.TrainingRunnerUp(
+                            stat = stat,
+                            rejected = true,
+                            reason = skipEntry.skipReason ?: "skipped (no reason recorded)",
+                            failureChance = skipEntry.failureChance,
+                            statGains = skipEntry.statGains,
+                        ),
+                    )
+                }
+                analyzedEntry != null -> {
+                    // failureChance = -1 means OCR did not measure it; surface as null in the runner-up so the report doesn't show "fail=-1%".
+                    val failureChance = analyzedEntry.failureChance.takeIf { it >= 0 }
+                    runnerUps.add(
+                        DecisionTracer.TrainingRunnerUp(
+                            stat = stat,
+                            rejected = false,
+                            reason = "considered by analyzer but lost to selection",
+                            failureChance = failureChance,
+                            statGains = analyzedEntry.statGains,
+                        ),
+                    )
+                }
+            }
+        }
+        return runnerUps
+    }
+
     override fun onMainScreenEntry() {
         // Before taking any action, check for items to use.
         // This handles Stats, Energy, Mood, and Bad Conditions.
@@ -1013,12 +1151,14 @@ class Trackblazer(game: Game) : Campaign(game) {
         // Summer Training: Train during July and August in Classic/Senior.
         if (date.isSummer() && !(racing.skipSummerTrainingForAgenda && racing.enableUserInGameRaceAgenda)) {
             MessageLog.i(TAG, "[TRACKBLAZER] It is Summer. Prioritizing training.")
+            decisionTracer.recordActionChoice(MainScreenAction.TRAIN, "Trackblazer: Summer prioritizes training")
             return MainScreenAction.TRAIN
         }
 
         // Finale: Train during the final 3 turns (Qualifier, Semifinal, Finals).
         if (date.bIsFinaleSeason && date.day >= 73) {
             MessageLog.i(TAG, "[TRACKBLAZER] It is the Finale. Prioritizing training.")
+            decisionTracer.recordActionChoice(MainScreenAction.TRAIN, "Trackblazer: Finale (day >= 73) prioritizes training")
             return MainScreenAction.TRAIN
         }
 
@@ -1059,12 +1199,20 @@ class Trackblazer(game: Game) : Campaign(game) {
                     // Fall through to normal racing/training logic below.
                 } else {
                     MessageLog.w(TAG, "[WARN] decideNextAction:: Energy still low (${trainee.energy}%) after emergency recovery. Resting.")
+                    decisionTracer.recordActionChoice(
+                        MainScreenAction.REST,
+                        "Trackblazer low-energy guard: energy ${trainee.energy}% still <= 10 after emergency conserved-item use ($consecutiveRaceCount consecutive races)",
+                    )
                     return MainScreenAction.REST
                 }
             } else {
                 MessageLog.w(
                     TAG,
                     "[WARN] decideNextAction:: Energy is low (${trainee.energy}%) with $consecutiveRaceCount consecutive races and no energy items available. Resting to avoid -30 stat penalty.",
+                )
+                decisionTracer.recordActionChoice(
+                    MainScreenAction.REST,
+                    "Trackblazer low-energy guard: energy ${trainee.energy}% <= 10 with $consecutiveRaceCount consecutive races and no energy items in inventory",
                 )
                 return MainScreenAction.REST
             }
@@ -1077,6 +1225,7 @@ class Trackblazer(game: Game) : Campaign(game) {
             val solverRaceKey = SmartRaceSolverIntegration.peekRaceKeyForTurn(currentTurn = date.day, scenario = game.scenario)
             if (solverRaceKey != null) {
                 MessageLog.i(TAG, "[TRACKBLAZER] Smart Race Solver has \"$solverRaceKey\" planned for turn ${date.day}; deferring to racing flow.")
+                decisionTracer.recordActionChoice(MainScreenAction.RACE, "Smart Race Solver planned race \"$solverRaceKey\" for this turn")
                 return MainScreenAction.RACE
             }
         }
@@ -1114,6 +1263,7 @@ class Trackblazer(game: Game) : Campaign(game) {
                         MessageLog.i(TAG, "[TRACKBLAZER] Valid Irregular Training found ($bestTraining). Hijacking turn.")
 
                         bIsIrregularTraining = true
+                        decisionTracer.recordActionChoice(MainScreenAction.TRAIN, "Irregular Training pre-screen found viable pick: $bestTraining")
                         return MainScreenAction.TRAIN
                     } else {
                         MessageLog.i(TAG, "[TRACKBLAZER] No valid Irregular Training found. Backing out to resume racing logic.")
@@ -1168,6 +1318,12 @@ class Trackblazer(game: Game) : Campaign(game) {
                     MessageLog.i(TAG, "[TRACKBLAZER] Shop check counter: $shopCheckCounter / $shopCheckFrequency. Next check in ${shopCheckFrequency - shopCheckCounter} day(s).")
                 }
             }
+        }
+
+        // Emit the Decision Report after the override's TRAIN path completes. The non-TRAIN paths delegate to super.executeAction which
+        // emits there - the hasEmitted guard on DecisionTracer makes the second call here a no-op for those branches.
+        if (result && action != MainScreenAction.NONE) {
+            decisionTracer.emit()
         }
 
         return result
@@ -1538,6 +1694,7 @@ class Trackblazer(game: Game) : Campaign(game) {
         if (bIsIrregularTraining) {
             MessageLog.i(TAG, "[TRACKBLAZER] Using existing irregular training analysis (already on Training screen).")
             val trainingSelected: StatName? = training.recommendTraining(args = mapOf("isIrregularEvaluation" to true, "irregularTrainingMinStatGain" to minIrregularGain))
+            captureRunnerUpsSnapshot()
             if (trainingSelected != null && training.lastSelectionSource != SelectionSource.ANALYSIS) {
                 MessageLog.i(TAG, "[TRACKBLAZER] On-screen evaluation used fallback (${training.lastSelectionSource}): $trainingSelected.")
             }
@@ -1548,9 +1705,24 @@ class Trackblazer(game: Game) : Campaign(game) {
             }
 
             if (trainingSelected != null) {
+                val (pickFail, pickGains) = pickedStatDetails(trainingSelected)
+                decisionTracer.recordTrainingSelection(
+                    selected = trainingSelected,
+                    source = training.lastSelectionSource,
+                    reason = "Irregular Training fast-path (already on Training screen from pre-screen evaluation)",
+                    runnerUps = buildTrainingRunnerUps(trainingSelected),
+                    pickedFailureChance = pickFail,
+                    pickedStatGains = pickGains,
+                )
                 training.executeTraining(trainingSelected)
             } else {
                 MessageLog.w(TAG, "[WARN] handleTrackblazerTraining:: Irregular training unexpectedly became null. Backing out.")
+                decisionTracer.recordTrainingSelection(
+                    selected = null,
+                    source = training.lastSelectionSource,
+                    reason = "Irregular Training fast-path lost its selection (recommendTraining returned null after pre-screen pick); backing out",
+                    runnerUps = buildTrainingRunnerUps(null),
+                )
                 ButtonBack.click(game.imageUtils)
                 game.wait(game.dialogWaitDelay)
             }
@@ -1571,6 +1743,7 @@ class Trackblazer(game: Game) : Campaign(game) {
         val hasCharm = date.day >= 13 && !bUsedCharmToday && (currentInventory["Good-Luck Charm"] ?: 0) > 0
         training.analyzeTrainings(mapOf("ignoreFailureChance" to hasCharm, "minStatGainForCharm" to minCharmGain))
         var trainingSelected: StatName? = training.recommendTraining()
+        captureRunnerUpsSnapshot()
         if (trainingSelected != null && training.lastSelectionSource != SelectionSource.ANALYSIS) {
             MessageLog.i(TAG, "[TRACKBLAZER] Initial training selection used fallback (${training.lastSelectionSource}): $trainingSelected.")
         }
@@ -1613,6 +1786,10 @@ class Trackblazer(game: Game) : Campaign(game) {
 
             if (whistleGateBlocks) {
                 // Whistle usage was skipped such that trainingSelected stays null and the existing recovery branch below fires.
+                decisionTracer.recordWhistleOutcome(
+                    DecisionTracer.WhistleVerdict.BLOCKED,
+                    "Mood ${trainee.mood} would cap gains after reshuffle; refusing to spend Whistle on a near-no-op turn",
+                )
             } else if (hasWhistle) {
                 MessageLog.i(TAG, "[TRACKBLAZER] No suitable training found. Using Reset Whistle.")
                 if (shopList.openTrainingItemsDialog()) {
@@ -1626,10 +1803,17 @@ class Trackblazer(game: Game) : Campaign(game) {
                         MessageLog.i(TAG, "[TRACKBLAZER] Re-analyzing trainings after Reset Whistle.")
                         training.analyzeTrainings(mapOf("ignoreFailureChance" to hasCharm, "minStatGainForCharm" to minCharmGain))
                         trainingSelected = training.recommendTraining(forceSelection = whistleForcesTraining)
+                        captureRunnerUpsSnapshot()
 
                         when {
-                            trainingSelected == null ->
+                            trainingSelected == null -> {
                                 MessageLog.i(TAG, "[TRACKBLAZER] Reset Whistle re-analysis returned no training; nothing to execute.")
+                                decisionTracer.recordWhistleOutcome(
+                                    DecisionTracer.WhistleVerdict.USED,
+                                    "Re-analysis after Whistle still produced no acceptable training",
+                                    postRollSelection = null,
+                                )
+                            }
                             training.lastSelectionSource == SelectionSource.FORCED_FROM_SKIPPED -> {
                                 // The forced pick comes from the rejected pool, so by definition either its main gain is below minCharmGain or its failure is too high to clear without a charm.
                                 // If the analyzer's charm gates would suppress the charm anyway, executing this pick is a near-certain failure with no defensive item.
@@ -1645,6 +1829,11 @@ class Trackblazer(game: Game) : Campaign(game) {
                                         TAG,
                                         "[TRACKBLAZER] Skipping Whistle force-pick: $trainingSelected at $forcedFail% fail with no Good-Luck Charm. Falling back to recovery.",
                                     )
+                                    decisionTracer.recordWhistleOutcome(
+                                        DecisionTracer.WhistleVerdict.USED,
+                                        "Re-analysis force-picked $trainingSelected at $forcedFail% fail but charm cannot fire; abandoned to recovery",
+                                        postRollSelection = null,
+                                    )
                                     trainingSelected = null
                                 } else {
                                     MessageLog.i(
@@ -1652,31 +1841,80 @@ class Trackblazer(game: Game) : Campaign(game) {
                                         "[TRACKBLAZER] Reset Whistle re-analysis still rejected all trainings; Whistle Forces Training is enabled, " +
                                             "so executing forced pick: $trainingSelected. Megaphone (if available) will be applied to this forced selection.",
                                     )
+                                    decisionTracer.recordWhistleOutcome(
+                                        DecisionTracer.WhistleVerdict.USED,
+                                        "Re-analysis rejected all trainings; Whistle Forces Training enabled, force-pick $trainingSelected (fail=$forcedFail%, gain=$forcedMainGain)",
+                                        postRollSelection = trainingSelected,
+                                    )
                                 }
                             }
-                            training.lastSelectionSource != SelectionSource.ANALYSIS ->
+                            training.lastSelectionSource != SelectionSource.ANALYSIS -> {
                                 MessageLog.i(TAG, "[TRACKBLAZER] Reset Whistle re-analysis used fallback (${training.lastSelectionSource}): $trainingSelected.")
-                            else ->
+                                decisionTracer.recordWhistleOutcome(
+                                    DecisionTracer.WhistleVerdict.USED,
+                                    "Re-analysis used ${training.lastSelectionSource} fallback to pick $trainingSelected",
+                                    postRollSelection = trainingSelected,
+                                )
+                            }
+                            else -> {
                                 MessageLog.i(TAG, "[TRACKBLAZER] Reset Whistle re-analysis selected: $trainingSelected.")
+                                decisionTracer.recordWhistleOutcome(
+                                    DecisionTracer.WhistleVerdict.USED,
+                                    "Re-analysis selected $trainingSelected from new shuffle",
+                                    postRollSelection = trainingSelected,
+                                )
+                            }
                         }
 
                         // Perform another consolidated item usage pass if needed after shuffle.
                         useItems(trainee, trainingSelected)
                     } else {
                         MessageLog.i(TAG, "[TRACKBLAZER] No Reset Whistles found in inventory.")
+                        decisionTracer.recordWhistleOutcome(
+                            DecisionTracer.WhistleVerdict.NOT_IN_INVENTORY,
+                            "Cached inventory had Whistle but in-dialog scan returned no usable Whistles",
+                        )
                         ButtonClose.click(game.imageUtils)
                         game.wait(game.dialogWaitDelay, skipWaitingForLoading = true)
                     }
                 }
             } else {
                 MessageLog.i(TAG, "[TRACKBLAZER] No suitable training found and no Reset Whistles in cached inventory or all are disabled.")
+                decisionTracer.recordWhistleOutcome(
+                    DecisionTracer.WhistleVerdict.NOT_IN_INVENTORY,
+                    "No Reset Whistles in cached inventory (or all disabled in dialog)",
+                )
             }
         } else if (training.needsEnergyRecovery && trainingSelected == null) {
             MessageLog.i(TAG, "[TRACKBLAZER] Skipping Reset Whistle as energy recovery is needed, not a training re-roll.")
+            decisionTracer.recordWhistleOutcome(
+                DecisionTracer.WhistleVerdict.NOT_ELIGIBLE,
+                "Recovery is needed (training.needsEnergyRecovery=true) - reshuffling won't help",
+            )
+        } else if (trainingSelected == null && (date.day !in 37..40 && date.day <= 60)) {
+            // Selection failed but the Whistle window is closed - explain in the report why no reshuffle was attempted.
+            decisionTracer.recordWhistleOutcome(
+                DecisionTracer.WhistleVerdict.NOT_ELIGIBLE,
+                "Outside Whistle window (day=${date.day}, allowed: 37..40 or > 60)",
+            )
         }
 
         // Final Training Execution.
         if (trainingSelected != null) {
+            val (pickFail, pickGains) = pickedStatDetails(trainingSelected)
+            decisionTracer.recordTrainingSelection(
+                selected = trainingSelected,
+                source = training.lastSelectionSource,
+                reason =
+                    if (bUsedWhistleToday) {
+                        "Final pick selected by analyzer after Reset Whistle re-roll"
+                    } else {
+                        "Final pick selected by initial analyzer pass (no Reset Whistle used)"
+                    },
+                runnerUps = buildTrainingRunnerUps(trainingSelected),
+                pickedFailureChance = pickFail,
+                pickedStatGains = pickGains,
+            )
             training.executeTraining(trainingSelected)
             training.firstTrainingCheck = false
         } else {
@@ -1684,6 +1922,12 @@ class Trackblazer(game: Game) : Campaign(game) {
             // Resting has 62.5% chance of being +50 energy, Shrine (remove status conditions) has 30% chance in recreation.
             if (trainee.mood <= Mood.NORMAL || trainee.energy <= 50) {
                 MessageLog.i(TAG, "[TRACKBLAZER] Still no suitable training found. Backing out for recovery.")
+                decisionTracer.recordTrainingSelection(
+                    selected = null,
+                    source = training.lastSelectionSource,
+                    reason = "No training selected; mood ${trainee.mood} <= NORMAL or energy ${trainee.energy}% <= 50 - backing out for recovery",
+                    runnerUps = buildTrainingRunnerUps(null),
+                )
 
                 // firstTrainingCheck is false since there is no suitable training (breaks looping on recovery/energy)
                 training.firstTrainingCheck = false
@@ -1693,9 +1937,17 @@ class Trackblazer(game: Game) : Campaign(game) {
                 if (checkMainScreen()) {
                     if (trainee.mood == Mood.AWFUL || (trainee.mood <= Mood.NORMAL && trainee.energy >= 20)) {
                         MessageLog.i(TAG, "[TRACKBLAZER] Mood is ${trainee.mood}. Attempting to recover mood.")
+                        decisionTracer.recordRecoveryExecuted(
+                            action = "RECOVER_MOOD",
+                            reason = "Mood ${trainee.mood} is AWFUL, or <= NORMAL with energy ${trainee.energy}% >= 20%",
+                        )
                         recoverMood()
                     } else {
                         MessageLog.i(TAG, "[TRACKBLAZER] Energy is ${trainee.energy}%. Attempting to recover energy.")
+                        decisionTracer.recordRecoveryExecuted(
+                            action = "RECOVER_ENERGY",
+                            reason = "Mood ${trainee.mood} > NORMAL or energy ${trainee.energy}% < 20%",
+                        )
                         recoverEnergy()
                     }
                 }
@@ -1710,6 +1962,12 @@ class Trackblazer(game: Game) : Campaign(game) {
                 if (skippedForced != null || forcedIsBlacklisted) {
                     val reason = skippedForced?.skipReason ?: "blacklisted"
                     MessageLog.w(TAG, "[WARN] handleTrackblazerTraining:: Cannot force $forcedStat training ($reason). Backing out for recovery instead.")
+                    decisionTracer.recordTrainingSelection(
+                        selected = null,
+                        source = training.lastSelectionSource,
+                        reason = "Wanted to force $forcedStat but it was rejected ($reason); backing out for recovery",
+                        runnerUps = buildTrainingRunnerUps(null),
+                    )
 
                     training.firstTrainingCheck = false
                     ButtonBack.click(game.imageUtils)
@@ -1718,14 +1976,31 @@ class Trackblazer(game: Game) : Campaign(game) {
                     if (checkMainScreen()) {
                         if (trainee.mood == Mood.AWFUL || (trainee.mood <= Mood.NORMAL && trainee.energy >= 20)) {
                             MessageLog.i(TAG, "[TRACKBLAZER] Mood is ${trainee.mood}. Attempting to recover mood.")
+                            decisionTracer.recordRecoveryExecuted(
+                                action = "RECOVER_MOOD",
+                                reason = "Mood ${trainee.mood} is AWFUL, or <= NORMAL with energy ${trainee.energy}% >= 20% (forced-stat backout)",
+                            )
                             recoverMood()
                         } else {
                             MessageLog.i(TAG, "[TRACKBLAZER] Energy is ${trainee.energy}%. Attempting to recover energy.")
+                            decisionTracer.recordRecoveryExecuted(
+                                action = "RECOVER_ENERGY",
+                                reason = "Mood ${trainee.mood} > NORMAL or energy ${trainee.energy}% < 20% (forced-stat backout)",
+                            )
                             recoverEnergy()
                         }
                     }
                 } else {
                     MessageLog.i(TAG, "[TRACKBLAZER] Still no suitable training found. Energy (${trainee.energy}%) and Mood (${trainee.mood}) are sufficient. Forcing $forcedStat training.")
+                    val (forcedPickFail, forcedPickGains) = pickedStatDetails(forcedStat)
+                    decisionTracer.recordTrainingSelection(
+                        selected = forcedStat,
+                        source = SelectionSource.FORCED_DEFAULT,
+                        reason = "No analyzer pick but energy ${trainee.energy}% > 50 and mood ${trainee.mood} > NORMAL - forcing $forcedStat",
+                        runnerUps = buildTrainingRunnerUps(forcedStat),
+                        pickedFailureChance = forcedPickFail,
+                        pickedStatGains = forcedPickGains,
+                    )
                     training.executeTraining(forcedStat)
                     training.firstTrainingCheck = false
                 }
@@ -2157,21 +2432,36 @@ class Trackblazer(game: Game) : Campaign(game) {
 
         // Good-Luck Charm Check.
         val failureChance = training.trainingMap[trainingSelected]?.failureChance ?: 0
-        if (date.day >= 13 && !bUsedCharmToday && failureChance >= 20 && itemName == "Good-Luck Charm") {
-            // When mood is below NORMAL, the mood multiplier structurally caps stat gain. Burning Charm on a
-            // low-gain training squanders its 0%-failure benefit — conserve for a higher-gain turn instead.
-            if (shouldConserveTrainingEffectItems(trainingSelected, trainee)) {
-                val selectedMainGain = training.cachedAnalysisResults?.firstOrNull { it.name == trainingSelected }?.statGains?.get(trainingSelected) ?: 0
-                MessageLog.i(
-                    TAG,
-                    "[TRACKBLAZER] Skipping Good-Luck Charm: mood=${trainee.mood}, selected $trainingSelected main gain ($selectedMainGain) below floor ($lowMainStatGainItemFloor). Conserving Charm for a higher-gain turn.",
-                )
-                return null
-            }
-            val reason = "Setting training failure chance to 0%."
-            if (clickItemPlusButton(itemName, entry, "[TRACKBLAZER] Queuing Good-Luck Charm via inline pass.", nextInventory, reason = reason)) {
-                bUsedCharmToday = true
-                return reason
+        if (itemName == "Good-Luck Charm") {
+            when {
+                date.day < 13 ->
+                    decisionTracer.recordCharmGate(queued = false, blockingGate = "Day ${date.day} < 13 (training items not yet available)")
+                bUsedCharmToday ->
+                    decisionTracer.recordCharmGate(queued = false, blockingGate = "Already used a Good-Luck Charm this turn")
+                trainingSelected == null ->
+                    decisionTracer.recordCharmGate(queued = false, blockingGate = "No training selected by analyzeTrainings (failureChance unknown)")
+                failureChance < 20 ->
+                    decisionTracer.recordCharmGate(queued = false, blockingGate = "Selected $trainingSelected has failureChance=$failureChance%, below 20% threshold")
+                shouldConserveTrainingEffectItems(trainingSelected, trainee) -> {
+                    val selectedMainGain = training.cachedAnalysisResults?.firstOrNull { it.name == trainingSelected }?.statGains?.get(trainingSelected) ?: 0
+                    decisionTracer.recordCharmGate(
+                        queued = false,
+                        blockingGate = "Conservation: mood=${trainee.mood}, $trainingSelected main gain ($selectedMainGain) below floor ($lowMainStatGainItemFloor)",
+                    )
+                    MessageLog.i(
+                        TAG,
+                        "[TRACKBLAZER] Skipping Good-Luck Charm: mood=${trainee.mood}, selected $trainingSelected main gain ($selectedMainGain) below floor ($lowMainStatGainItemFloor). Conserving Charm for a higher-gain turn.",
+                    )
+                    return null
+                }
+                else -> {
+                    val reason = "Setting training failure chance to 0%."
+                    if (clickItemPlusButton(itemName, entry, "[TRACKBLAZER] Queuing Good-Luck Charm via inline pass.", nextInventory, reason = reason)) {
+                        bUsedCharmToday = true
+                        decisionTracer.recordCharmGate(queued = true)
+                        return reason
+                    }
+                }
             }
         }
 
@@ -2189,6 +2479,7 @@ class Trackblazer(game: Game) : Campaign(game) {
                 val conserveItem = energyItemConservationOrder.firstOrNull { (nextInventory[it] ?: 0) > 0 }
                 if (conserveItem == itemName && (nextInventory[itemName] ?: 0) <= 1) {
                     MessageLog.i(TAG, "[TRACKBLAZER] Conserving last $itemName for emergency race recovery.")
+                    decisionTracer.recordItemDecision(itemName, DecisionTracer.ItemVerdict.CONSERVED, "Last unit reserved for emergency race recovery")
                     return null
                 }
             }
@@ -2200,6 +2491,7 @@ class Trackblazer(game: Game) : Campaign(game) {
                     val oldEnergy = trainee.energy
                     trainee.energy = (trainee.energy + gain).coerceAtMost(100)
                     MessageLog.i(TAG, "[TRACKBLAZER] Trainee energy updated: $oldEnergy% -> ${trainee.energy}%.")
+                    decisionTracer.recordItemDecision(itemName, DecisionTracer.ItemVerdict.USED, "Energy $oldEnergy% -> ${trainee.energy}% (gain +$gain)")
                     return reason
                 }
             }
@@ -2241,6 +2533,7 @@ class Trackblazer(game: Game) : Campaign(game) {
                     (itemName == "Berry Sweet Cupcake" && berryCount <= 1 && plainCount == 0)
             if (shouldConserve) {
                 MessageLog.i(TAG, "[TRACKBLAZER] Conserving last $itemName for potential Royal Kale Juice usage.")
+                decisionTracer.recordItemDecision(itemName, DecisionTracer.ItemVerdict.CONSERVED, "Last unit reserved for potential Royal Kale Juice synergy")
                 return null
             }
 
@@ -2250,6 +2543,7 @@ class Trackblazer(game: Game) : Campaign(game) {
                 val oldMood = trainee.mood
                 trainee.mood = if (itemName == "Berry Sweet Cupcake") Mood.GOOD else Mood.NORMAL
                 MessageLog.i(TAG, "[TRACKBLAZER] Trainee mood updated: $oldMood -> ${trainee.mood}.")
+                decisionTracer.recordItemDecision(itemName, DecisionTracer.ItemVerdict.USED, "Mood $oldMood -> ${trainee.mood} (energy ${trainee.energy}% < 70%)")
                 return reason
             }
         }
@@ -2264,6 +2558,11 @@ class Trackblazer(game: Game) : Campaign(game) {
                 MessageLog.i(
                     TAG,
                     "[TRACKBLAZER] Skipping $itemName: mood=${trainee.mood}, selected $trainingSelected main gain ($selectedMainGain) below floor ($lowMainStatGainItemFloor). Conserving Megaphone for a higher-gain turn.",
+                )
+                decisionTracer.recordItemDecision(
+                    itemName,
+                    DecisionTracer.ItemVerdict.CONSERVED,
+                    "Conservation: mood=${trainee.mood}, $trainingSelected main gain ($selectedMainGain) below floor ($lowMainStatGainItemFloor)",
                 )
                 return null
             }
@@ -2291,6 +2590,11 @@ class Trackblazer(game: Game) : Campaign(game) {
                             "Coaching Megaphone" -> 4
                             else -> 0
                         }
+                    decisionTracer.recordItemDecision(
+                        itemName,
+                        DecisionTracer.ItemVerdict.USED,
+                        "Best megaphone in inventory; setting megaphone turn duration to ${trainee.megaphoneTurnCounter}",
+                    )
                     return reason
                 }
             }
@@ -2415,6 +2719,20 @@ class Trackblazer(game: Game) : Campaign(game) {
             }
         } else {
             MessageLog.i(TAG, "[TRACKBLAZER] Skipping Training Items dialog as no relevant items are in the cached inventory.")
+            // When the dialog is skipped with a training already locked in, `shouldDecideToUseItem` never runs - surface the per-item
+            // Charm reason so the Decision Report can answer "why didn't it use my Charm?" without cross-referencing the gating logic.
+            // When trainingSelected is null we deliberately skip this: the Whistle re-roll path in handleTrackblazerTraining will run
+            // next and record the real Charm/Whistle outcomes, so pre-recording here would just produce stale entries that contradict
+            // the actual decision (e.g. Whistle: NOT_ELIGIBLE followed by Whistle: USED in the same report).
+            if (trainingSelected != null && (currentInventory["Good-Luck Charm"] ?: 0) > 0) {
+                val gate =
+                    when {
+                        date.day < 13 -> "Day ${date.day} < 13 (training items not yet available)"
+                        bUsedCharmToday -> "Already used a Good-Luck Charm this turn"
+                        else -> "Selected $trainingSelected has failureChance below 20% threshold (charm reserved for risky trainings)"
+                    }
+                decisionTracer.recordCharmGate(queued = false, blockingGate = "Item dialog skipped: $gate")
+            }
         }
     }
 


### PR DESCRIPTION
## Description
- This PR introduces a `DecisionTracer` that emits a consolidated `Decision Report` block at the end of every main-screen turn, capturing the action choice, items used, training selection with runner-ups, race eligibility, and any recovery executed to hopefully reduce the amount of time needed to diagnose issues of "Why did the bot do X?"
- Coverage spans all three scenarios: `Trackblazer` gets full item / charm / whistle / training instrumentation, while `UraFinale` and `UnityCup` are covered through hooks added to the shared `Training.handleTraining()` flow.

### Sample Decision Report

```
00:39:17.977 [INFO] ============== Turn 75 (SENIOR LATE DECEMBER) Decision Report ==============
State:
  Energy = 91%
  Mood = GREAT
  Negative Statuses = []
  Megaphone Turns = 1
  Consecutive Races = 5
  Used Charm Today = false
  Used Whistle Today = false
Inventory (decision-relevant):
  Berry Sweet Cupcake = 0
  Coaching Megaphone = 3
  Empowering Megaphone = 0
  Good-Luck Charm = 2
  Motivating Megaphone = 0
  Plain Cupcake = 0
  Reset Whistle = 3
  Royal Kale Juice = 0
Settings (decision-relevant):
  Trackblazer Energy Threshold = 40
  Min Stat Gain for Charm = 30
  Consecutive Races Limit = 5
  Low Main Stat Gain Floor = 15
  Whistle Forces Training = true
  Irregular Training = on (min main 30)
  Enable In-Game Race Agenda = false
  Max Failure Chance = 20%
  Riskier Training = on (max fail 25%, min main 30)
Items Used: None

Action: TRAIN
  Reason: Trackblazer: Finale (day >= 73) prioritizes training

Training selected: SPEED (source=ANALYSIS)
  Reason: Final pick selected by initial analyzer pass (no Reset Whistle used)
  Pick: fail=0%, gains=[SPD:37 STA:0 PWR:18 GUTS:0 WIT:0]
  Runner-ups:
    - STAMINA (considered): fail=0%, gains=[SPD:0 STA:15 PWR:0 GUTS:5 WIT:0], considered by analyzer but lost to selection
    - POWER (considered): fail=0%, gains=[SPD:0 STA:7 PWR:9 GUTS:0 WIT:0], considered by analyzer but lost to selection
    - WIT (considered): fail=0%, gains=[SPD:2 STA:0 PWR:0 GUTS:0 WIT:12], considered by analyzer but lost to selection
==============================================================
```