### PR TITLE
Honor Smart Race Solver picks regardless of grade or race count

### DIFF
--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/Trackblazer.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/Trackblazer.kt
@@ -556,7 +556,11 @@ class Trackblazer(game: Game) : Campaign(game) {
                         val reasons = mutableListOf<String>()
                         race.isRival = rivalFound
 
-                        if (date.year == DateYear.JUNIOR) {
+                        // Solver-scheduled races bypass the grade and consecutive-race filters: the solver already weighed those factors when picking this race.
+                        val solverMatched = solverPlannedKey != null && SmartRaceSolverIntegration.isRaceKeyMatch(race, solverPlannedKey)
+                        if (solverMatched) {
+                            isSuitable = true
+                        } else if (date.year == DateYear.JUNIOR) {
                             if (listOf(RaceGrade.G1, RaceGrade.G2, RaceGrade.G3).contains(race.grade)) {
                                 isSuitable = true
                             } else {
@@ -577,8 +581,9 @@ class Trackblazer(game: Game) : Campaign(game) {
                         if (isSuitable) {
                             val candidate = Candidate(screenPoint, race, detectedName, rivalFound)
                             allSuitableRaces.add(candidate)
-                            sb.appendLine("\n- Found Suitable Race: \"${race.name}\" (${race.grade}) Rival: $rivalFound")
-                            if (solverPlannedKey != null && SmartRaceSolverIntegration.isRaceKeyMatch(race, solverPlannedKey)) {
+                            val suffix = if (solverMatched) " [Smart Race Solver override]" else ""
+                            sb.appendLine("\n- Found Suitable Race: \"${race.name}\" (${race.grade}) Rival: $rivalFound$suffix")
+                            if (solverMatched) {
                                 solverMatchedCandidate = candidate
                             }
                         } else {
@@ -618,7 +623,11 @@ class Trackblazer(game: Game) : Campaign(game) {
                     val reasons = mutableListOf<String>()
                     race.isRival = rivalFound
 
-                    if (date.year == DateYear.JUNIOR) {
+                    // Solver-scheduled races bypass the grade and consecutive-race filters: the solver already weighed those factors when picking this race.
+                    val solverMatched = solverPlannedKey != null && SmartRaceSolverIntegration.isRaceKeyMatch(race, solverPlannedKey)
+                    if (solverMatched) {
+                        isSuitable = true
+                    } else if (date.year == DateYear.JUNIOR) {
                         if (listOf(RaceGrade.G1, RaceGrade.G2, RaceGrade.G3).contains(race.grade)) {
                             isSuitable = true
                         } else {
@@ -637,7 +646,11 @@ class Trackblazer(game: Game) : Campaign(game) {
                     }
 
                     if (isSuitable) {
-                        allSuitableRaces.add(Candidate(location, race, detectedName, rivalFound))
+                        val candidate = Candidate(location, race, detectedName, rivalFound)
+                        allSuitableRaces.add(candidate)
+                        if (solverMatched) {
+                            solverMatchedCandidate = candidate
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Description
- This PR adds a `solverMatched` short-circuit at the top of `findSuitableRace()` in `Trackblazer` so that any race scheduled by `SmartRaceSolverIntegration` is treated as suitable regardless of its grade or the consecutive-race count.
- Previously, the Junior-year `G1`/`G2`/`G3`-only filter and the Senior-year consecutive-races-3+ filter could both reject solver-planned races (e.g. `OP` / `Pre-OP`); the bypass is now applied in both scan paths (`ScrollList` and single-page fallback).
