### PR TITLE
Add anticipatory rainbow multiplier for near-max friendship bars

### DIFF
--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Training.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Training.kt
@@ -113,6 +113,9 @@ open class Training(protected val game: Game, protected val campaign: Campaign) 
     /** Whether the rainbow training bonus is active. */
     private val enableRainbowTrainingBonus: Boolean = SettingsHelper.getBooleanSetting("training", "enableRainbowTrainingBonus")
 
+    /** Whether to apply an anticipatory rainbow multiplier in Year 2+ when a training has multiple near-max (green/blue) friendship bars. */
+    private val enablePrioritizeNearMaxFriendship: Boolean = SettingsHelper.getBooleanSetting("training", "enablePrioritizeNearMaxFriendship", true)
+
     /** Whether to enable risky training logic. */
     private val enableRiskyTraining: Boolean = SettingsHelper.getBooleanSetting("training", "enableRiskyTraining")
 
@@ -290,6 +293,7 @@ open class Training(protected val game: Game, protected val campaign: Campaign) 
      * @property enablePrioritizeSkillHints Whether to prioritize skill hints.
      * @property enableTrainingLevelWeighting Whether to amplify priority-list stat scores by their OCR-detected training level (1-5).
      * @property disableStatTargets Whether per-distance stat targets are overridden by the scenario stat cap for all stats.
+     * @property enablePrioritizeNearMaxFriendship Whether to apply an anticipatory rainbow multiplier in Year 2+ when a training has multiple near-max (green/blue) friendship bars.
      * @property statsTrainedOverBuffer Set of stats that have already exceeded their cap buffer.
      */
     data class TrainingConfig(
@@ -310,6 +314,7 @@ open class Training(protected val game: Game, protected val campaign: Campaign) 
         val enablePrioritizeSkillHints: Boolean = false,
         val enableTrainingLevelWeighting: Boolean = false,
         val disableStatTargets: Boolean = false,
+        val enablePrioritizeNearMaxFriendship: Boolean = true,
         val statsTrainedOverBuffer: Set<StatName> = emptySet(),
     ) {
         override fun equals(other: Any?): Boolean {
@@ -334,6 +339,7 @@ open class Training(protected val game: Game, protected val campaign: Campaign) 
             if (enablePrioritizeSkillHints != other.enablePrioritizeSkillHints) return false
             if (enableTrainingLevelWeighting != other.enableTrainingLevelWeighting) return false
             if (disableStatTargets != other.disableStatTargets) return false
+            if (enablePrioritizeNearMaxFriendship != other.enablePrioritizeNearMaxFriendship) return false
             if (statsTrainedOverBuffer != other.statsTrainedOverBuffer) return false
 
             return true
@@ -356,6 +362,7 @@ open class Training(protected val game: Game, protected val campaign: Campaign) 
             result = 31 * result + enablePrioritizeSkillHints.hashCode()
             result = 31 * result + enableTrainingLevelWeighting.hashCode()
             result = 31 * result + disableStatTargets.hashCode()
+            result = 31 * result + enablePrioritizeNearMaxFriendship.hashCode()
             result = 31 * result + statsTrainedOverBuffer.hashCode()
             return result
         }
@@ -926,6 +933,36 @@ open class Training(protected val game: Game, protected val campaign: Campaign) 
 
             // Apply rainbow multiplier to total score.
             totalScore *= rainbowMultiplier
+
+            // 5. Anticipatory rainbow multiplier (Year 2+ only, when no real rainbows present).
+            // Each near-max (green/blue) friendship bar contributes fillPercent/100 to a sum, then 0.2 * sum is added to a 1.0 base, capped at +0.6.
+            // Caps at 1.6x to remain strictly below the real 2.0x rainbow multiplier so anticipation never outranks an actual rainbow.
+            if (
+                config.enablePrioritizeNearMaxFriendship &&
+                config.currentDate.year > DateYear.JUNIOR &&
+                training.numRainbow == 0 &&
+                training.relationshipBars.isNotEmpty()
+            ) {
+                var contributions = 0.0
+                var qualifyingBars = 0
+                for (bar in training.relationshipBars) {
+                    if ((bar.dominantColor == "green" || bar.dominantColor == "blue") && bar.fillPercent > 10.0) {
+                        contributions += bar.fillPercent / 100.0
+                        qualifyingBars += 1
+                    }
+                }
+                if (qualifyingBars > 0) {
+                    val anticipatoryMultiplier = 1.0 + minOf(0.6, 0.2 * contributions)
+                    MessageLog.i(
+                        TAG,
+                        "[TRAINING] [${training.name}] $qualifyingBars near-max friendship bar(s) detected (contributions=${String.format(
+                            "%.2f",
+                            contributions,
+                        )}). Applying anticipatory multiplier ${String.format("%.2fx", anticipatoryMultiplier)}.",
+                    )
+                    totalScore *= anticipatoryMultiplier
+                }
+            }
 
             return totalScore.coerceAtLeast(0.0)
         }
@@ -2060,6 +2097,7 @@ open class Training(protected val game: Game, protected val campaign: Campaign) 
                 enablePrioritizeSkillHints = enablePrioritizeSkillHints,
                 enableTrainingLevelWeighting = enableTrainingLevelWeighting,
                 disableStatTargets = disableStatTargets,
+                enablePrioritizeNearMaxFriendship = enablePrioritizeNearMaxFriendship,
                 statsTrainedOverBuffer = statsTrainedOverBuffer,
             )
 
@@ -2231,6 +2269,12 @@ open class Training(protected val game: Game, protected val campaign: Campaign) 
                     // Stat Efficiency mode.
                     if (selected.numRainbow > 0) {
                         keyFactors.add("Rainbow training detected (multiplier applied).")
+                    }
+                    if (config.enablePrioritizeNearMaxFriendship && selected.numRainbow == 0) {
+                        val nearMaxFriendshipCount = selected.relationshipBars.count { (it.dominantColor == "green" || it.dominantColor == "blue") && it.fillPercent > 10.0 }
+                        if (nearMaxFriendshipCount > 0) {
+                            keyFactors.add("$nearMaxFriendshipCount near-max friendship bar(s) (anticipatory rainbow multiplier applied).")
+                        }
                     }
                     val mainGain = selected.statGains[selected.name] ?: 0
                     val currentVal = config.currentStats[selected.name] ?: 0

--- a/src/components/ProfileCreationModal/index.tsx
+++ b/src/components/ProfileCreationModal/index.tsx
@@ -157,6 +157,7 @@ const ProfileCreationModal: React.FC<ProfileCreationModalProps> = ({ visible, on
         settings.push(`Disable on Maxed: ${currentTrainingSettings.disableTrainingOnMaxedStat ? "Yes" : "No"}`)
         settings.push(`Focus on Sparks: ${currentTrainingSettings.focusOnSparkStatTarget ? "Yes" : "No"}`)
         settings.push(`Rainbow Bonus: ${currentTrainingSettings.enableRainbowTrainingBonus ? "Yes" : "No"}`)
+        settings.push(`Prioritize Near-Max Friendship: ${currentTrainingSettings.enablePrioritizeNearMaxFriendship ? "Yes" : "No"}`)
         settings.push(`Preferred Distance: ${currentTrainingSettings.preferredDistanceOverride}`)
         settings.push(`Must Rest Before Summer: ${currentTrainingSettings.mustRestBeforeSummer ? "Yes" : "No"}`)
         settings.push(`Train Wit During Finale: ${currentTrainingSettings.trainWitDuringFinale ? "Yes" : "No"}`)

--- a/src/context/BotStateContext.tsx
+++ b/src/context/BotStateContext.tsx
@@ -119,6 +119,7 @@ export interface Settings {
         disableTrainingOnMaxedStat: boolean
         focusOnSparkStatTarget: string[]
         enableRainbowTrainingBonus: boolean
+        enablePrioritizeNearMaxFriendship: boolean
         preferredDistanceOverride: string
         mustRestBeforeSummer: boolean
         enableRiskyTraining: boolean
@@ -378,6 +379,7 @@ export const defaultSettings: Settings = {
         disableTrainingOnMaxedStat: true,
         focusOnSparkStatTarget: ["Speed", "Stamina", "Power"],
         enableRainbowTrainingBonus: false,
+        enablePrioritizeNearMaxFriendship: true,
         preferredDistanceOverride: "Auto",
         mustRestBeforeSummer: false,
         enableRiskyTraining: false,

--- a/src/context/searchConfig.ts
+++ b/src/context/searchConfig.ts
@@ -172,6 +172,13 @@ const searchConfig: SearchOption[] = [
         page: "TrainingSettings",
     },
     {
+        id: "enable-prioritize-near-max-friendship",
+        title: "Prioritize Near-Max Friendship Bars",
+        description:
+            "When enabled (Year 2+), trainings with multiple green/blue friendship bars close to maxing receive an anticipatory rainbow multiplier (up to 1.6x), helping the bot favor them so the bars cross into orange and unlock real rainbow training on later turns. Does not stack with the actual rainbow bonus.",
+        page: "TrainingSettings",
+    },
+    {
         id: "enable-training-analysis-validation",
         title: "Enable Training Analysis Validation",
         description:

--- a/src/lib/messageLog/buildSettingsBanner.ts
+++ b/src/lib/messageLog/buildSettingsBanner.ts
@@ -115,6 +115,7 @@ export function buildSettingsBanner(settings: Settings): string {
 ✨ Focus on Sparks for Stat Targets: ${settings.training.focusOnSparkStatTarget.length === 0 ? "None" : settings.training.focusOnSparkStatTarget.join(", ")}
 📏 Preferred Distance Override: ${settings.training.preferredDistanceOverride === "Default" ? "Default" : settings.training.preferredDistanceOverride}
 🌈 Enable Rainbow Training Bonus: ${settings.training.enableRainbowTrainingBonus ? "✅" : "❌"}
+💞 Prioritize Near-Max Friendship: ${settings.training.enablePrioritizeNearMaxFriendship ? "✅" : "❌"}
 💡 Prioritize Skill Hints: ${settings.training.enablePrioritizeSkillHints ? "✅" : "❌"}
 📈 Weight Score by Training Level: ${settings.training.enableTrainingLevelWeighting ? "✅" : "❌"}
 ☀️ Must Rest Before Summer: ${settings.training.mustRestBeforeSummer ? "✅" : "❌"}

--- a/src/pages/TrainingSettings/index.tsx
+++ b/src/pages/TrainingSettings/index.tsx
@@ -102,6 +102,7 @@ const TrainingSettings = () => {
         maximumFailureChance,
         disableTrainingOnMaxedStat,
         enableRainbowTrainingBonus,
+        enablePrioritizeNearMaxFriendship,
         preferredDistanceOverride,
         mustRestBeforeSummer,
         enableRiskyTraining,
@@ -691,6 +692,17 @@ const TrainingSettings = () => {
                                         description="When enabled (Year 2+), rainbow trainings receive a significant bonus to their score, making them more likely to be selected. This is highly dependent on device configuration and may result in false positives."
                                         className="my-2"
                                         searchId="enable-rainbow-training-bonus"
+                                    />
+                                </View>
+
+                                <View style={styles.section}>
+                                    <CustomCheckbox
+                                        checked={enablePrioritizeNearMaxFriendship}
+                                        onCheckedChange={(checked) => updateTrainingSetting("enablePrioritizeNearMaxFriendship", checked)}
+                                        label="Prioritize Near-Max Friendship Bars"
+                                        description="When enabled (Year 2+), trainings with multiple green/blue friendship bars close to maxing receive an anticipatory rainbow multiplier (up to 1.6x), helping the bot favor them so the bars cross into orange and unlock rainbow training on later turns. Does not stack with the actual rainbow bonus."
+                                        className="my-2"
+                                        searchId="enable-prioritize-near-max-friendship"
                                     />
                                 </View>
 


### PR DESCRIPTION
## Description
- This PR addresses #337 by adding an anticipatory rainbow multiplier in Year 2+ Stat Efficiency scoring so the bot stops skipping trainings whose friendship bars are about to cross the orange threshold and unlock real rainbow training. This new option (defaults to ON) is added to the Training Settings page.
