### PR TITLE
Rename Trackblazer Charm and Item Floor setting names to be more clearer

### DIFF
--- a/HOW_IT_WORKS.md
+++ b/HOW_IT_WORKS.md
@@ -675,7 +675,7 @@ If **none** of these conditions are met and the inventory has already been synce
 - **Conserved energy item only:** If the only energy items in inventory are the lowest-tier copies reserved for emergency race recovery, the dialog is skipped — opening it would just use them and defeat the conservation rule.
 - **Conserved megaphone or Charm only:** If the only training-effect items in inventory would be filtered out by the megaphone-priority logic or by the Charm low-failure / low-gain rules, the dialog is skipped.
 - **No matching condition heal:** If no negative status is active, condition heals don't trigger the dialog even when they're in inventory.
-- **Low main stat gain floor (Trackblazer):** Trackblazer also tracks a `trackblazerLowMainStatGainItemFloor` (default 20) — when mood is low, the bot refuses to spend a Charm or run a Reset Whistle reshuffle if the selected training's main stat gain falls below this floor. The mood penalty would cap the gain enough that the item is conserved for a higher-gain turn instead.
+- **Low main stat gain floor (Trackblazer):** Trackblazer also tracks a `trackblazerSkipBadMoodItemsBelowGain` (default 15) — when mood is low, the bot refuses to spend a Charm or run a Reset Whistle reshuffle if the selected training's main stat gain falls below this floor. The mood penalty would cap the gain enough that the item is conserved for a higher-gain turn instead.
 
 Once the dialog is open, the bot scrolls through the full item list, performing **inventory sync** and **inline item usage** in a single pass. Each item encountered is evaluated against the rules below. If the cached inventory already accounts for every item of interest, the scan exits early.
 

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/Trackblazer.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/Trackblazer.kt
@@ -216,7 +216,7 @@ class Trackblazer(game: Game) : Campaign(game) {
     private val enableIrregularTraining: Boolean = SettingsHelper.getBooleanSetting("scenarioOverrides", "trackblazerEnableIrregularTraining", false)
 
     /** The minimum stat gain required for using a Good-Luck Charm to bypass failure chance. */
-    private val minCharmGain: Int = SettingsHelper.getIntSetting("scenarioOverrides", "trackblazerMinStatGainForCharm", 30)
+    private val minCharmGain: Int = SettingsHelper.getIntSetting("scenarioOverrides", "trackblazerSkipRiskyCharmTrainingBelowGain", 30)
 
     /** The minimum stat gain threshold for irregular training evaluation. */
     private val minIrregularGain: Int = SettingsHelper.getIntSetting("scenarioOverrides", "trackblazerIrregularTrainingMinStatGain", 30)
@@ -231,7 +231,7 @@ class Trackblazer(game: Game) : Campaign(game) {
      * When mood is below NORMAL (BAD or AWFUL), training resources (Reset Whistle reshuffle, Good-Luck Charm, and Megaphones) refuse to fire if main-stat gain is below this floor.
      * Prevents wasting items on structurally low-return turns where the mood multiplier caps the gain.
      */
-    private val lowMainStatGainItemFloor: Int = SettingsHelper.getIntSetting("scenarioOverrides", "trackblazerLowMainStatGainItemFloor", 20)
+    private val lowMainStatGainItemFloor: Int = SettingsHelper.getIntSetting("scenarioOverrides", "trackblazerSkipBadMoodItemsBelowGain", 15)
 
     /** The frequency to check the shop after a race. */
     private val shopCheckFrequency: Int = SettingsHelper.getIntSetting("scenarioOverrides", "trackblazerShopCheckFrequency", 3)
@@ -1043,9 +1043,9 @@ class Trackblazer(game: Game) : Campaign(game) {
         DecisionTracer
             .SettingsSnapshot()
             .add("Trackblazer Energy Threshold", energyThresholdToUseEnergyItems)
-            .add("Min Stat Gain for Charm", minCharmGain)
+            .add("Skip Risky Charm Training Below Gain", minCharmGain)
             .add("Consecutive Races Limit", consecutiveRacesLimit)
-            .add("Low Main Stat Gain Floor", lowMainStatGainItemFloor)
+            .add("Skip Bad-Mood Items Below Gain", lowMainStatGainItemFloor)
             .add("Whistle Forces Training", whistleForcesTraining)
             .add("Irregular Training", if (enableIrregularTraining) "on (min main $minIrregularGain)" else "off")
             .add("Enable In-Game Race Agenda", racing.enableUserInGameRaceAgenda)

--- a/src/context/BotStateContext.tsx
+++ b/src/context/BotStateContext.tsx
@@ -206,8 +206,8 @@ export interface Settings {
         trackblazerConsecutiveRacesLimit: number
         trackblazerEnergyThreshold: number
         trackblazerShopCheckGrades: string[]
-        trackblazerMinStatGainForCharm: number
-        trackblazerLowMainStatGainItemFloor: number
+        trackblazerSkipRiskyCharmTrainingBelowGain: number
+        trackblazerSkipBadMoodItemsBelowGain: number
         trackblazerMaxRetriesPerRace: number
         trackblazerWhistleForcesTraining: boolean
         trackblazerRetryRacesBeforeFinalGrades: string[]
@@ -448,8 +448,8 @@ export const defaultSettings: Settings = {
         trackblazerConsecutiveRacesLimit: 5,
         trackblazerEnergyThreshold: 40,
         trackblazerShopCheckGrades: ["G1", "G2", "G3"],
-        trackblazerMinStatGainForCharm: 30,
-        trackblazerLowMainStatGainItemFloor: 15,
+        trackblazerSkipRiskyCharmTrainingBelowGain: 30,
+        trackblazerSkipBadMoodItemsBelowGain: 15,
         trackblazerMaxRetriesPerRace: 1,
         trackblazerWhistleForcesTraining: true,
         trackblazerRetryRacesBeforeFinalGrades: ["G1", "G2", "G3"],

--- a/src/context/searchConfig.ts
+++ b/src/context/searchConfig.ts
@@ -707,16 +707,17 @@ const searchConfig: SearchOption[] = [
         page: "ScenarioOverridesSettings",
     },
     {
-        id: "trackblazer-min-stat-gain-for-charm",
-        title: "Trackblazer Min Main Stat Gain for Good-Luck Charm",
-        description: "Sets the minimum main stat gain required to justify using a Good-Luck Charm during training in the Trackblazer scenario.",
+        id: "trackblazer-skip-risky-charm-training-below-gain",
+        title: "Trackblazer Skip Risky Charm Training Below Stat Gain",
+        description:
+            "When a Good-Luck Charm is available to override a risky training's failure chance, skip that training anyway if its main stat gain is below this value. Prevents committing the Charm to low-value risky picks in the Trackblazer scenario.",
         page: "ScenarioOverridesSettings",
     },
     {
-        id: "trackblazer-low-main-stat-gain-item-floor",
-        title: "Trackblazer Low Main Stat Gain Item Floor",
+        id: "trackblazer-skip-bad-mood-items-below-gain",
+        title: "Trackblazer Skip Items During Bad Mood Below Stat Gain",
         description:
-            "When mood is BAD or AWFUL, refuse to use Reset Whistle, Good-Luck Charm, or Megaphone if main-stat gain is below this floor. Prevents wasting items on structurally low-return turns where the mood multiplier caps the stat gains.",
+            "When mood is BAD or AWFUL, refuse to use Reset Whistle, Good-Luck Charm, or Megaphone if the selected training's main stat gain is below this floor. Prevents wasting items on structurally low-return turns where the mood multiplier caps the stat gains.",
         page: "ScenarioOverridesSettings",
     },
     {

--- a/src/lib/messageLog/buildSettingsBanner.ts
+++ b/src/lib/messageLog/buildSettingsBanner.ts
@@ -190,8 +190,8 @@ ${longTargetsString}
 🛍️ Trackblazer Shop Check Grades: ${settings.scenarioOverrides?.trackblazerShopCheckGrades?.join(", ")}
 🛍️ Trackblazer Shop Check Frequency: ${settings.scenarioOverrides?.trackblazerShopCheckFrequency}
 🛍️ Trackblazer Excluded Items: ${settings.scenarioOverrides?.trackblazerExcludedItems?.length === 0 ? "None" : settings.scenarioOverrides?.trackblazerExcludedItems?.join(", ")}
-✨ Trackblazer Min Stat Gain for Charm: ${settings.scenarioOverrides?.trackblazerMinStatGainForCharm}
-✨ Trackblazer Low Main Stat Gain Item Floor: ${settings.scenarioOverrides?.trackblazerLowMainStatGainItemFloor}
+✨ Trackblazer Skip Risky Charm Training Below Stat Gain: ${settings.scenarioOverrides?.trackblazerSkipRiskyCharmTrainingBelowGain}
+✨ Trackblazer Skip Items During Bad Mood Below Stat Gain: ${settings.scenarioOverrides?.trackblazerSkipBadMoodItemsBelowGain}
 🔄 Trackblazer Max Retries per Race: ${settings.scenarioOverrides?.trackblazerMaxRetriesPerRace}
 🔄 Trackblazer Whistle Forces Training: ${settings.scenarioOverrides?.trackblazerWhistleForcesTraining ? "✅" : "❌"}
 🔄 Trackblazer Retry Grades: ${settings.scenarioOverrides?.trackblazerRetryRacesBeforeFinalGrades?.join(", ")}

--- a/src/lib/settingsUtils.ts
+++ b/src/lib/settingsUtils.ts
@@ -176,5 +176,25 @@ export const applyMigrations = (settings: any, rawSettings?: any): { settings: a
         logWithTimestamp("[SettingsManager] Dropped removed setting enablePopupCheck.")
     }
 
+    // Migration: Rename Trackblazer Charm and Item Floor settings to behavior-first names.
+    // The old keys (trackblazerMinStatGainForCharm, trackblazerLowMainStatGainItemFloor) are replaced by
+    // trackblazerSkipRiskyCharmTrainingBelowGain and trackblazerSkipBadMoodItemsBelowGain respectively.
+    const scenarioOverrides = migratedSettings.scenarioOverrides as any
+    const rawScenarioOverrides = rawSettings?.scenarioOverrides as any
+    if (scenarioOverrides && rawScenarioOverrides) {
+        if (rawScenarioOverrides.trackblazerMinStatGainForCharm !== undefined) {
+            scenarioOverrides.trackblazerSkipRiskyCharmTrainingBelowGain = rawScenarioOverrides.trackblazerMinStatGainForCharm
+            delete scenarioOverrides.trackblazerMinStatGainForCharm
+            anyMigrated = true
+            logWithTimestamp("[SettingsManager] Migrated trackblazerMinStatGainForCharm to trackblazerSkipRiskyCharmTrainingBelowGain.")
+        }
+        if (rawScenarioOverrides.trackblazerLowMainStatGainItemFloor !== undefined) {
+            scenarioOverrides.trackblazerSkipBadMoodItemsBelowGain = rawScenarioOverrides.trackblazerLowMainStatGainItemFloor
+            delete scenarioOverrides.trackblazerLowMainStatGainItemFloor
+            anyMigrated = true
+            logWithTimestamp("[SettingsManager] Migrated trackblazerLowMainStatGainItemFloor to trackblazerSkipBadMoodItemsBelowGain.")
+        }
+    }
+
     return { settings: migratedSettings, anyMigrated }
 }

--- a/src/pages/ScenarioOverridesSettings/index.tsx
+++ b/src/pages/ScenarioOverridesSettings/index.tsx
@@ -215,37 +215,37 @@ const ScenarioOverridesSettings = () => {
 
                                                 <View style={styles.section}>
                                                     <CustomSlider
-                                                        searchId="trackblazer-min-stat-gain-for-charm"
-                                                        value={scenarioOverrides.trackblazerMinStatGainForCharm}
-                                                        placeholder={defaultSettings.scenarioOverrides.trackblazerMinStatGainForCharm}
-                                                        onValueChange={(value) => updateOverrideSetting("trackblazerMinStatGainForCharm", value)}
-                                                        onSlidingComplete={(value) => updateOverrideSetting("trackblazerMinStatGainForCharm", value)}
+                                                        searchId="trackblazer-skip-risky-charm-training-below-gain"
+                                                        value={scenarioOverrides.trackblazerSkipRiskyCharmTrainingBelowGain}
+                                                        placeholder={defaultSettings.scenarioOverrides.trackblazerSkipRiskyCharmTrainingBelowGain}
+                                                        onValueChange={(value) => updateOverrideSetting("trackblazerSkipRiskyCharmTrainingBelowGain", value)}
+                                                        onSlidingComplete={(value) => updateOverrideSetting("trackblazerSkipRiskyCharmTrainingBelowGain", value)}
                                                         min={20}
                                                         max={100}
                                                         step={5}
-                                                        label="Minimum Main Stat Gain for Good-Luck Charm"
+                                                        label="Skip Risky Charm Training Below Stat Gain"
                                                         labelUnit=""
                                                         showValue={true}
                                                         showLabels={true}
-                                                        description="The minimum expected gain for the main training stat required to use a Good-Luck Charm instead of skipping training."
+                                                        description="When a Good-Luck Charm is available to override a risky training's failure chance, skip that training anyway if its main stat gain is below this value. Prevents committing the Charm to low-value risky picks."
                                                     />
                                                 </View>
 
                                                 <View style={styles.section}>
                                                     <CustomSlider
-                                                        searchId="trackblazer-low-main-stat-gain-item-floor"
-                                                        value={scenarioOverrides.trackblazerLowMainStatGainItemFloor}
-                                                        placeholder={defaultSettings.scenarioOverrides.trackblazerLowMainStatGainItemFloor}
-                                                        onValueChange={(value) => updateOverrideSetting("trackblazerLowMainStatGainItemFloor", value)}
-                                                        onSlidingComplete={(value) => updateOverrideSetting("trackblazerLowMainStatGainItemFloor", value)}
+                                                        searchId="trackblazer-skip-bad-mood-items-below-gain"
+                                                        value={scenarioOverrides.trackblazerSkipBadMoodItemsBelowGain}
+                                                        placeholder={defaultSettings.scenarioOverrides.trackblazerSkipBadMoodItemsBelowGain}
+                                                        onValueChange={(value) => updateOverrideSetting("trackblazerSkipBadMoodItemsBelowGain", value)}
+                                                        onSlidingComplete={(value) => updateOverrideSetting("trackblazerSkipBadMoodItemsBelowGain", value)}
                                                         min={0}
                                                         max={50}
                                                         step={1}
-                                                        label="Low Main Stat Gain Item Floor"
+                                                        label="Skip Items During Bad Mood Below Stat Gain"
                                                         labelUnit=""
                                                         showValue={true}
                                                         showLabels={true}
-                                                        description="When mood is BAD or AWFUL, refuse to use Reset Whistle / Good-Luck Charm / Megaphone if main-stat gain is below this floor. Prevents wasting items on structurally low-return turns where the mood multiplier caps the stat gains."
+                                                        description="When mood is BAD or AWFUL, refuse to use Reset Whistle / Good-Luck Charm / Megaphone if the selected training's main stat gain is below this floor. Prevents wasting items on structurally low-return turns where the mood multiplier caps the stat gains."
                                                     />
                                                 </View>
 


### PR DESCRIPTION
## Description
- This PR renames the two ambiguous Trackblazer settings to behavior-first names: `Minimum Main Stat Gain for Good-Luck Charm` is now `Skip Risky Charm Training Below Stat Gain`, and `Low Main Stat Gain Item Floor` is now `Skip Items During Bad Mood Below Stat Gain`.
- Fixes the backend default for the Item Floor setting (was `20` in Kotlin, now `15`) with the frontend default so both sides agree.
- Adds a one-time migration in `applyMigrations()` that copies any user-saved values from the old keys (`trackblazerMinStatGainForCharm`, `trackblazerLowMainStatGainItemFloor`) to the new keys (`trackblazerSkipRiskyCharmTrainingBelowGain`, `trackblazerSkipBadMoodItemsBelowGain`) on first launch, preserving existing configurations.
