### PR TITLE
Customize Trackblazer item conservation thresholds

### DIFF
--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Campaign.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Campaign.kt
@@ -819,11 +819,11 @@ abstract class Campaign(game: Game) : Task(game) {
     }
 
     /**
-     * Decision-relevant inventory snapshot for the current turn. Subclasses with inventory tracking (e.g. Trackblazer) should override to
-     * return the items that drive their decisions (charms, whistles, megaphones, energy/mood items). Empty map by default for campaigns
+     * Decision-relevant inventory snapshot for the current turn, grouped by category label (e.g. `Megaphones`, `Race Items`) then mapped to item-name -> count. Subclasses with inventory tracking
+     * (e.g. Trackblazer) should override to return the items that drive their decisions. Use `LinkedHashMap` so the category order is preserved when rendered. Empty map by default for campaigns
      * without inventory.
      */
-    open fun gatherDecisionInventory(): Map<String, Int> = emptyMap()
+    open fun gatherDecisionInventory(): Map<String, Map<String, Int>> = emptyMap()
 
     /**
      * Decision-relevant settings snapshot for the current turn. Subclasses should populate the snapshot with the user-configurable knobs

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/DecisionTracer.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/DecisionTracer.kt
@@ -44,8 +44,8 @@ class DecisionTracer {
         val mood: Mood,
         /** Active negative status names. Empty when none. */
         val negativeStatuses: List<String>,
-        /** Map of decision-relevant inventory item names to counts. May be empty for campaigns without inventory tracking. */
-        val inventory: Map<String, Int>,
+        /** Decision-relevant inventory grouped by category label (e.g. `Megaphones`) then mapped to item-name -> count. Outer and inner maps preserve insertion order (use `LinkedHashMap`). Empty for campaigns without inventory tracking. */
+        val inventory: Map<String, Map<String, Int>>,
         /** Campaign-specific extra state (e.g. `consecutiveRaceCount` for Trackblazer) as displayable key/value pairs. */
         val extra: Map<String, String>,
     )
@@ -191,18 +191,24 @@ class DecisionTracer {
      *
      * @param date Current game date used for the turn label.
      * @param trainee Live trainee whose state is snapshotted (shallow copy of relevant fields).
-     * @param inventorySnapshot Decision-relevant inventory counts. Pass an empty map when the campaign has no inventory concept.
+     * @param inventorySnapshot Decision-relevant inventory grouped by category label -> item-name -> count. Both maps preserve insertion order (use `LinkedHashMap`). Pass an empty map when the campaign has no inventory concept.
      * @param settings Settings values that drive decisions this turn.
      * @param extraState Optional map of campaign-specific state values (e.g. Trackblazer's `consecutiveRaceCount`) that the base trainee snapshot does not carry.
      */
-    fun startTurn(date: GameDate, trainee: Trainee, inventorySnapshot: Map<String, Int> = emptyMap(), settings: SettingsSnapshot = SettingsSnapshot(), extraState: Map<String, String> = emptyMap()) {
+    fun startTurn(
+        date: GameDate,
+        trainee: Trainee,
+        inventorySnapshot: Map<String, Map<String, Int>> = emptyMap(),
+        settings: SettingsSnapshot = SettingsSnapshot(),
+        extraState: Map<String, String> = emptyMap(),
+    ) {
         turnLabel = formatTurnLabel(date)
         stateSnapshot =
             StateSnapshot(
                 energy = trainee.energy,
                 mood = trainee.mood,
                 negativeStatuses = trainee.currentNegativeStatuses.toList(),
-                inventory = inventorySnapshot.toMap(),
+                inventory = inventorySnapshot.mapValuesTo(LinkedHashMap()) { (_, items) -> LinkedHashMap(items) },
                 extra = extraState.toMap(),
             )
         settingsSnapshot = settings
@@ -355,7 +361,10 @@ class DecisionTracer {
         state.extra.forEach { (key, value) -> sb.append("  $key = $value\n") }
         if (state.inventory.isNotEmpty()) {
             sb.append("Inventory (decision-relevant):\n")
-            state.inventory.toSortedMap().forEach { (name, count) -> sb.append("  $name = $count\n") }
+            state.inventory.forEach { (group, items) ->
+                sb.append("  [$group]\n")
+                items.toSortedMap().forEach { (name, count) -> sb.append("  $name = $count\n") }
+            }
         }
         return sb.toString()
     }

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/Trackblazer.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/Trackblazer.kt
@@ -212,6 +212,9 @@ class Trackblazer(game: Game) : Campaign(game) {
     /** Number of energy items (lowest-tier first across `energyItemConservationOrder`) held back as the emergency-race-recovery reserve. 0 = no reserve. */
     private val energyItemReserveCount: Int = SettingsHelper.getIntSetting("scenarioOverrides", "trackblazerEnergyItemReserve", 1)
 
+    /** Number of cupcakes (Plain preferred over Berry Sweet) held back so Royal Kale Juice's mood penalty can be offset. 0 = no reserve. */
+    private val cupcakeReserveCount: Int = SettingsHelper.getIntSetting("scenarioOverrides", "trackblazerCupcakeReserve", 1)
+
     /** Whether the Reset Whistle forces training. */
     private val whistleForcesTraining: Boolean = SettingsHelper.getBooleanSetting("scenarioOverrides", "trackblazerWhistleForcesTraining", true)
 
@@ -2540,17 +2543,20 @@ class Trackblazer(game: Game) : Campaign(game) {
         // Mood Items Check.
         val shouldUseMoodItem = trainee.mood <= Mood.NORMAL && trainee.energy < 70
         if (shouldUseMoodItem && (itemName == "Berry Sweet Cupcake" || itemName == "Plain Cupcake")) {
-            // Conservation: always keep at least 1 cupcake in case Royal Kale Juice is purchased later.
-            // Prefer conserving Plain Cupcake (+1 mood) since Kale Juice is -1 mood and we can avoid waste from Berry Sweet (+2).
-            val plainCount = nextInventory["Plain Cupcake"] ?: 0
-            val berryCount = nextInventory["Berry Sweet Cupcake"] ?: 0
-            val shouldConserve =
-                (itemName == "Plain Cupcake" && plainCount <= 1) ||
-                    (itemName == "Berry Sweet Cupcake" && berryCount <= 1 && plainCount == 0)
-            if (shouldConserve) {
-                MessageLog.i(TAG, "[TRACKBLAZER] Conserving last $itemName for potential Royal Kale Juice usage.")
-                decisionTracer.recordItemDecision(itemName, DecisionTracer.ItemVerdict.CONSERVED, "Last unit reserved for potential Royal Kale Juice synergy")
-                return null
+            // Conservation: hold back `cupcakeReserveCount` cupcakes (Plain preferred) so Royal Kale Juice's -1 mood penalty can be offset.
+            // Plain (+1 mood) is preferred for the reserve because Berry Sweet (+2 mood) would overshoot when paired with Kale Juice.
+            if (cupcakeReserveCount > 0) {
+                val plainCount = nextInventory["Plain Cupcake"] ?: 0
+                val berryCount = nextInventory["Berry Sweet Cupcake"] ?: 0
+                val totalCupcakes = plainCount + berryCount
+                val shouldConserve =
+                    (itemName == "Plain Cupcake" && plainCount <= cupcakeReserveCount) ||
+                        (itemName == "Berry Sweet Cupcake" && totalCupcakes <= cupcakeReserveCount && plainCount == 0)
+                if (shouldConserve) {
+                    MessageLog.i(TAG, "[TRACKBLAZER] Conserving $itemName for potential Royal Kale Juice usage (reserve floor: $cupcakeReserveCount).")
+                    decisionTracer.recordItemDecision(itemName, DecisionTracer.ItemVerdict.CONSERVED, "Within Kale Juice synergy reserve of $cupcakeReserveCount")
+                    return null
+                }
             }
 
             // Very simple inline mood: use the first one seen if energy is low.

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/Trackblazer.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/Trackblazer.kt
@@ -209,6 +209,9 @@ class Trackblazer(game: Game) : Campaign(game) {
     /** Threshold for energy level to use energy items. */
     private var energyThresholdToUseEnergyItems: Int = SettingsHelper.getIntSetting("scenarioOverrides", "trackblazerEnergyThreshold", 40)
 
+    /** Number of energy items (lowest-tier first across `energyItemConservationOrder`) held back as the emergency-race-recovery reserve. 0 = no reserve. */
+    private val energyItemReserveCount: Int = SettingsHelper.getIntSetting("scenarioOverrides", "trackblazerEnergyItemReserve", 1)
+
     /** Whether the Reset Whistle forces training. */
     private val whistleForcesTraining: Boolean = SettingsHelper.getBooleanSetting("scenarioOverrides", "trackblazerWhistleForcesTraining", true)
 
@@ -2489,14 +2492,12 @@ class Trackblazer(game: Game) : Campaign(game) {
 
         // Energy Items Check.
         if (!charmBeingUsedThisTurn && passStartEnergy <= energyThresholdToUseEnergyItems && shopList.energyItemNames.contains(itemName)) {
-            // Conservation: always keep the last unit of the lowest-level energy item for emergency race recovery.
-            if (!bForceUseReservedItem) {
-                val conserveItem = energyItemConservationOrder.firstOrNull { (nextInventory[it] ?: 0) > 0 }
-                if (conserveItem == itemName && (nextInventory[itemName] ?: 0) <= 1) {
-                    MessageLog.i(TAG, "[TRACKBLAZER] Conserving last $itemName for emergency race recovery.")
-                    decisionTracer.recordItemDecision(itemName, DecisionTracer.ItemVerdict.CONSERVED, "Last unit reserved for emergency race recovery")
-                    return null
-                }
+            // Conservation: hold back up to `energyItemReserveCount` units across the conservation order (lowest-tier first) for emergency race recovery.
+            val reservedHere = reservedEnergyUnitsFor(itemName, nextInventory)
+            if (reservedHere > 0 && (nextInventory[itemName] ?: 0) <= reservedHere) {
+                MessageLog.i(TAG, "[TRACKBLAZER] Conserving $itemName for emergency race recovery (reserve floor: $energyItemReserveCount).")
+                decisionTracer.recordItemDecision(itemName, DecisionTracer.ItemVerdict.CONSERVED, "Within emergency reserve floor of $energyItemReserveCount")
+                return null
             }
 
             if (isBestEnergyItemToUse(trainee, itemName, nextInventory, remainingItemsOfInterest)) {
@@ -2619,6 +2620,27 @@ class Trackblazer(game: Game) : Campaign(game) {
     }
 
     /**
+     * Returns how many units of `itemName` are currently being held back as part of the energy reserve floor.
+     * Reserves are allocated across `energyItemConservationOrder` lowest-tier-first up to `energyItemReserveCount` total units.
+     *
+     * @param itemName The energy item name to inspect.
+     * @param inventory The inventory snapshot to evaluate against.
+     * @return The number of units of `itemName` that are reserved (0 if `itemName` is not in the order, the reserve is disabled, or the higher-priority tiers already absorbed the full budget).
+     */
+    private fun reservedEnergyUnitsFor(itemName: String, inventory: Map<String, Int>): Int {
+        if (bForceUseReservedItem || energyItemReserveCount <= 0) return 0
+        var remaining = energyItemReserveCount
+        for (name in energyItemConservationOrder) {
+            if (remaining <= 0) break
+            val count = inventory[name] ?: 0
+            val reservedHere = minOf(count, remaining)
+            if (name == itemName) return reservedHere
+            remaining -= reservedHere
+        }
+        return 0
+    }
+
+    /**
      * Returns the energy item name currently being conserved as the last-resort emergency-race-recovery stash.
      *
      * Mirrors the conservation logic inside `isBestEnergyItemToUse` so the dialog-open gate predicts the same outcome the dialog scan would reach.
@@ -2627,7 +2649,7 @@ class Trackblazer(game: Game) : Campaign(game) {
      * @return The conserved item name, or `null` if conservation is bypassed or no conservable item is in inventory.
      */
     private fun getConservedEnergyItem(inventory: Map<String, Int>): String? {
-        if (bForceUseReservedItem) return null
+        if (bForceUseReservedItem || energyItemReserveCount <= 0) return null
         return energyItemConservationOrder.firstOrNull { (inventory[it] ?: 0) > 0 }
     }
 
@@ -2840,23 +2862,17 @@ class Trackblazer(game: Game) : Campaign(game) {
         }
 
         // Collect all available energy items from this scan pass.
-        // Always reserve one unit of the lowest-tier item for emergency race recovery, unless force-override is active.
+        // Subtract any units that fall inside the user-configured emergency reserve (lowest-tier first across `energyItemConservationOrder`).
         val availableEnergyItems = mutableListOf<Int>()
-        val conserveItem = if (!bForceUseReservedItem) energyItemConservationOrder.firstOrNull { (nextInventory[it] ?: 0) > 0 } else null
         remainingItemsOfInterest.forEach { name ->
             val gain = energyGains[name]
             if (gain != null) {
                 // If this is Kale Juice, only include it if it's usable.
                 if (name == "Royal Kale Juice" && !isKaleJuiceUsable) return@forEach
 
-                var count = (nextInventory[name] ?: 0)
-
-                // Exclude one unit of the conserved item from the greedy pool.
-                if (name == conserveItem && count > 0) {
-                    count--
-                }
-
-                repeat(count) { availableEnergyItems.add(gain) }
+                val rawCount = nextInventory[name] ?: 0
+                val available = (rawCount - reservedEnergyUnitsFor(name, nextInventory)).coerceAtLeast(0)
+                repeat(available) { availableEnergyItems.add(gain) }
             }
         }
 

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/Trackblazer.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/Trackblazer.kt
@@ -218,6 +218,12 @@ class Trackblazer(game: Game) : Campaign(game) {
     /** Number of Master Cleat Hammers held back for the Finale days (73-75). 0 = no reserve, spend freely on G1/G2 races. */
     private val masterHammerFinaleReserve: Int = SettingsHelper.getIntSetting("scenarioOverrides", "trackblazerMasterHammerFinaleReserve", 2)
 
+    /** Minimum Artisan Cleat Hammer stock required before the bot will spend one on a G3 race. 0 = always allowed when stock > 0. */
+    private val artisanMinStockForG3: Int = SettingsHelper.getIntSetting("scenarioOverrides", "trackblazerArtisanHammerMinStockForG3", 3)
+
+    /** Minimum Artisan Cleat Hammer stock required before the bot will spend one on a G2 race. 0 = always allowed when stock > 0. G1 is always allowed. */
+    private val artisanMinStockForG2: Int = SettingsHelper.getIntSetting("scenarioOverrides", "trackblazerArtisanHammerMinStockForG2", 2)
+
     /** Whether the Reset Whistle forces training. */
     private val whistleForcesTraining: Boolean = SettingsHelper.getBooleanSetting("scenarioOverrides", "trackblazerWhistleForcesTraining", true)
 
@@ -2090,18 +2096,18 @@ class Trackblazer(game: Game) : Campaign(game) {
                 hasEnough && grade == RaceGrade.G1
             }
 
-        // Artisan Hammer Logic
-        // Grade priority: G1 > G2 > G3, with G3 only allowed if 3+ artisan hammers.
+        // Artisan Hammer Logic. User-configured per-grade stock floors:
+        // - G3 requires `artisanMinStockForG3` (default 3) units before the bot will spend one.
+        // - G2 requires `artisanMinStockForG2` (default 2) units before the bot will spend one.
+        // - G1 only requires at least 1 in stock. Threshold of 0 means "always allowed (as long as stock > 0)".
         val canUseArtisanHammer =
-            if (artisanHammerCount >= 3) {
-                true
-            } else if (artisanHammerCount >= 2) {
-                grade == RaceGrade.G1 || grade == RaceGrade.G2
-            } else if (artisanHammerCount == 1) {
-                grade == RaceGrade.G1
-            } else {
-                false
-            }
+            artisanHammerCount > 0 &&
+                when (grade) {
+                    RaceGrade.G1 -> true
+                    RaceGrade.G2 -> artisanHammerCount >= maxOf(1, artisanMinStockForG2)
+                    RaceGrade.G3 -> artisanHammerCount >= maxOf(1, artisanMinStockForG3)
+                    else -> false
+                }
 
         // Master takes priority at the finale since it provides a higher bonus (35% vs 20%).
         val hammerToUse =

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/Trackblazer.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/Trackblazer.kt
@@ -1079,6 +1079,13 @@ class Trackblazer(game: Game) : Campaign(game) {
                     "off"
                 },
             )
+            .add("Energy Item Reserve", energyItemReserveCount)
+            .add("Cupcake Reserve", cupcakeReserveCount)
+            .add("Master Hammer Finale Reserve", masterHammerFinaleReserve)
+            .add("Artisan Hammer Min Stock G3", artisanMinStockForG3)
+            .add("Artisan Hammer Min Stock G2", artisanMinStockForG2)
+            .add("Glow Stick Final-Day Reserve", glowStickFinalReserve)
+            .add("Glow Stick Min Fans", glowStickMinFans)
 
     override fun gatherDecisionExtraState(): Map<String, String> =
         mapOf(

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/Trackblazer.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/Trackblazer.kt
@@ -215,6 +215,9 @@ class Trackblazer(game: Game) : Campaign(game) {
     /** Number of cupcakes (Plain preferred over Berry Sweet) held back so Royal Kale Juice's mood penalty can be offset. 0 = no reserve. */
     private val cupcakeReserveCount: Int = SettingsHelper.getIntSetting("scenarioOverrides", "trackblazerCupcakeReserve", 1)
 
+    /** Number of Master Cleat Hammers held back for the Finale days (73-75). 0 = no reserve, spend freely on G1/G2 races. */
+    private val masterHammerFinaleReserve: Int = SettingsHelper.getIntSetting("scenarioOverrides", "trackblazerMasterHammerFinaleReserve", 2)
+
     /** Whether the Reset Whistle forces training. */
     private val whistleForcesTraining: Boolean = SettingsHelper.getBooleanSetting("scenarioOverrides", "trackblazerWhistleForcesTraining", true)
 
@@ -2071,18 +2074,19 @@ class Trackblazer(game: Game) : Campaign(game) {
         val artisanHammerCount = currentInventory["Artisan Cleat Hammer"] ?: 0
         val glowSticksCount = currentInventory["Glow Sticks"] ?: 0
 
-        // Always reserve 2 master hammers for the finale (days 73-75)
-        val spareMasterHammers = (masterHammerCount - 2).coerceAtLeast(0)
+        // Reserve `masterHammerFinaleReserve` master hammers for the finale (days 73-75). Pre-finale days only spend the surplus above that reserve.
+        val spareMasterHammers = (masterHammerCount - masterHammerFinaleReserve).coerceAtLeast(0)
 
         // Master Hammer Logic
         val canUseMasterHammer =
             if (date.day < 73) {
-                // Only use spare masters beyond the 2 reserved for the finale
+                // Only use spare masters beyond the reserve for the finale.
                 spareMasterHammers > 0 && (grade == RaceGrade.G1 || grade == RaceGrade.G2)
             } else {
-                // Ensure we still have enough for remaining finale days.
+                // Ensure we still have enough for remaining finale days. Reserve count caps the per-day allowance.
                 val remainingFinaleDays = listOf(73, 74, 75).count { it >= date.day }
-                val hasEnough = masterHammerCount > remainingFinaleDays.coerceAtMost(masterHammerCount - 1).coerceAtLeast(0)
+                val effectiveReserve = remainingFinaleDays.coerceAtMost(masterHammerCount - 1).coerceAtLeast(0)
+                val hasEnough = masterHammerCount > effectiveReserve
                 hasEnough && grade == RaceGrade.G1
             }
 

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/Trackblazer.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/Trackblazer.kt
@@ -224,6 +224,12 @@ class Trackblazer(game: Game) : Campaign(game) {
     /** Minimum Artisan Cleat Hammer stock required before the bot will spend one on a G2 race. 0 = always allowed when stock > 0. G1 is always allowed. */
     private val artisanMinStockForG2: Int = SettingsHelper.getIntSetting("scenarioOverrides", "trackblazerArtisanHammerMinStockForG2", 2)
 
+    /** Number of Glow Sticks held back for Day 75 (the Final). 0 = no reserve. */
+    private val glowStickFinalReserve: Int = SettingsHelper.getIntSetting("scenarioOverrides", "trackblazerGlowStickFinalReserve", 1)
+
+    /** Minimum projected fan gain on a race before a Glow Stick is used. 0 = use on any race. */
+    private val glowStickMinFans: Int = SettingsHelper.getIntSetting("scenarioOverrides", "trackblazerGlowStickMinFans", 20000)
+
     /** Whether the Reset Whistle forces training. */
     private val whistleForcesTraining: Boolean = SettingsHelper.getBooleanSetting("scenarioOverrides", "trackblazerWhistleForcesTraining", true)
 
@@ -2125,18 +2131,11 @@ class Trackblazer(game: Game) : Campaign(game) {
                 }
             }
 
-        // Glow Sticks Logic
-        val useGlowSticks =
-            if (date.day >= 73) {
-                // Reserve 1 stick for Day 75 (the Final).
-                val reserveForFinals = if (date.day < 75) 1 else 0
-                fans >= 20000 && glowSticksCount > reserveForFinals
-            } else if (fans >= 30000) {
-                // Use the last stick. Shops refresh when the Finales start so there is a chance for another Glow Stick to buy.
-                glowSticksCount > 0
-            } else {
-                fans >= 20000 && glowSticksCount > 1
-            }
+        // Glow Sticks Logic. User-configured controls:
+        // - `glowStickFinalReserve` holds N sticks back for Day 75 (the Final). Pre-Day-75 races only spend the surplus.
+        // - `glowStickMinFans` is the per-race fan floor. Applies on standard and finale days.
+        val effectiveReserve = if (date.day < 75) glowStickFinalReserve else 0
+        val useGlowSticks = fans >= glowStickMinFans && glowSticksCount > effectiveReserve
 
         if (hammerToUse != null || useGlowSticks) {
             MessageLog.i(TAG, "[TRACKBLAZER] Suitable race items found in inventory (Hammer: $hammerToUse, Glow Sticks: $useGlowSticks). Opening Training Items dialog.")

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/Trackblazer.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/Trackblazer.kt
@@ -1059,11 +1059,21 @@ class Trackblazer(game: Game) : Campaign(game) {
         }
     }
 
-    override fun gatherDecisionInventory(): Map<String, Int> {
-        // Only the items that drive Trackblazer's decision tree this turn. Energy items are aggregated under their displayable name.
-        val keys = listOf("Good-Luck Charm", "Empowering Megaphone", "Motivating Megaphone", "Coaching Megaphone", "Reset Whistle", "Royal Kale Juice", "Berry Sweet Cupcake", "Plain Cupcake")
-        val snapshot = mutableMapOf<String, Int>()
-        keys.forEach { name -> snapshot[name] = currentInventory[name] ?: 0 }
+    override fun gatherDecisionInventory(): Map<String, Map<String, Int>> {
+        // Only the items that drive Trackblazer's decision tree this turn. Grouped by category so the Decision Report renders related items together.
+        val groups =
+            linkedMapOf(
+                "Charms & Whistles" to listOf("Good-Luck Charm", "Reset Whistle"),
+                "Megaphones" to listOf("Empowering Megaphone", "Motivating Megaphone", "Coaching Megaphone"),
+                "Cupcakes & Heals" to listOf("Berry Sweet Cupcake", "Plain Cupcake", "Royal Kale Juice"),
+                "Race Items" to listOf("Artisan Cleat Hammer", "Master Cleat Hammer", "Glow Sticks"),
+            )
+        val snapshot = linkedMapOf<String, Map<String, Int>>()
+        groups.forEach { (group, keys) ->
+            val items = linkedMapOf<String, Int>()
+            keys.forEach { name -> items[name] = currentInventory[name] ?: 0 }
+            snapshot[group] = items
+        }
         return snapshot
     }
 

--- a/src/context/BotStateContext.tsx
+++ b/src/context/BotStateContext.tsx
@@ -218,6 +218,13 @@ export interface Settings {
         trackblazerShopCheckFrequency: number
         trackblazerPreferredDistances: string[]
         trackblazerPreferredSurfaces: string[]
+        trackblazerEnergyItemReserve: number
+        trackblazerCupcakeReserve: number
+        trackblazerMasterHammerFinaleReserve: number
+        trackblazerArtisanHammerMinStockForG3: number
+        trackblazerArtisanHammerMinStockForG2: number
+        trackblazerGlowStickFinalReserve: number
+        trackblazerGlowStickMinFans: number
     }
 }
 
@@ -461,6 +468,13 @@ export const defaultSettings: Settings = {
         trackblazerShopCheckFrequency: 3,
         trackblazerPreferredDistances: [] as string[],
         trackblazerPreferredSurfaces: [] as string[],
+        trackblazerEnergyItemReserve: 1,
+        trackblazerCupcakeReserve: 1,
+        trackblazerMasterHammerFinaleReserve: 2,
+        trackblazerArtisanHammerMinStockForG3: 3,
+        trackblazerArtisanHammerMinStockForG2: 2,
+        trackblazerGlowStickFinalReserve: 1,
+        trackblazerGlowStickMinFans: 20000,
     },
 }
 

--- a/src/context/searchConfig.ts
+++ b/src/context/searchConfig.ts
@@ -782,6 +782,55 @@ const searchConfig: SearchOption[] = [
         description: "Select preferred track surfaces for extra race selection. Matching races will be prioritized. Leave empty for no preference.",
         page: "ScenarioOverridesSettings",
     },
+    {
+        id: "trackblazer-energy-item-reserve",
+        title: "Trackblazer Energy Item Emergency Reserve",
+        description:
+            "Number of energy items (lowest-tier first) the Trackblazer bot keeps reserved for emergency race recovery when energy hits 1% or below with 3+ consecutive races. Set to 0 to disable the reserve and use energy items freely.",
+        page: "ScenarioOverridesSettings",
+    },
+    {
+        id: "trackblazer-cupcake-reserve",
+        title: "Trackblazer Cupcake Reserve for Kale Juice Synergy",
+        description:
+            "Number of cupcakes (Plain preferred) the Trackblazer bot keeps so the mood penalty from Royal Kale Juice can be offset. Set to 0 to disable the reserve and use cupcakes freely for mood.",
+        page: "ScenarioOverridesSettings",
+    },
+    {
+        id: "trackblazer-master-hammer-finale-reserve",
+        title: "Trackblazer Master Cleat Hammer Finale Reserve",
+        description:
+            "Master Cleat Hammers the Trackblazer bot holds back for the Finale days (73-75). Pre-finale days only spend the surplus above this reserve, and only on G1/G2 races. Set to 0 to disable the reserve.",
+        page: "ScenarioOverridesSettings",
+    },
+    {
+        id: "trackblazer-artisan-hammer-min-stock-for-g3",
+        title: "Trackblazer Artisan Hammer Min Stock for G3",
+        description:
+            "Minimum Artisan Cleat Hammer inventory before the Trackblazer bot is allowed to spend one on a G3 race. Set to 0 to always allow G3 use (as long as stock is positive).",
+        page: "ScenarioOverridesSettings",
+    },
+    {
+        id: "trackblazer-artisan-hammer-min-stock-for-g2",
+        title: "Trackblazer Artisan Hammer Min Stock for G2",
+        description:
+            "Minimum Artisan Cleat Hammer inventory before the Trackblazer bot is allowed to spend one on a G2 race. G1 is always allowed. Set to 0 to always allow G2 use (as long as stock is positive).",
+        page: "ScenarioOverridesSettings",
+    },
+    {
+        id: "trackblazer-glow-stick-final-reserve",
+        title: "Trackblazer Glow Stick Final-Day Reserve",
+        description:
+            "Glow Sticks the Trackblazer bot holds back for Day 75 (the Final). Pre-final-day races only spend sticks above this reserve. Set to 0 to disable the reserve.",
+        page: "ScenarioOverridesSettings",
+    },
+    {
+        id: "trackblazer-glow-stick-min-fans",
+        title: "Trackblazer Glow Stick Minimum Fans",
+        description:
+            "Minimum projected fan gain on a race before the Trackblazer bot uses a Glow Stick on it. Applies on standard and finale days. Set to 0 to use Glow Sticks on any race.",
+        page: "ScenarioOverridesSettings",
+    },
 
     // ============================================================
     // Discord Settings

--- a/src/lib/messageLog/buildSettingsBanner.ts
+++ b/src/lib/messageLog/buildSettingsBanner.ts
@@ -200,6 +200,13 @@ ${longTargetsString}
 ✨ Trackblazer Irregular Training Min Gain: ${settings.scenarioOverrides?.trackblazerIrregularTrainingMinStatGain}
 🏇 Trackblazer Preferred Distances: ${settings.scenarioOverrides?.trackblazerPreferredDistances?.length === 0 ? "None" : settings.scenarioOverrides?.trackblazerPreferredDistances?.join(", ")}
 🏇 Trackblazer Preferred Surfaces: ${settings.scenarioOverrides?.trackblazerPreferredSurfaces?.length === 0 ? "None" : settings.scenarioOverrides?.trackblazerPreferredSurfaces?.join(", ")}
+🔋 Trackblazer Energy Item Reserve: ${settings.scenarioOverrides?.trackblazerEnergyItemReserve}
+🧁 Trackblazer Cupcake Reserve: ${settings.scenarioOverrides?.trackblazerCupcakeReserve}
+🔨 Trackblazer Master Hammer Finale Reserve: ${settings.scenarioOverrides?.trackblazerMasterHammerFinaleReserve}
+🔨 Trackblazer Artisan Hammer Min Stock G3: ${settings.scenarioOverrides?.trackblazerArtisanHammerMinStockForG3}
+🔨 Trackblazer Artisan Hammer Min Stock G2: ${settings.scenarioOverrides?.trackblazerArtisanHammerMinStockForG2}
+✨ Trackblazer Glow Stick Final-Day Reserve: ${settings.scenarioOverrides?.trackblazerGlowStickFinalReserve}
+✨ Trackblazer Glow Stick Min Fans: ${settings.scenarioOverrides?.trackblazerGlowStickMinFans}
 
 ---------- Misc Options ----------
 🔍 Enable Crane Game Attempt: ${settings.general.enableCraneGameAttempt ? "✅" : "❌"}

--- a/src/pages/ScenarioOverridesSettings/index.tsx
+++ b/src/pages/ScenarioOverridesSettings/index.tsx
@@ -596,6 +596,10 @@ const ScenarioOverridesSettings = () => {
                                                 </View>
 
                                                 <Text style={styles.conservationCategoryLabel}>RACE ITEMS</Text>
+                                                <Text style={styles.conservationSectionIntro}>
+                                                    Reserves and stock floors below take effect starting Turn 65 (right after Senior Year Summer training). Before Turn 65, the bot uses Hammers freely
+                                                    on every race it takes. The Glow Stick Min Fans floor is the only race-item threshold that applies before Turn 65.
+                                                </Text>
 
                                                 <View style={styles.section}>
                                                     <CustomSlider

--- a/src/pages/ScenarioOverridesSettings/index.tsx
+++ b/src/pages/ScenarioOverridesSettings/index.tsx
@@ -136,6 +136,28 @@ const ScenarioOverridesSettings = () => {
                     justifyContent: "space-between",
                     alignItems: "center",
                 },
+                conservationSectionHeader: {
+                    fontSize: 18,
+                    fontWeight: "600",
+                    color: colors.foreground,
+                    marginTop: 8,
+                    marginBottom: 4,
+                },
+                conservationSectionIntro: {
+                    fontSize: 13,
+                    color: colors.foreground,
+                    opacity: 0.7,
+                    marginBottom: 12,
+                },
+                conservationCategoryLabel: {
+                    fontSize: 12,
+                    fontWeight: "700",
+                    color: colors.foreground,
+                    opacity: 0.65,
+                    letterSpacing: 0.8,
+                    marginTop: 16,
+                    marginBottom: 8,
+                },
             }),
         [colors]
     )
@@ -524,6 +546,145 @@ const ScenarioOverridesSettings = () => {
                                                             </ScrollView>
                                                         </View>
                                                     </View>
+                                                </View>
+
+                                                <Divider style={{ marginVertical: 16 }} />
+
+                                                <Text style={styles.conservationSectionHeader}>Item Conservation</Text>
+                                                <Text style={styles.conservationSectionIntro}>
+                                                    Controls how aggressively the bot saves items for high-value turns. Set any threshold to 0 to disable that conservation rule and use items freely.
+                                                </Text>
+
+                                                <Text style={styles.conservationCategoryLabel}>ENERGY</Text>
+
+                                                <View style={styles.section}>
+                                                    <CustomSlider
+                                                        searchId="trackblazer-energy-item-reserve"
+                                                        value={scenarioOverrides.trackblazerEnergyItemReserve}
+                                                        placeholder={defaultSettings.scenarioOverrides.trackblazerEnergyItemReserve}
+                                                        onValueChange={(value) => updateOverrideSetting("trackblazerEnergyItemReserve", value)}
+                                                        onSlidingComplete={(value) => updateOverrideSetting("trackblazerEnergyItemReserve", value)}
+                                                        min={0}
+                                                        max={3}
+                                                        step={1}
+                                                        label="Energy Item Emergency Reserve"
+                                                        labelUnit=""
+                                                        showValue={true}
+                                                        showLabels={true}
+                                                        description="Number of energy items (lowest-tier first) to keep reserved for emergency race recovery when energy hits 1% or below with 3+ consecutive races."
+                                                    />
+                                                </View>
+
+                                                <Text style={styles.conservationCategoryLabel}>MOOD</Text>
+
+                                                <View style={styles.section}>
+                                                    <CustomSlider
+                                                        searchId="trackblazer-cupcake-reserve"
+                                                        value={scenarioOverrides.trackblazerCupcakeReserve}
+                                                        placeholder={defaultSettings.scenarioOverrides.trackblazerCupcakeReserve}
+                                                        onValueChange={(value) => updateOverrideSetting("trackblazerCupcakeReserve", value)}
+                                                        onSlidingComplete={(value) => updateOverrideSetting("trackblazerCupcakeReserve", value)}
+                                                        min={0}
+                                                        max={3}
+                                                        step={1}
+                                                        label="Cupcake Reserve for Kale Juice Synergy"
+                                                        labelUnit=""
+                                                        showValue={true}
+                                                        showLabels={true}
+                                                        description="Number of cupcakes (Plain preferred) to keep so the mood penalty from Royal Kale Juice can be offset."
+                                                    />
+                                                </View>
+
+                                                <Text style={styles.conservationCategoryLabel}>RACE ITEMS</Text>
+
+                                                <View style={styles.section}>
+                                                    <CustomSlider
+                                                        searchId="trackblazer-master-hammer-finale-reserve"
+                                                        value={scenarioOverrides.trackblazerMasterHammerFinaleReserve}
+                                                        placeholder={defaultSettings.scenarioOverrides.trackblazerMasterHammerFinaleReserve}
+                                                        onValueChange={(value) => updateOverrideSetting("trackblazerMasterHammerFinaleReserve", value)}
+                                                        onSlidingComplete={(value) => updateOverrideSetting("trackblazerMasterHammerFinaleReserve", value)}
+                                                        min={0}
+                                                        max={3}
+                                                        step={1}
+                                                        label="Master Cleat Hammer Finale Reserve"
+                                                        labelUnit=""
+                                                        showValue={true}
+                                                        showLabels={true}
+                                                        description="Master Cleat Hammers held back for the Finale days (73-75). Pre-finale days only spend the surplus above this reserve, and only on G1/G2 races."
+                                                    />
+                                                </View>
+
+                                                <View style={styles.section}>
+                                                    <CustomSlider
+                                                        searchId="trackblazer-artisan-hammer-min-stock-for-g3"
+                                                        value={scenarioOverrides.trackblazerArtisanHammerMinStockForG3}
+                                                        placeholder={defaultSettings.scenarioOverrides.trackblazerArtisanHammerMinStockForG3}
+                                                        onValueChange={(value) => updateOverrideSetting("trackblazerArtisanHammerMinStockForG3", value)}
+                                                        onSlidingComplete={(value) => updateOverrideSetting("trackblazerArtisanHammerMinStockForG3", value)}
+                                                        min={0}
+                                                        max={3}
+                                                        step={1}
+                                                        label="Artisan Hammer Min Stock for G3"
+                                                        labelUnit=""
+                                                        showValue={true}
+                                                        showLabels={true}
+                                                        description="Minimum Artisan Cleat Hammer inventory before the bot is allowed to spend one on a G3 race."
+                                                    />
+                                                </View>
+
+                                                <View style={styles.section}>
+                                                    <CustomSlider
+                                                        searchId="trackblazer-artisan-hammer-min-stock-for-g2"
+                                                        value={scenarioOverrides.trackblazerArtisanHammerMinStockForG2}
+                                                        placeholder={defaultSettings.scenarioOverrides.trackblazerArtisanHammerMinStockForG2}
+                                                        onValueChange={(value) => updateOverrideSetting("trackblazerArtisanHammerMinStockForG2", value)}
+                                                        onSlidingComplete={(value) => updateOverrideSetting("trackblazerArtisanHammerMinStockForG2", value)}
+                                                        min={0}
+                                                        max={3}
+                                                        step={1}
+                                                        label="Artisan Hammer Min Stock for G2"
+                                                        labelUnit=""
+                                                        showValue={true}
+                                                        showLabels={true}
+                                                        description="Minimum Artisan Cleat Hammer inventory before the bot is allowed to spend one on a G2 race. G1 is always allowed."
+                                                    />
+                                                </View>
+
+                                                <View style={styles.section}>
+                                                    <CustomSlider
+                                                        searchId="trackblazer-glow-stick-final-reserve"
+                                                        value={scenarioOverrides.trackblazerGlowStickFinalReserve}
+                                                        placeholder={defaultSettings.scenarioOverrides.trackblazerGlowStickFinalReserve}
+                                                        onValueChange={(value) => updateOverrideSetting("trackblazerGlowStickFinalReserve", value)}
+                                                        onSlidingComplete={(value) => updateOverrideSetting("trackblazerGlowStickFinalReserve", value)}
+                                                        min={0}
+                                                        max={3}
+                                                        step={1}
+                                                        label="Glow Stick Final-Day Reserve"
+                                                        labelUnit=""
+                                                        showValue={true}
+                                                        showLabels={true}
+                                                        description="Glow Sticks held back for Day 75 (the Final). Pre-final-day races only spend sticks above this reserve."
+                                                    />
+                                                </View>
+
+                                                <View style={styles.section}>
+                                                    <CustomSlider
+                                                        searchId="trackblazer-glow-stick-min-fans"
+                                                        value={scenarioOverrides.trackblazerGlowStickMinFans}
+                                                        placeholder={defaultSettings.scenarioOverrides.trackblazerGlowStickMinFans}
+                                                        onValueChange={(value) => updateOverrideSetting("trackblazerGlowStickMinFans", value)}
+                                                        onSlidingComplete={(value) => updateOverrideSetting("trackblazerGlowStickMinFans", value)}
+                                                        min={0}
+                                                        max={30000}
+                                                        step={1000}
+                                                        label="Glow Stick Minimum Fans"
+                                                        labelUnit=""
+                                                        showValue={true}
+                                                        showLabels={true}
+                                                        description="Minimum projected fan gain on a race before the bot uses a Glow Stick on it. Applies on standard and finale days."
+                                                    />
                                                 </View>
                                             </>
                                         ),


### PR DESCRIPTION
## Description
- This PR introduces 7 user-configurable Trackblazer conservation thresholds (`trackblazerEnergyItemReserve`, `trackblazerCupcakeReserve`, `trackblazerMasterHammerFinaleReserve`, `trackblazerArtisanHammerMinStockForG3`, `trackblazerArtisanHammerMinStockForG2`, `trackblazerGlowStickFinalReserve`, `trackblazerGlowStickMinFans`) as sliders on the Scenario Overrides page and wires them into `useRaceItems()` and the energy / cupcake usage paths in place of the previous hardcoded floors.