### PR TITLE
Fix Trackblazer wasting items on low-energy Summer/Finale train clicks

### DIFF
--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/Trackblazer.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/Trackblazer.kt
@@ -1210,15 +1210,18 @@ class Trackblazer(game: Game) : Campaign(game) {
     }
 
     override fun decideNextAction(): MainScreenAction {
+        // Energy floor for always train priorities to avoid wasting items.
+        val canSafelyTrain = trainee.energy > 20
+
         // Summer Training: Train during July and August in Classic/Senior.
-        if (date.isSummer() && !(racing.skipSummerTrainingForAgenda && racing.enableUserInGameRaceAgenda)) {
+        if (canSafelyTrain && date.isSummer() && !(racing.skipSummerTrainingForAgenda && racing.enableUserInGameRaceAgenda)) {
             MessageLog.i(TAG, "[TRACKBLAZER] It is Summer. Prioritizing training.")
             decisionTracer.recordActionChoice(MainScreenAction.TRAIN, "Trackblazer: Summer prioritizes training")
             return MainScreenAction.TRAIN
         }
 
         // Finale: Train during the final 3 turns (Qualifier, Semifinal, Finals).
-        if (date.bIsFinaleSeason && date.day >= 73) {
+        if (canSafelyTrain && date.bIsFinaleSeason && date.day >= 73) {
             MessageLog.i(TAG, "[TRACKBLAZER] It is the Finale. Prioritizing training.")
             decisionTracer.recordActionChoice(MainScreenAction.TRAIN, "Trackblazer: Finale (day >= 73) prioritizes training")
             return MainScreenAction.TRAIN
@@ -1699,10 +1702,25 @@ class Trackblazer(game: Game) : Campaign(game) {
 
         // Finalize by closing the dialog.
         MessageLog.i(TAG, "[TRACKBLAZER] Closing training items dialog.")
-        if (ButtonClose.check(game.imageUtils, tries = 50)) {
-            game.wait(1.0)
-            ButtonClose.click(game.imageUtils)
-            game.wait(1.0)
+        val maxCloseAttempts = 3
+        var closeAttempt = 0
+        while (closeAttempt < maxCloseAttempts) {
+            if (ButtonClose.check(game.imageUtils, tries = 50)) {
+                game.wait(1.0)
+                ButtonClose.click(game.imageUtils)
+                game.wait(1.0)
+            }
+            if (!ButtonConfirmUse.check(game.imageUtils, tries = 5)) {
+                break
+            }
+            closeAttempt++
+            if (closeAttempt < maxCloseAttempts) {
+                MessageLog.w(TAG, "[WARN] confirmAndCloseItemDialog:: Training Items dialog still visible after close attempt $closeAttempt/$maxCloseAttempts. Retrying.")
+                game.wait(1.0)
+            }
+        }
+        if (closeAttempt >= maxCloseAttempts) {
+            MessageLog.e(TAG, "[ERROR] confirmAndCloseItemDialog:: Training Items dialog did not close after $maxCloseAttempts attempts. The next training click may misfire.")
         }
 
         // Clear the training analysis cache so that the bot re-evaluates the training options if it re-enters the training screen.

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/Trackblazer.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/Trackblazer.kt
@@ -212,6 +212,12 @@ class Trackblazer(game: Game) : Campaign(game) {
     /** Threshold for energy level to use energy items. */
     private var energyThresholdToUseEnergyItems: Int = SettingsHelper.getIntSetting("scenarioOverrides", "trackblazerEnergyThreshold", 40)
 
+    /**
+     * Energy floor below which Summer / Finale prioritization is suppressed so queued items
+     * (megaphones, ankle weights, charms) are not wasted on a train click the game will refuse.
+     */
+    private val forceTrainEnergyFloor: Int = SettingsHelper.getIntSetting("scenarioOverrides", "trackblazerForceTrainEnergyFloor", 20)
+
     /** Number of energy items (lowest-tier first across `energyItemConservationOrder`) held back as the emergency-race-recovery reserve. 0 = no reserve. */
     private val energyItemReserveCount: Int = SettingsHelper.getIntSetting("scenarioOverrides", "trackblazerEnergyItemReserve", 1)
 
@@ -1084,6 +1090,7 @@ class Trackblazer(game: Game) : Campaign(game) {
         DecisionTracer
             .SettingsSnapshot()
             .add("Trackblazer Energy Threshold", energyThresholdToUseEnergyItems)
+            .add("Force-Train Energy Floor", forceTrainEnergyFloor)
             .add("Skip Risky Charm Training Below Gain", minCharmGain)
             .add("Consecutive Races Limit", consecutiveRacesLimit)
             .add("Skip Bad-Mood Items Below Gain", lowMainStatGainItemFloor)
@@ -1211,7 +1218,7 @@ class Trackblazer(game: Game) : Campaign(game) {
 
     override fun decideNextAction(): MainScreenAction {
         // Energy floor for always train priorities to avoid wasting items.
-        val canSafelyTrain = trainee.energy > 20
+        val canSafelyTrain = trainee.energy > forceTrainEnergyFloor
 
         // Summer Training: Train during July and August in Classic/Senior.
         if (canSafelyTrain && date.isSummer() && !(racing.skipSummerTrainingForAgenda && racing.enableUserInGameRaceAgenda)) {

--- a/src/context/BotStateContext.tsx
+++ b/src/context/BotStateContext.tsx
@@ -206,6 +206,7 @@ export interface Settings {
     scenarioOverrides: {
         trackblazerConsecutiveRacesLimit: number
         trackblazerEnergyThreshold: number
+        trackblazerForceTrainEnergyFloor: number
         trackblazerShopCheckGrades: string[]
         trackblazerSkipRiskyCharmTrainingBelowGain: number
         trackblazerSkipBadMoodItemsBelowGain: number
@@ -456,6 +457,7 @@ export const defaultSettings: Settings = {
     scenarioOverrides: {
         trackblazerConsecutiveRacesLimit: 5,
         trackblazerEnergyThreshold: 40,
+        trackblazerForceTrainEnergyFloor: 20,
         trackblazerShopCheckGrades: ["G1", "G2", "G3"],
         trackblazerSkipRiskyCharmTrainingBelowGain: 30,
         trackblazerSkipBadMoodItemsBelowGain: 15,

--- a/src/context/searchConfig.ts
+++ b/src/context/searchConfig.ts
@@ -702,6 +702,13 @@ const searchConfig: SearchOption[] = [
         page: "ScenarioOverridesSettings",
     },
     {
+        id: "trackblazer-force-train-energy-floor",
+        title: "Trackblazer Force-Train Energy Floor (Summer/Finale)",
+        description:
+            "During Summer and the Finale, the Trackblazer scenario normally always picks training. If energy is at or below this floor, the bot skips that override and falls through to the standard decision flow so items are not queued for a training with little hope for success.",
+        page: "ScenarioOverridesSettings",
+    },
+    {
         id: "trackblazer-shop-check-grades",
         title: "Trackblazer Shop Check Grades",
         description: "Select which race grades should trigger a shop check after the race in the Trackblazer scenario.",

--- a/src/lib/messageLog/buildSettingsBanner.ts
+++ b/src/lib/messageLog/buildSettingsBanner.ts
@@ -188,6 +188,7 @@ ${longTargetsString}
 ---------- Scenario Overrides ----------
 🏁 Trackblazer Consecutive Races Limit: ${settings.scenarioOverrides?.trackblazerConsecutiveRacesLimit}
 🔋 Trackblazer Energy Threshold: ${settings.scenarioOverrides?.trackblazerEnergyThreshold}
+🔋 Trackblazer Force-Train Energy Floor: ${settings.scenarioOverrides?.trackblazerForceTrainEnergyFloor}
 🛍️ Trackblazer Shop Check Grades: ${settings.scenarioOverrides?.trackblazerShopCheckGrades?.join(", ")}
 🛍️ Trackblazer Shop Check Frequency: ${settings.scenarioOverrides?.trackblazerShopCheckFrequency}
 🛍️ Trackblazer Excluded Items: ${settings.scenarioOverrides?.trackblazerExcludedItems?.length === 0 ? "None" : settings.scenarioOverrides?.trackblazerExcludedItems?.join(", ")}

--- a/src/pages/ScenarioOverridesSettings/index.tsx
+++ b/src/pages/ScenarioOverridesSettings/index.tsx
@@ -116,6 +116,7 @@ const ScenarioOverridesSettings = () => {
     /** Reset Energy & Resources section sliders to defaults. */
     const resetEnergyDefaults = useCallback(() => {
         updateOverrideSetting("trackblazerEnergyThreshold", defaultSettings.scenarioOverrides.trackblazerEnergyThreshold)
+        updateOverrideSetting("trackblazerForceTrainEnergyFloor", defaultSettings.scenarioOverrides.trackblazerForceTrainEnergyFloor)
         updateOverrideSetting("trackblazerSkipBadMoodItemsBelowGain", defaultSettings.scenarioOverrides.trackblazerSkipBadMoodItemsBelowGain)
     }, [updateOverrideSetting, defaultSettings])
 
@@ -382,6 +383,24 @@ const ScenarioOverridesSettings = () => {
                                             showValue={true}
                                             showLabels={true}
                                             description="The energy level below which the bot will attempt to use energy-restoring items in the Trackblazer scenario."
+                                        />
+                                    </View>
+
+                                    <View style={{ padding: SPACING.md }}>
+                                        <CustomSlider
+                                            searchId="trackblazer-force-train-energy-floor"
+                                            value={scenarioOverrides.trackblazerForceTrainEnergyFloor}
+                                            placeholder={defaultSettings.scenarioOverrides.trackblazerForceTrainEnergyFloor}
+                                            onValueChange={(value) => updateOverrideSetting("trackblazerForceTrainEnergyFloor", value)}
+                                            onSlidingComplete={(value) => updateOverrideSetting("trackblazerForceTrainEnergyFloor", value)}
+                                            min={0}
+                                            max={50}
+                                            step={5}
+                                            label="Force-Train Energy Floor (Summer/Finale)"
+                                            labelUnit=""
+                                            showValue={true}
+                                            showLabels={true}
+                                            description="During Summer and the Finale, the Trackblazer scenario normally always picks training. If energy is at or below this floor, the bot skips that override and falls through to the standard decision flow so items are not queued for a training with little hope for success."
                                         />
                                     </View>
 


### PR DESCRIPTION
## Description

- This PR gates Trackblazer's Summer / Finale forced-training override behind a new `trackblazerForceTrainEnergyFloor` scenario override (default 20). At low energy the train click silently misfires after `confirmAndCloseItemDialog()` closes the items dialog, so any queued Megaphone / Ankle Weights / Good-Luck Charm was burned for nothing.
- `confirmAndCloseItemDialog()` now verifies dismissal via `ButtonConfirmUse.check()` and retries the close up to 3 times, so a stale items dialog never absorbs the subsequent training tap.
- The new floor is wired through the Energy & Resources section of the Scenario Overrides page (slider, reset-section, reset-all), the settings banner, the static search config, and the `DecisionTracer` settings snapshot.

### Original problem

```
[INFO]  [TRACKBLAZER] Queuing Empowering Megaphone for use.
[INFO]  [TRACKBLAZER] Queuing Speed Ankle Weights for use.
[INFO]  [TRACKBLAZER] Queuing Good-Luck Charm for use.
[INFO]  [TRACKBLAZER] Closing training items dialog.
[WARN]  Training Items dialog detected. Closing it as it is not currently being handled...
[INFO]  Resting to recover energy. (Energy 0%)
```