### PR TITLE
Always run scheduled races during Trackblazer regardless of energy or consecutive-race limits

### DIFF
--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/Trackblazer.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/Trackblazer.kt
@@ -1240,6 +1240,16 @@ class Trackblazer(game: Game) : Campaign(game) {
         // charm only fires after analyzeTrainings produces a selected training with measured
         // failureChance >= 20, so it cannot protect a turn whose analysis is the thing at risk.
         if (trainee.energy <= 10 && consecutiveRaceCount >= 3) {
+            // Scheduled and mandatory races must always run. They take priority over this low-energy guard so an agenda race is never skipped.
+            val sourceBitmap = game.imageUtils.getSourceBitmap()
+            val bIsScheduledRaceDay = LabelScheduledRace.check(game.imageUtils, sourceBitmap = sourceBitmap)
+            val bIsMandatoryRaceDay = IconRaceDayRibbon.check(game.imageUtils, sourceBitmap = sourceBitmap) || IconGoalRibbon.check(game.imageUtils, sourceBitmap = sourceBitmap)
+            if (bIsScheduledRaceDay || bIsMandatoryRaceDay) {
+                MessageLog.i(TAG, "[TRACKBLAZER] Scheduled/mandatory race detected at low energy. Racing anyway - critical energy and consecutive-race limits are ignored for scheduled races.")
+                decisionTracer.recordActionChoice(MainScreenAction.RACE, "Scheduled/mandatory race overrides low-energy guard - scheduled races always run")
+                return MainScreenAction.RACE
+            }
+
             // Before resting, attempt to use a conserved energy item for emergency race recovery.
             val conserveItem = energyItemConservationOrder.firstOrNull { (currentInventory[it] ?: 0) > 0 }
             if (conserveItem != null) {

--- a/src/pages/RacingSettings/index.tsx
+++ b/src/pages/RacingSettings/index.tsx
@@ -9,6 +9,7 @@ import { SearchPageProvider } from "../../context/SearchPageContext"
 import CustomSelect from "../../components/CustomSelect"
 import CustomSlider from "../../components/CustomSlider"
 import PageHeader from "../../components/PageHeader"
+import InfoContainer from "../../components/InfoContainer"
 import WarningContainer from "../../components/WarningContainer"
 import SearchableItem from "../../components/SearchableItem"
 import { usePerformanceLogging } from "../../hooks/usePerformanceLogging"
@@ -393,6 +394,7 @@ const RacingSettings = () => {
                             </SearchableItem>
                             {enableUserInGameRaceAgenda && (
                                 <>
+                                    <InfoContainer style={{ marginHorizontal: SPACING.md }}>Critical energy level and consecutive race limits are ignored for the user in-game racing agenda.</InfoContainer>
                                     <SearchableItem
                                         id="user-in-game-race-agenda"
                                         title="Select Agenda"


### PR DESCRIPTION
## Description
- This PR returns `MainScreenAction.RACE` from `decideNextAction()` when a scheduled or mandatory race is detected, before the Trackblazer low-energy guard can rest the turn, so critical energy and consecutive-race limits can no longer skip an in-game agenda race (every other scenario already races scheduled days first via the base flow).
- It also adds an info note under the In-Game Race Agenda settings stating that these limits are ignored for the agenda.

Before, a scheduled-race turn at critical energy was rested instead of raced:

```
00:45:37.923 [WARN] decideNextAction:: Energy is low (0%) with 5 consecutive races and no energy items available. Resting to avoid -30 stat penalty.
Action: REST
  Reason: Trackblazer low-energy guard: energy 0% <= 10 with 5 consecutive races and no energy items in inventory
```