### PR TITLE
Add logcat dump button to Debug Settings page

### DIFF
--- a/android/app/src/main/java/com/steve1316/uma_android_automation/LogcatModule.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/LogcatModule.kt
@@ -1,0 +1,98 @@
+package com.steve1316.uma_android_automation
+
+import android.util.Log
+import androidx.documentfile.provider.DocumentFile
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContextBaseJavaModule
+import com.facebook.react.bridge.ReactMethod
+import com.facebook.react.bridge.WritableMap
+import com.steve1316.automation_library.utils.UserStorageManager
+import java.io.File
+import java.io.FileOutputStream
+import java.io.OutputStream
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+/**
+ * Bridge module that dumps this app's own logcat output to a text file at the root of the user's storage folder. On modern Android an unprivileged app only
+ * sees its own process logs, which is exactly the bot's debug output, errors, and crashes.
+ *
+ * @param reactContext The React Native application context.
+ */
+class LogcatModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaModule(reactContext) {
+    companion object {
+        private val TAG = "[${MainActivity.loggerTag}]LogcatModule"
+
+        // The dump covers the last 6 hours, bounded by the actual logcat ring-buffer capacity.
+        private const val WINDOW_MILLIS = 6L * 60L * 60L * 1000L
+    }
+
+    private val appContext: ReactApplicationContext = reactContext
+
+    override fun getName(): String {
+        return "LogcatModule"
+    }
+
+    /** Dump the app's logcat from the last 6 hours into `adb_dump_<timestamp>.txt` at the storage root. Resolves with
+     * `{filename, bytes, location}`, or rejects with `DUMP_FAILED` when no writable location exists or logcat fails.
+     *
+     * @param promise Resolved with the dump result map, or rejected on failure.
+     */
+    @ReactMethod
+    fun dumpLogcat(promise: Promise) {
+        try {
+            val now = Date()
+            val filename = "adb_dump_${SimpleDateFormat("yyyy-MM-dd_HH_mm_ss", Locale.US).format(now)}.txt"
+            val since = SimpleDateFormat("MM-dd HH:mm:ss.SSS", Locale.US).format(Date(now.time - WINDOW_MILLIS))
+
+            val target = openDumpTarget(filename)
+            if (target == null) {
+                promise.reject("DUMP_FAILED", "No writable storage location is available for the logcat dump.")
+                return
+            }
+            val (out, location) = target
+
+            val bytes = out.use { stream ->
+                val process = Runtime.getRuntime().exec(arrayOf("logcat", "-d", "-v", "threadtime", "-t", since))
+                process.inputStream.use { input -> input.copyTo(stream) }
+            }
+
+            val map: WritableMap = Arguments.createMap()
+            map.putString("filename", filename)
+            map.putDouble("bytes", bytes.toDouble())
+            map.putString("location", location)
+            promise.resolve(map)
+        } catch (e: Exception) {
+            Log.e(TAG, "dumpLogcat failed", e)
+            promise.reject("DUMP_FAILED", e.message ?: e.toString(), e)
+        }
+    }
+
+    /** Open a writable stream for the dump file at the root of the configured SAF folder, falling back to the root of the legacy external-files directory when no folder is
+     * configured. Returns the stream paired with a short location label (the folder name for SAF, or the absolute path for legacy), or null when nothing writable exists.
+     * The label is derived locally rather than via `UserStorageManager.pathLabel()` so the module only depends on `getInstance` / `getTreeUri`.
+     *
+     * @param filename The dump file name to create at the root.
+     *
+     * @return The output stream and a location label, or null.
+     */
+    private fun openDumpTarget(filename: String): Pair<OutputStream, String>? {
+        val treeUri = UserStorageManager.getInstance(appContext).getTreeUri()
+        if (treeUri != null) {
+            val tree = DocumentFile.fromTreeUri(appContext, treeUri)
+            if (tree != null && tree.canWrite()) {
+                tree.findFile(filename)?.delete()
+                val file = tree.createFile("text/plain", filename)
+                if (file != null) {
+                    val stream = appContext.contentResolver.openOutputStream(file.uri)
+                    if (stream != null) return Pair(stream, tree.name ?: "your storage folder")
+                }
+            }
+        }
+        val root = appContext.getExternalFilesDir(null) ?: appContext.filesDir ?: return null
+        return Pair(FileOutputStream(File(root, filename)), root.absolutePath)
+    }
+}

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/LogcatModule.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/LogcatModule.kt
@@ -57,7 +57,12 @@ class LogcatModule(reactContext: ReactApplicationContext) : ReactContextBaseJava
 
             val bytes = out.use { stream ->
                 val process = Runtime.getRuntime().exec(arrayOf("logcat", "-d", "-v", "threadtime", "-t", since))
-                process.inputStream.use { input -> input.copyTo(stream) }
+                try {
+                    process.inputStream.use { input -> input.copyTo(stream) }
+                } finally {
+                    process.errorStream.close()
+                    process.waitFor()
+                }
             }
 
             val map: WritableMap = Arguments.createMap()
@@ -89,6 +94,7 @@ class LogcatModule(reactContext: ReactApplicationContext) : ReactContextBaseJava
                 if (file != null) {
                     val stream = appContext.contentResolver.openOutputStream(file.uri)
                     if (stream != null) return Pair(stream, tree.name ?: "your storage folder")
+                    file.delete()
                 }
             }
         }

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/LogcatModule.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/LogcatModule.kt
@@ -55,15 +55,16 @@ class LogcatModule(reactContext: ReactApplicationContext) : ReactContextBaseJava
             }
             val (out, location) = target
 
-            val bytes = out.use { stream ->
-                val process = Runtime.getRuntime().exec(arrayOf("logcat", "-d", "-v", "threadtime", "-t", since))
-                try {
-                    process.inputStream.use { input -> input.copyTo(stream) }
-                } finally {
-                    process.errorStream.close()
-                    process.waitFor()
+            val bytes =
+                out.use { stream ->
+                    val process = Runtime.getRuntime().exec(arrayOf("logcat", "-d", "-v", "threadtime", "-t", since))
+                    try {
+                        process.inputStream.use { input -> input.copyTo(stream) }
+                    } finally {
+                        process.errorStream.close()
+                        process.waitFor()
+                    }
                 }
-            }
 
             val map: WritableMap = Arguments.createMap()
             map.putString("filename", filename)

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/StartPackage.java
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/StartPackage.java
@@ -30,6 +30,7 @@ public class StartPackage implements ReactPackage {
         modules.add(new LLMChatModule(reactContext));
         modules.add(new SmartRaceSolverModule(reactContext));
         modules.add(new StorageBridgeModule(reactContext));
+        modules.add(new LogcatModule(reactContext));
 
         return modules;
     }

--- a/src/context/searchConfig.ts
+++ b/src/context/searchConfig.ts
@@ -1019,6 +1019,12 @@ const searchConfig: SearchOption[] = [
         page: "DebugSettings",
     },
     {
+        id: "dump-logcat",
+        title: "Dump logcat (last 6h)",
+        description: "Saves this app's recent logcat output to a timestamped .txt file at the root of your storage folder.",
+        page: "DebugSettings",
+    },
+    {
         id: "llm-ask-the-docs",
         title: "Ask the Docs",
         description:

--- a/src/hooks/__tests__/useLogcatDump.test.tsx
+++ b/src/hooks/__tests__/useLogcatDump.test.tsx
@@ -1,0 +1,64 @@
+import { act, renderHook, waitFor } from "@testing-library/react-native"
+
+jest.mock("../../lib/logcatBridge", () => ({
+    logcatBridge: { dumpLogcat: jest.fn() },
+}))
+
+import { useLogcatDump } from "../useLogcatDump"
+import { logcatBridge } from "../../lib/logcatBridge"
+
+const mockBridge = logcatBridge as jest.Mocked<typeof logcatBridge>
+
+describe("useLogcatDump", () => {
+    beforeEach(() => {
+        mockBridge.dumpLogcat.mockReset()
+    })
+
+    it("sets a success message after a dump resolves", async () => {
+        mockBridge.dumpLogcat.mockResolvedValue({ filename: "adb_dump_2026-06-12_00_30_15.txt", bytes: 1234, location: "UmaAutomation" })
+        const { result } = renderHook(() => useLogcatDump())
+        await act(async () => {
+            await result.current.dump()
+        })
+        expect(result.current.message).toBe("Saved adb_dump_2026-06-12_00_30_15.txt to UmaAutomation")
+        expect(result.current.dumping).toBe(false)
+        expect(mockBridge.dumpLogcat).toHaveBeenCalledTimes(1)
+    })
+
+    it("sets an error message when the dump rejects", async () => {
+        mockBridge.dumpLogcat.mockRejectedValue(new Error("No writable storage location is available for the logcat dump."))
+        const { result } = renderHook(() => useLogcatDump())
+        await act(async () => {
+            await result.current.dump()
+        })
+        expect(result.current.message).toContain("failed")
+        expect(result.current.dumping).toBe(false)
+    })
+
+    it("reports dumping while a dump is in flight and clears it afterwards", async () => {
+        let resolveDump: (value: { filename: string; bytes: number; location: string }) => void = () => {}
+        mockBridge.dumpLogcat.mockReturnValue(new Promise((resolve) => { resolveDump = resolve }))
+        const { result } = renderHook(() => useLogcatDump())
+        act(() => {
+            void result.current.dump()
+        })
+        await waitFor(() => expect(result.current.dumping).toBe(true))
+        await act(async () => {
+            resolveDump({ filename: "a.txt", bytes: 1, location: "X" })
+        })
+        expect(result.current.dumping).toBe(false)
+    })
+
+    it("clears the message when clearMessage is called", async () => {
+        mockBridge.dumpLogcat.mockResolvedValue({ filename: "a.txt", bytes: 1, location: "X" })
+        const { result } = renderHook(() => useLogcatDump())
+        await act(async () => {
+            await result.current.dump()
+        })
+        expect(result.current.message).not.toBeNull()
+        act(() => {
+            result.current.clearMessage()
+        })
+        expect(result.current.message).toBeNull()
+    })
+})

--- a/src/hooks/__tests__/useLogcatDump.test.tsx
+++ b/src/hooks/__tests__/useLogcatDump.test.tsx
@@ -42,7 +42,7 @@ describe("useLogcatDump", () => {
         act(() => {
             void result.current.dump()
         })
-        await waitFor(() => expect(result.current.dumping).toBe(true))
+        expect(result.current.dumping).toBe(true)
         await act(async () => {
             resolveDump({ filename: "a.txt", bytes: 1, location: "X" })
         })
@@ -60,5 +60,21 @@ describe("useLogcatDump", () => {
             result.current.clearMessage()
         })
         expect(result.current.message).toBeNull()
+    })
+
+    it("ignores a second dump call while one is already in flight", async () => {
+        let resolveDump: (value: { filename: string; bytes: number; location: string }) => void = () => {}
+        mockBridge.dumpLogcat.mockReturnValue(new Promise((resolve) => { resolveDump = resolve }))
+        const { result } = renderHook(() => useLogcatDump())
+        act(() => {
+            void result.current.dump()
+        })
+        act(() => {
+            void result.current.dump()
+        })
+        await act(async () => {
+            resolveDump({ filename: "a.txt", bytes: 1, location: "X" })
+        })
+        expect(mockBridge.dumpLogcat).toHaveBeenCalledTimes(1)
     })
 })

--- a/src/hooks/__tests__/useLogcatDump.test.tsx
+++ b/src/hooks/__tests__/useLogcatDump.test.tsx
@@ -1,4 +1,4 @@
-import { act, renderHook, waitFor } from "@testing-library/react-native"
+import { act, renderHook } from "@testing-library/react-native"
 
 jest.mock("../../lib/logcatBridge", () => ({
     logcatBridge: { dumpLogcat: jest.fn() },

--- a/src/hooks/__tests__/useLogcatDump.test.tsx
+++ b/src/hooks/__tests__/useLogcatDump.test.tsx
@@ -37,7 +37,11 @@ describe("useLogcatDump", () => {
 
     it("reports dumping while a dump is in flight and clears it afterwards", async () => {
         let resolveDump: (value: { filename: string; bytes: number; location: string }) => void = () => {}
-        mockBridge.dumpLogcat.mockReturnValue(new Promise((resolve) => { resolveDump = resolve }))
+        mockBridge.dumpLogcat.mockReturnValue(
+            new Promise((resolve) => {
+                resolveDump = resolve
+            })
+        )
         const { result } = renderHook(() => useLogcatDump())
         act(() => {
             void result.current.dump()
@@ -64,7 +68,11 @@ describe("useLogcatDump", () => {
 
     it("ignores a second dump call while one is already in flight", async () => {
         let resolveDump: (value: { filename: string; bytes: number; location: string }) => void = () => {}
-        mockBridge.dumpLogcat.mockReturnValue(new Promise((resolve) => { resolveDump = resolve }))
+        mockBridge.dumpLogcat.mockReturnValue(
+            new Promise((resolve) => {
+                resolveDump = resolve
+            })
+        )
         const { result } = renderHook(() => useLogcatDump())
         act(() => {
             void result.current.dump()

--- a/src/hooks/useLogcatDump.ts
+++ b/src/hooks/useLogcatDump.ts
@@ -1,0 +1,42 @@
+import { useCallback, useState } from "react"
+import { logcatBridge } from "../lib/logcatBridge"
+
+/** State and actions returned by `useLogcatDump`. */
+export interface LogcatDumpState {
+    /** True while a dump is in progress. Used to disable the trigger and show a busy label. */
+    dumping: boolean
+    /** The latest result or error message to surface in a Snackbar, or null when nothing to show. */
+    message: string | null
+    /** Trigger a logcat dump. No-op while a previous dump is still running. */
+    dump: () => Promise<void>
+    /** Clear the current message (e.g. on Snackbar dismiss). */
+    clearMessage: () => void
+}
+
+/**
+ * Owns the logcat-dump action: tracks the busy flag and builds the user-facing result message from the native bridge call.
+ * Keeping this out of the page makes it unit-testable without rendering the whole Debug Settings screen.
+ *
+ * @returns The dump state and actions.
+ */
+export function useLogcatDump(): LogcatDumpState {
+    const [dumping, setDumping] = useState(false)
+    const [message, setMessage] = useState<string | null>(null)
+
+    const dump = useCallback(async () => {
+        if (dumping) return
+        setDumping(true)
+        try {
+            const result = await logcatBridge.dumpLogcat()
+            setMessage(`Saved ${result.filename} to ${result.location}`)
+        } catch (error) {
+            setMessage(`Logcat dump failed: ${error instanceof Error ? error.message : String(error)}`)
+        } finally {
+            setDumping(false)
+        }
+    }, [dumping])
+
+    const clearMessage = useCallback(() => setMessage(null), [])
+
+    return { dumping, message, dump, clearMessage }
+}

--- a/src/hooks/useLogcatDump.ts
+++ b/src/hooks/useLogcatDump.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react"
+import { useCallback, useRef, useState } from "react"
 import { logcatBridge } from "../lib/logcatBridge"
 
 /** State and actions returned by `useLogcatDump`. */
@@ -22,9 +22,11 @@ export interface LogcatDumpState {
 export function useLogcatDump(): LogcatDumpState {
     const [dumping, setDumping] = useState(false)
     const [message, setMessage] = useState<string | null>(null)
+    const dumpingRef = useRef(false)
 
     const dump = useCallback(async () => {
-        if (dumping) return
+        if (dumpingRef.current) return
+        dumpingRef.current = true
         setDumping(true)
         try {
             const result = await logcatBridge.dumpLogcat()
@@ -32,9 +34,10 @@ export function useLogcatDump(): LogcatDumpState {
         } catch (error) {
             setMessage(`Logcat dump failed: ${error instanceof Error ? error.message : String(error)}`)
         } finally {
+            dumpingRef.current = false
             setDumping(false)
         }
-    }, [dumping])
+    }, [])
 
     const clearMessage = useCallback(() => setMessage(null), [])
 

--- a/src/lib/logcatBridge.ts
+++ b/src/lib/logcatBridge.ts
@@ -1,0 +1,22 @@
+import { NativeModules } from "react-native"
+
+/** Result of a successful logcat dump, surfaced to JS by `dumpLogcat`. */
+export interface LogcatDumpResult {
+    /** Name of the written file, e.g. `adb_dump_2026-06-12_00_30_15.txt`. */
+    filename: string
+    /** Number of bytes written to the file. */
+    bytes: number
+    /** Short label of where the file landed: the SAF folder name, or the legacy external-files path. */
+    location: string
+}
+
+/** Typed surface of the native `LogcatModule`. */
+interface LogcatBridgeApi {
+    /** Dump this app's logcat from the last 6 hours to a timestamped file at the storage root. */
+    dumpLogcat(): Promise<LogcatDumpResult>
+}
+
+const { LogcatModule } = NativeModules as { LogcatModule: LogcatBridgeApi }
+
+/** Singleton wrapper around the native logcat bridge. */
+export const logcatBridge = LogcatModule

--- a/src/pages/DebugSettings/index.tsx
+++ b/src/pages/DebugSettings/index.tsx
@@ -481,7 +481,7 @@ const DebugSettings = () => {
                             Diagnostics */}
                         <Section label="Diagnostics" firstDivider={false}>
                             <Text style={styles.sectionDescription}>
-                                {"Saves this app's recent logcat output to a timestamped .txt file at the root of your storage folder. The 6-hour window is capped by the device's log buffer size."}
+                                {"Saves this app's recent logcat output to a timestamped .txt file at the root of your storage folder. The 6-hour window is capped by the device's log buffer size. To increase it, enable Developer Options (tap Build number 7 times under Settings > About phone), then raise Logger buffer sizes in Developer options."}
                             </Text>
                             <SearchableItem
                                 id="dump-logcat"

--- a/src/pages/DebugSettings/index.tsx
+++ b/src/pages/DebugSettings/index.tsx
@@ -481,7 +481,7 @@ const DebugSettings = () => {
                             Diagnostics */}
                         <Section label="Diagnostics" firstDivider={false}>
                             <Text style={styles.sectionDescription}>
-                                Saves this app&apos;s recent logcat output to a timestamped .txt file at the root of your storage folder. The 6-hour window is capped by the device&apos;s log buffer size.
+                                {"Saves this app's recent logcat output to a timestamped .txt file at the root of your storage folder. The 6-hour window is capped by the device's log buffer size."}
                             </Text>
                             <SearchableItem
                                 id="dump-logcat"

--- a/src/pages/DebugSettings/index.tsx
+++ b/src/pages/DebugSettings/index.tsx
@@ -21,6 +21,8 @@ import { useModalShellStyles } from "../../components/ui/modal-shell-styles"
 import { TYPE } from "../../lib/type"
 import { SPACING } from "../../lib/spacing"
 import { RADII } from "../../lib/radii"
+import { Snackbar } from "react-native-paper"
+import { useLogcatDump } from "../../hooks/useLogcatDump"
 
 /** Descriptor for a single diagnostic test surfaced in the Debug Tests section. Drives the mutually-exclusive Switch rows. */
 interface DebugTestDescriptor {
@@ -133,6 +135,7 @@ const DebugSettings = () => {
     const { defaultSettings } = useContext(BotMetaContext)
     const scrollViewRef = useRef<ScrollView>(null)
     const modalShellStyles = useModalShellStyles()
+    const { dumping, message: logcatMessage, dump: dumpLogcat, clearMessage: clearLogcatMessage } = useLogcatDump()
 
     /**
      * Handles mutual exclusivity for diagnostic debug tests. When one test is enabled, all others are automatically disabled.
@@ -472,6 +475,32 @@ const DebugSettings = () => {
                                 ))}
                             </View>
                         </View>
+
+                        {/* //////////////////////////////////////////////////////////////////////////////////////////////////
+                            //////////////////////////////////////////////////////////////////////////////////////////////////
+                            Diagnostics */}
+                        <Section label="Diagnostics" firstDivider={false}>
+                            <Text style={styles.sectionDescription}>
+                                Saves this app&apos;s recent logcat output to a timestamped .txt file at the root of your storage folder. The 6-hour window is capped by the device&apos;s log buffer size.
+                            </Text>
+                            <SearchableItem
+                                id="dump-logcat"
+                                title="Dump logcat (last 6h)"
+                                description="Saves this app's recent logcat output to a timestamped .txt file at the root of your storage folder."
+                            >
+                                <View style={styles.hostPad}>
+                                    <Pressable
+                                        onPress={dumpLogcat}
+                                        disabled={dumping}
+                                        android_ripple={{ color: colors.ripple, foreground: true }}
+                                        style={{ padding: SPACING.sm, backgroundColor: colors.surfaceRaised, borderRadius: RADII.md, flexDirection: "row", alignItems: "center", gap: SPACING.sm, opacity: dumping ? 0.6 : 1 }}
+                                    >
+                                        <Ionicons name="download-outline" size={16} color={colors.brand} />
+                                        <Text style={{ ...TYPE.monoLabel, color: colors.brand, flex: 1 }}>{dumping ? "Dumping logcat..." : "Dump logcat (last 6h)"}</Text>
+                                    </Pressable>
+                                </View>
+                            </SearchableItem>
+                        </Section>
                     </View>
                 </ScrollView>
             </SearchPageProvider>
@@ -508,6 +537,9 @@ const DebugSettings = () => {
                     ))}
                 </View>
             </SheetModal>
+            <Snackbar visible={logcatMessage !== null} onDismiss={clearLogcatMessage} duration={4000} style={{ backgroundColor: colors.surfaceRaised, borderRadius: 10 }}>
+                {logcatMessage ?? ""}
+            </Snackbar>
         </View>
     )
 }

--- a/src/pages/DebugSettings/index.tsx
+++ b/src/pages/DebugSettings/index.tsx
@@ -493,7 +493,15 @@ const DebugSettings = () => {
                                         onPress={dumpLogcat}
                                         disabled={dumping}
                                         android_ripple={{ color: colors.ripple, foreground: true }}
-                                        style={{ padding: SPACING.sm, backgroundColor: colors.surfaceRaised, borderRadius: RADII.md, flexDirection: "row", alignItems: "center", gap: SPACING.sm, opacity: dumping ? 0.6 : 1 }}
+                                        style={{
+                                            padding: SPACING.sm,
+                                            backgroundColor: colors.surfaceRaised,
+                                            borderRadius: RADII.md,
+                                            flexDirection: "row",
+                                            alignItems: "center",
+                                            gap: SPACING.sm,
+                                            opacity: dumping ? 0.6 : 1,
+                                        }}
                                     >
                                         <Ionicons name="download-outline" size={16} color={colors.brand} />
                                         <Text style={{ ...TYPE.monoLabel, color: colors.brand, flex: 1 }}>{dumping ? "Dumping logcat..." : "Dump logcat (last 6h)"}</Text>


### PR DESCRIPTION
## Description
- This PR adds a "Dump logcat (last 6h)" button in Debug Settings that saves this app's recent logcat output to a timestamped `adb_dump_*.txt` file at the root of the storage folder.
- The button is wired through a native `LogcatModule` and a `useLogcatDump()` hook.
