### PR TITLE
Fix Remote Log Viewer Log Files and Debug Images tabs after the storage redesign

### DIFF
--- a/android/app/src/main/assets/log_viewer.html
+++ b/android/app/src/main/assets/log_viewer.html
@@ -1118,6 +1118,9 @@
                 z-index: 10000;
                 box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
                 max-width: 250px;
+                /* Cap height so a tall tooltip (many epithet rows) can never exceed the viewport. The 30px matches the 15px viewport padding used when positioning. */
+                max-height: calc(100vh - 30px);
+                overflow-y: auto;
             }
             .custom-tooltip.visible {
                 opacity: 1;
@@ -2135,18 +2138,23 @@
                 const padding = 15
                 let x = event.clientX + padding
                 let y = event.clientY + padding
-                
-                // Keep within viewport.
+
                 const width = tooltip.offsetWidth
                 const height = tooltip.offsetHeight
-                
+
+                // Flip to the other side of the cursor when the preferred side would overflow.
                 if (x + width > window.innerWidth) {
                     x = event.clientX - width - padding
                 }
                 if (y + height > window.innerHeight) {
                     y = event.clientY - height - padding
                 }
-                
+
+                // Clamp into the viewport so the tooltip never spills off an edge, even when it is
+                // taller than the space beside the cursor (e.g. a race cell with many epithet rows).
+                x = Math.max(padding, Math.min(x, window.innerWidth - width - padding))
+                y = Math.max(padding, Math.min(y, window.innerHeight - height - padding))
+
                 tooltip.style.left = x + "px"
                 tooltip.style.top = y + "px"
             }

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/utils/LogStreamServer.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/utils/LogStreamServer.kt
@@ -1132,7 +1132,7 @@ object LogStreamServer {
                                 if (raw.contains('/') ||
                                     raw.contains('\\') ||
                                     raw.contains("..") ||
-                                    raw.contains(' ') ||
+                                    raw.contains('\u0000') ||
                                     !raw.lowercase().endsWith(".txt")
                                 ) {
                                     call.respondText("Invalid filename.", ContentType.Text.Plain, HttpStatusCode.BadRequest)

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/utils/LogStreamServer.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/utils/LogStreamServer.kt
@@ -10,6 +10,7 @@ import android.util.Log
 import com.steve1316.automation_library.data.SharedData
 import com.steve1316.automation_library.events.JSEvent
 import com.steve1316.automation_library.utils.MessageLog
+import com.steve1316.automation_library.utils.UserStorageManager
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
@@ -447,7 +448,7 @@ object LogStreamServer {
      */
     private suspend fun sendDebugImages(session: DefaultWebSocketServerSession) {
         val context = applicationContext ?: return
-        val tempDir = File(context.getExternalFilesDir(null), "temp")
+        val tempDir = File(context.filesDir, "temp")
         if (!tempDir.exists() || !tempDir.isDirectory) {
             Log.w(TAG, "[WARN] sendDebugImages:: Temp directory does not exist or is not a directory: ${tempDir.absolutePath}")
             return
@@ -489,6 +490,47 @@ object LogStreamServer {
 
         // Signal completion of image batch transmission.
         session.send(Frame.Text(JSONObject().apply { put("type", "image_batch_done") }.toString()))
+    }
+
+    /** Metadata for a single saved log file, sourced from either the SAF tree or the legacy logs dir. */
+    private data class LogFileEntry(
+        /** File name including the .txt extension. */
+        val name: String,
+        /** File size in bytes. */
+        val size: Long,
+        /** Last-modified timestamp in epoch milliseconds. */
+        val modified: Long,
+    )
+
+    /**
+     * Lists the completed-session .txt log files. Honors the user-selected SAF folder when one is configured and falls back to the
+     * legacy getExternalFilesDir/logs path otherwise, so the viewer reads from wherever [MessageLog] actually wrote them.
+     *
+     * @param context Context used to resolve the storage location.
+     * @return The log file entries, unsorted.
+     */
+    private fun listLogFiles(context: Context): List<LogFileEntry> {
+        val storage = UserStorageManager.getInstance(context)
+        if (storage.isConfigured()) {
+            return storage.listFiles("logs")
+                .filter { it.isFile && it.name?.lowercase()?.endsWith(".txt") == true }
+                .map { LogFileEntry(it.name ?: "", it.length(), it.lastModified()) }
+        }
+        val logsDir = File(context.getExternalFilesDir(null), "logs")
+        if (!logsDir.exists() || !logsDir.isDirectory) return emptyList()
+        return (logsDir.listFiles { _, name -> name.lowercase().endsWith(".txt") } ?: emptyArray())
+            .map { LogFileEntry(it.name, it.length(), it.lastModified()) }
+    }
+
+    /**
+     * Reads the text content of a single saved log file by name, honoring the SAF folder when configured.
+     *
+     * @param context Context used to resolve the storage location.
+     * @param name The log file name to read.
+     * @return The file content, or null when the file does not exist or could not be read.
+     */
+    private fun readLogFile(context: Context, name: String): String? {
+        return UserStorageManager.getInstance(context).openInputStream("logs", name)?.use { it.bufferedReader().readText() }
     }
 
     /**
@@ -1047,23 +1089,18 @@ object LogStreamServer {
                         // List every completed-session .txt log file in the /logs/ directory, sorted most-recent-first.
                         get("/logs/files") {
                             try {
-                                val logsDir = File(context.getExternalFilesDir(null), "logs")
                                 val filesArray = JSONArray()
                                 var totalSize = 0L
 
-                                if (logsDir.exists() && logsDir.isDirectory) {
-                                    val logFiles = logsDir.listFiles { _, name -> name.lowercase().endsWith(".txt") } ?: emptyArray()
-                                    for (file in logFiles.sortedByDescending { it.lastModified() }) {
-                                        val size = file.length()
-                                        totalSize += size
-                                        filesArray.put(
-                                            JSONObject().apply {
-                                                put("name", file.name)
-                                                put("size", size)
-                                                put("modified", file.lastModified())
-                                            },
-                                        )
-                                    }
+                                for (entry in listLogFiles(context).sortedByDescending { it.modified }) {
+                                    totalSize += entry.size
+                                    filesArray.put(
+                                        JSONObject().apply {
+                                            put("name", entry.name)
+                                            put("size", entry.size)
+                                            put("modified", entry.modified)
+                                        },
+                                    )
                                 }
 
                                 val response =
@@ -1102,23 +1139,16 @@ object LogStreamServer {
                                     return@get
                                 }
 
-                                val logsDir = File(context.getExternalFilesDir(null), "logs")
-                                if (!logsDir.exists() || !logsDir.isDirectory) {
-                                    call.respondText("File not found.", ContentType.Text.Plain, HttpStatusCode.NotFound)
-                                    return@get
-                                }
-
                                 // Whitelist against the actual directory listing - the canonical guarantee against any encoded payload.
-                                val available = logsDir.listFiles { _, name -> name.lowercase().endsWith(".txt") }?.map { it.name }?.toSet() ?: emptySet()
+                                val available = listLogFiles(context).map { it.name }.toSet()
                                 if (raw !in available) {
                                     call.respondText("File not found.", ContentType.Text.Plain, HttpStatusCode.NotFound)
                                     return@get
                                 }
 
-                                val target = File(logsDir, raw)
-                                // Belt-and-suspenders containment check.
-                                if (!target.canonicalPath.startsWith(logsDir.canonicalPath + File.separator)) {
-                                    call.respondText("Invalid filename.", ContentType.Text.Plain, HttpStatusCode.BadRequest)
+                                val content = readLogFile(context, raw)
+                                if (content == null) {
+                                    call.respondText("File not found.", ContentType.Text.Plain, HttpStatusCode.NotFound)
                                     return@get
                                 }
 
@@ -1128,7 +1158,7 @@ object LogStreamServer {
                                 } else {
                                     call.response.header(HttpHeaders.ContentDisposition, "inline")
                                 }
-                                call.respondText(target.readText(), ContentType.Text.Plain)
+                                call.respondText(content, ContentType.Text.Plain)
                             } catch (e: Exception) {
                                 Log.e(TAG, "[ERROR] /logs/files/{filename}:: Failed to serve log file: ${e.message}")
                                 call.respondText(


### PR DESCRIPTION
## Description

- This PR fixes the Remote Log Viewer showing empty Log Files and Debug Images tabs after the storage redesign by pointing `LogStreamServer`'s reads at the new write locations.
- It also clamps the race history tooltip within the viewport in `updateTooltipPosition()` so a tall tooltip can no longer spill off-screen.
