### PR TITLE
Fix rare startup crash from reading empty template match settings

### DIFF
--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Game.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Game.kt
@@ -266,10 +266,10 @@ class Game(val myContext: Context) {
             )
         }
         if (debugMode) MessageLog.w(TAG, "[WARN] ⚠️ Debug Mode is enabled. All bot operations will be significantly slower as a result.")
-        if (SettingsHelper.getStringSetting("debug", "templateMatchCustomScale").toDouble() != 1.0) {
+        if (SettingsHelper.getDoubleSetting("debug", "templateMatchCustomScale", 1.0) != 1.0) {
             MessageLog.w(
                 TAG,
-                "[WARN] Manual scale has been set to ${SettingsHelper.getStringSetting("debug", "templateMatchCustomScale").toDouble()}",
+                "[WARN] Manual scale has been set to ${SettingsHelper.getDoubleSetting("debug", "templateMatchCustomScale", 1.0)}",
             )
         }
         MessageLog.w(

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Training.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Training.kt
@@ -96,19 +96,19 @@ open class Training(protected val game: Game, protected val campaign: Campaign) 
     private val scenario = game.scenario
 
     /** The current stat prioritization settings. */
-    private val statPrioritizationRaw: List<StatName> = SettingsHelper.getStringArraySetting("training", "statPrioritization").map { StatName.fromName(it)!! }
+    private val statPrioritizationRaw: List<StatName> = SettingsHelper.getStringArraySetting("training", "statPrioritization").mapNotNull { StatName.fromName(it) }
 
     /** The final stat prioritization list. */
     internal val statPrioritization: List<StatName> = statPrioritizationRaw.ifEmpty { StatName.entries }
 
     /** The raw stat prioritization list for in-game event choices, sourced from user settings. */
-    private val eventChoiceStatPriorityRaw: List<StatName> = SettingsHelper.getStringArraySetting("training", "eventChoiceStatPriority").map { StatName.fromName(it)!! }
+    private val eventChoiceStatPriorityRaw: List<StatName> = SettingsHelper.getStringArraySetting("training", "eventChoiceStatPriority").mapNotNull { StatName.fromName(it) }
 
     /** The final stat prioritization list applied to event choice scoring. Falls back to [statPrioritization] if unset. */
     internal val eventChoiceStatPriority: List<StatName> = eventChoiceStatPriorityRaw.ifEmpty { statPrioritization }
 
     /** The raw stat prioritization list for Summer Training, sourced from user settings. */
-    private val summerTrainingStatPriorityRaw: List<StatName> = SettingsHelper.getStringArraySetting("training", "summerTrainingStatPriority").map { StatName.fromName(it)!! }
+    private val summerTrainingStatPriorityRaw: List<StatName> = SettingsHelper.getStringArraySetting("training", "summerTrainingStatPriority").mapNotNull { StatName.fromName(it) }
 
     /** The final stat prioritization list applied during Summer Training. Falls back to [statPrioritization] if unset. */
     internal val summerTrainingStatPriority: List<StatName> = summerTrainingStatPriorityRaw.ifEmpty { statPrioritization }

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/utils/CustomImageUtils.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/utils/CustomImageUtils.kt
@@ -67,10 +67,10 @@ class CustomImageUtils(context: Context, private val game: Game) : ImageUtils(co
     override var debugMode: Boolean = SettingsHelper.getBooleanSetting("debug", "enableDebugMode")
 
     /** Template matching confidence threshold. */
-    override var confidence: Double = SettingsHelper.getStringSetting("debug", "templateMatchConfidence").toDouble()
+    override var confidence: Double = SettingsHelper.getDoubleSetting("debug", "templateMatchConfidence", 0.8)
 
     /** Custom scale factor for template matching. */
-    override var customScale: Double = SettingsHelper.getStringSetting("debug", "templateMatchCustomScale").toDouble()
+    override var customScale: Double = SettingsHelper.getDoubleSetting("debug", "templateMatchCustomScale", 1.0)
 
     /** Maximum allowed value for a single stat. */
     private val manualStatCap: Int = SettingsHelper.getIntSetting("training", "manualStatCap")


### PR DESCRIPTION
## Description

- This PR fixes a rare startup `NumberFormatException` crash by reading `templateMatchConfidence` and `templateMatchCustomScale` which crashed when the stored value was empty or missing.

```
[ERROR] com.steve1316.uma_android_automation.utils.CustomImageUtils.<init>(CustomImageUtils.kt:70)
[ERROR] com.steve1316.uma_android_automation.bot.Game.<init>(Game.kt:38)
00:00:00.004 [ERROR] java.lang.NumberFormatException: empty String
```
