### PR TITLE
Skip double-circle skills and apply the Style preference strictly across all strategies

### DIFF
--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/SkillPlan.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/SkillPlan.kt
@@ -123,6 +123,7 @@ class SkillPlan(private val game: Game, private val campaign: Campaign) {
      * @property skillBlacklist Names of skills to exclude from purchase regardless of strategy.
      * @property excludedTypes Skill type categories (GREEN / YELLOW / BLUE / RED) to exclude wholesale.
      * @property bExcludeUniqueSkills Whether to exclude all inherited unique skills from purchase, even if listed in the plan.
+     * @property bExcludeDoubleCircleSkills Whether to skip double-circle (double-O) skills in the auto-strategy. Planned ones are still bought.
      */
     data class SkillPlanSettings(
         val bIsEnabled: Boolean,
@@ -132,6 +133,7 @@ class SkillPlan(private val game: Game, private val campaign: Campaign) {
         val skillBlacklist: List<String> = emptyList(),
         val excludedTypes: Set<SkillType> = emptySet(),
         val bExcludeUniqueSkills: Boolean = false,
+        val bExcludeDoubleCircleSkills: Boolean = false,
     )
 
     companion object {
@@ -148,6 +150,7 @@ class SkillPlan(private val game: Game, private val campaign: Campaign) {
          * @property isUserPlanned Whether this skill is in the user's plan.
          * @property communityTier The community tier ranking (lower is better, null = unranked).
          * @property isBlacklisted Whether this skill is blacklisted by the user's plan settings (per-skill or category-level).
+         * @property isDoubleCircle Whether this is a double-circle (double-O) variant of the skill.
          */
         data class SkillCandidate(
             val name: String,
@@ -158,6 +161,7 @@ class SkillPlan(private val game: Game, private val campaign: Campaign) {
             val isUserPlanned: Boolean = false,
             val communityTier: Int? = null,
             val isBlacklisted: Boolean = false,
+            val isDoubleCircle: Boolean = false,
         ) {
             /** The ratio of rank gained to price. Higher is better. */
             val evaluationPointRatio: Double
@@ -267,7 +271,7 @@ class SkillPlan(private val game: Game, private val campaign: Campaign) {
             val alreadyBought = common.map { it.first }
 
             // Strategy-specific purchases
-            val remainingCandidates = candidates.filter { it.name !in alreadyBought }
+            val remainingCandidates = candidates.filter { it.name !in alreadyBought && !(settings.bExcludeDoubleCircleSkills && it.isDoubleCircle) }
             val strategyPurchases =
                 when (settings.strategy) {
                     SpendingStrategy.DEFAULT, SpendingStrategy.OPTIMIZE_RANK -> {

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/SkillPlan.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/SkillPlan.kt
@@ -775,7 +775,16 @@ class SkillPlan(private val game: Game, private val campaign: Campaign) {
                     continue
                 }
 
-                if (!matchesPreference(entry.trackDistance, entry.runningStyle, entry.inferredRunningStyles, entry.trackSurface, preferredTrackDistance, preferredRunningStyle, preferredTrackSurface)) {
+                if (!matchesPreference(
+                        entry.trackDistance,
+                        entry.runningStyle,
+                        entry.inferredRunningStyles,
+                        entry.trackSurface,
+                        preferredTrackDistance,
+                        preferredRunningStyle,
+                        preferredTrackSurface,
+                    )
+                ) {
                     continue
                 }
 

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/SkillPlan.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/SkillPlan.kt
@@ -144,6 +144,39 @@ class SkillPlan(private val game: Game, private val campaign: Campaign) {
         private const val DOUBLE_CIRCLE_CHAR: Char = '\u25CE'
 
         /**
+         * Whether a skill is compatible with the resolved Style preference on every axis. A skill passes when, for each axis with a
+         * preference, it either has no commitment on that axis (generic / aptitude-independent) or its value matches. Running style
+         * matches on the explicit style or any inferred style, mirroring the Optimize Skills include-pass.
+         *
+         * @param skillDistance The skill's track distance, or null.
+         * @param skillStyle The skill's explicit running style, or null.
+         * @param skillInferredStyles The skill's inferred running styles (may be empty).
+         * @param skillSurface The skill's track surface, or null.
+         * @param prefDistance The preferred track distance, or null for no restriction.
+         * @param prefStyle The preferred running style, or null for no restriction.
+         * @param prefSurface The preferred track surface, or null for no restriction.
+         * @return True if the skill is buyable under the preference.
+         */
+        fun matchesPreference(
+            skillDistance: TrackDistance?,
+            skillStyle: RunningStyle?,
+            skillInferredStyles: List<RunningStyle>,
+            skillSurface: TrackSurface?,
+            prefDistance: TrackDistance?,
+            prefStyle: RunningStyle?,
+            prefSurface: TrackSurface?,
+        ): Boolean {
+            val distanceOk = prefDistance == null || skillDistance == null || skillDistance == prefDistance
+            val surfaceOk = prefSurface == null || skillSurface == null || skillSurface == prefSurface
+            val styleOk =
+                prefStyle == null ||
+                    (skillStyle == null && skillInferredStyles.isEmpty()) ||
+                    skillStyle == prefStyle ||
+                    prefStyle in skillInferredStyles
+            return distanceOk && surfaceOk && styleOk
+        }
+
+        /**
          * Represents a skill available for purchase in a pure calculation context.
          *
          * @property name The skill name.
@@ -384,6 +417,42 @@ class SkillPlan(private val game: Game, private val campaign: Campaign) {
     // //////////////////////////////////////////////////////////////////////////////////////////////////
     // //////////////////////////////////////////////////////////////////////////////////////////////////
 
+    /** The resolved Style preference for each axis (null = no restriction). */
+    private data class PreferredAxes(
+        /** The resolved preferred running style, or null for no restriction. */
+        val runningStyle: RunningStyle?,
+        /** The resolved preferred track distance, or null for no restriction. */
+        val trackDistance: TrackDistance?,
+        /** The resolved preferred track surface, or null for no restriction. */
+        val trackSurface: TrackSurface?,
+    )
+
+    /**
+     * Resolve the global Style preference settings into concrete enum values, applying the no_preference / inherit rules.
+     *
+     * @return The resolved running style, track distance, and track surface (any of which may be null for no restriction).
+     */
+    private fun resolvePreferredAxes(): PreferredAxes {
+        val runningStyle: RunningStyle? =
+            when (skillSettingRunningStyleString.lowercase()) {
+                "no_preference" -> null
+                "inherit" -> RunningStyle.fromShortName(racingSettingRunningStyleString) ?: campaign.trainee.runningStyle
+                else -> RunningStyle.fromName(skillSettingRunningStyleString)
+            }
+        val trackDistance: TrackDistance? =
+            when (skillSettingTrackDistanceString.lowercase()) {
+                "no_preference" -> null
+                "inherit" -> TrackDistance.fromName(trainingSettingTrackDistanceString) ?: campaign.trainee.trackDistance
+                else -> TrackDistance.fromName(skillSettingTrackDistanceString)
+            }
+        val trackSurface: TrackSurface? =
+            when (skillSettingTrackSurfaceString.lowercase()) {
+                "no_preference" -> null
+                else -> TrackSurface.fromName(skillSettingTrackSurfaceString)
+            }
+        return PreferredAxes(runningStyle, trackDistance, trackSurface)
+    }
+
     /**
      * Whether the given skill entry should be excluded from purchase due to the user's blacklist settings.
      *
@@ -578,28 +647,7 @@ class SkillPlan(private val game: Game, private val campaign: Campaign) {
         val result: MutableMap<String, Int> = mutableMapOf()
         var remainingSkillPoints = availableSkillPoints
 
-        // Determine the user-specified preferred running style.
-        val preferredRunningStyle: RunningStyle? =
-            when (skillSettingRunningStyleString.lowercase()) {
-                "no_preference" -> null
-                "inherit" -> RunningStyle.fromShortName(racingSettingRunningStyleString) ?: campaign.trainee.runningStyle
-                else -> RunningStyle.fromName(skillSettingRunningStyleString)
-            }
-
-        // Determine the user-specified preferred track distance.
-        val preferredTrackDistance: TrackDistance? =
-            when (skillSettingTrackDistanceString.lowercase()) {
-                "no_preference" -> null
-                "inherit" -> TrackDistance.fromName(trainingSettingTrackDistanceString) ?: campaign.trainee.trackDistance
-                else -> TrackDistance.fromName(skillSettingTrackDistanceString)
-            }
-
-        // Determine the user-specified preferred track surface.
-        val preferredTrackSurface: TrackSurface? =
-            when (skillSettingTrackSurfaceString.lowercase()) {
-                "no_preference" -> null
-                else -> TrackSurface.fromName(skillSettingTrackSurfaceString)
-            }
+        val (preferredRunningStyle, preferredTrackDistance, preferredTrackSurface) = resolvePreferredAxes()
 
         MessageLog.d(TAG, "[DEBUG] getSkillsToBuyOptimizeSkillsStrategy:: Using preferred running style: $preferredRunningStyle")
         MessageLog.d(TAG, "[DEBUG] getSkillsToBuyOptimizeSkillsStrategy:: Using preferred track distance: $preferredTrackDistance")
@@ -702,6 +750,7 @@ class SkillPlan(private val game: Game, private val campaign: Campaign) {
     private fun getSkillsToBuyOptimizeRankStrategy(skillPlanSettings: SkillPlanSettings, skillList: SkillList, skillsToBuy: List<String>, availableSkillPoints: Int): Map<String, Int> {
         val result: MutableMap<String, Int> = mutableMapOf()
         var remainingSkillPoints = availableSkillPoints
+        val (preferredRunningStyle, preferredTrackDistance, preferredTrackSurface) = resolvePreferredAxes()
 
         // Iterate until no more affordable skills are found, as purchasing can unlock new options.
         val maxIterations = 10
@@ -723,6 +772,10 @@ class SkillPlan(private val game: Game, private val campaign: Campaign) {
                 }
 
                 if (skillPlanSettings.bExcludeDoubleCircleSkills && entry.skillData.name.contains(DOUBLE_CIRCLE_CHAR)) {
+                    continue
+                }
+
+                if (!matchesPreference(entry.trackDistance, entry.runningStyle, entry.inferredRunningStyles, entry.trackSurface, preferredTrackDistance, preferredRunningStyle, preferredTrackSurface)) {
                     continue
                 }
 

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/SkillPlan.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/SkillPlan.kt
@@ -77,6 +77,7 @@ class SkillPlan(private val game: Game, private val campaign: Campaign) {
                             skillBlacklist = skillBlacklist,
                             excludedTypes = excludedTypes,
                             bExcludeUniqueSkills = planData.optBoolean("excludeUniqueSkills", false),
+                            bExcludeDoubleCircleSkills = planData.optBoolean("excludeDoubleCircleSkills", false),
                         )
                 }
                 plansMap
@@ -138,6 +139,9 @@ class SkillPlan(private val game: Game, private val campaign: Campaign) {
 
     companion object {
         private val TAG: String = "[${MainActivity.loggerTag}]SkillPlan"
+
+        /** The double-circle (double-O) marker found in double-circle skill names. */
+        private const val DOUBLE_CIRCLE_CHAR: Char = '\u25CE'
 
         /**
          * Represents a skill available for purchase in a pure calculation context.
@@ -652,6 +656,10 @@ class SkillPlan(private val game: Game, private val campaign: Campaign) {
                         continue
                     }
 
+                    if (skillPlanSettings.bExcludeDoubleCircleSkills && entry.skillData.name.contains(DOUBLE_CIRCLE_CHAR)) {
+                        continue
+                    }
+
                     if (!entry.bIsAvailable || entry.screenPrice > remainingSkillPoints) {
                         continue
                     }
@@ -711,6 +719,10 @@ class SkillPlan(private val game: Game, private val campaign: Campaign) {
                 }
 
                 if (isBlacklisted(entry, skillPlanSettings)) {
+                    continue
+                }
+
+                if (skillPlanSettings.bExcludeDoubleCircleSkills && entry.skillData.name.contains(DOUBLE_CIRCLE_CHAR)) {
                     continue
                 }
 

--- a/android/app/src/test/java/com/steve1316/uma_android_automation/bot/SkillPlanPurchasingTest.kt
+++ b/android/app/src/test/java/com/steve1316/uma_android_automation/bot/SkillPlanPurchasingTest.kt
@@ -4,8 +4,12 @@ import com.steve1316.uma_android_automation.bot.SkillPlan.Companion.SkillCandida
 import com.steve1316.uma_android_automation.bot.SkillPlan.Companion.calculateCommonPurchases
 import com.steve1316.uma_android_automation.bot.SkillPlan.Companion.calculateOptimizeRankPurchases
 import com.steve1316.uma_android_automation.bot.SkillPlan.Companion.calculateSkillPurchases
+import com.steve1316.uma_android_automation.bot.SkillPlan.Companion.matchesPreference
 import com.steve1316.uma_android_automation.bot.SkillPlan.SkillPlanSettings
 import com.steve1316.uma_android_automation.bot.SkillPlan.SpendingStrategy
+import com.steve1316.uma_android_automation.types.RunningStyle
+import com.steve1316.uma_android_automation.types.TrackDistance
+import com.steve1316.uma_android_automation.types.TrackSurface
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
@@ -612,6 +616,62 @@ class SkillPlanPurchasingTest {
             val commonResult = calculateCommonPurchases(candidates, budget = 1000, settings = settings)
 
             assertTrue(commonResult.isEmpty(), "Common phase with no plan and both flags off should buy nothing")
+        }
+    }
+
+    // //////////////////////////////////////////////////////////////////////////////////////////////////
+    // //////////////////////////////////////////////////////////////////////////////////////////////////
+    // matchesPreference()
+
+    @Nested
+    @DisplayName("matchesPreference()")
+    inner class MatchesPreferenceTests {
+        @Test
+        fun `no preference set means everything matches`() {
+            assertTrue(matchesPreference(TrackDistance.SPRINT, RunningStyle.LATE_SURGER, emptyList(), TrackSurface.DIRT, null, null, null))
+        }
+
+        @Test
+        fun `matching distance is kept and off-distance is excluded`() {
+            assertTrue(matchesPreference(TrackDistance.MEDIUM, null, emptyList(), null, TrackDistance.MEDIUM, null, null))
+            assertFalse(matchesPreference(TrackDistance.SPRINT, null, emptyList(), null, TrackDistance.MEDIUM, null, null))
+        }
+
+        @Test
+        fun `generic skill with null axis is always kept`() {
+            assertTrue(matchesPreference(null, null, emptyList(), null, TrackDistance.MEDIUM, RunningStyle.FRONT_RUNNER, TrackSurface.TURF))
+        }
+
+        @Test
+        fun `explicit running style match is kept`() {
+            assertTrue(matchesPreference(null, RunningStyle.FRONT_RUNNER, emptyList(), null, null, RunningStyle.FRONT_RUNNER, null))
+        }
+
+        @Test
+        fun `inferred running style match is kept`() {
+            assertTrue(matchesPreference(null, null, listOf(RunningStyle.FRONT_RUNNER), null, null, RunningStyle.FRONT_RUNNER, null))
+        }
+
+        @Test
+        fun `committed running style with no matching inferred is excluded`() {
+            assertFalse(matchesPreference(null, RunningStyle.LATE_SURGER, listOf(RunningStyle.LATE_SURGER), null, null, RunningStyle.FRONT_RUNNER, null))
+        }
+
+        @Test
+        fun `matching surface kept and off-surface excluded`() {
+            assertTrue(matchesPreference(null, null, emptyList(), TrackSurface.TURF, null, null, TrackSurface.TURF))
+            assertFalse(matchesPreference(null, null, emptyList(), TrackSurface.DIRT, null, null, TrackSurface.TURF))
+        }
+
+        @Test
+        fun `one off-axis fails the whole match`() {
+            // distance matches MEDIUM but surface DIRT != preferred TURF -> excluded
+            assertFalse(matchesPreference(TrackDistance.MEDIUM, null, emptyList(), TrackSurface.DIRT, TrackDistance.MEDIUM, null, TrackSurface.TURF))
+        }
+
+        @Test
+        fun `explicit style match passes despite non-matching inferred styles`() {
+            assertTrue(matchesPreference(null, RunningStyle.FRONT_RUNNER, listOf(RunningStyle.LATE_SURGER), null, null, RunningStyle.FRONT_RUNNER, null))
         }
     }
 }

--- a/android/app/src/test/java/com/steve1316/uma_android_automation/bot/SkillPlanPurchasingTest.kt
+++ b/android/app/src/test/java/com/steve1316/uma_android_automation/bot/SkillPlanPurchasingTest.kt
@@ -456,6 +456,60 @@ class SkillPlanPurchasingTest {
                 )
             }
         }
+
+        @Test
+        fun `OPTIMIZE_RANK skips double-circle skills when toggle on`() {
+            val settings =
+                SkillPlanSettings(
+                    bIsEnabled = true,
+                    strategy = SpendingStrategy.OPTIMIZE_RANK,
+                    bEnableBuyNegativeSkills = false,
+                    skillNames = emptyList(),
+                    bExcludeDoubleCircleSkills = true,
+                )
+            // ASCII names; detection here is via the isDoubleCircle flag (mirrors real Winter Runner single/double variants).
+            val candidates =
+                listOf(
+                    SkillCandidate("Winter Runner (double)", price = 110, evaluationPoints = 174, isDoubleCircle = true),
+                    SkillCandidate("Winter Runner (single)", price = 90, evaluationPoints = 129),
+                )
+            val result = calculateSkillPurchases(candidates, 1000, settings)
+            assertTrue(result.none { it.first == "Winter Runner (double)" })
+            assertTrue(result.any { it.first == "Winter Runner (single)" })
+        }
+
+        @Test
+        fun `planned double-circle skill is still bought when toggle on`() {
+            val settings =
+                SkillPlanSettings(
+                    bIsEnabled = true,
+                    strategy = SpendingStrategy.OPTIMIZE_RANK,
+                    bEnableBuyNegativeSkills = false,
+                    skillNames = listOf("Nakayama Racecourse (double)"),
+                    bExcludeDoubleCircleSkills = true,
+                )
+            val candidates =
+                listOf(
+                    SkillCandidate("Nakayama Racecourse (double)", price = 110, evaluationPoints = 174, isDoubleCircle = true, isUserPlanned = true),
+                )
+            val result = calculateSkillPurchases(candidates, 1000, settings)
+            assertTrue(result.any { it.first == "Nakayama Racecourse (double)" })
+        }
+
+        @Test
+        fun `double-circle skill is bought when toggle off`() {
+            val settings =
+                SkillPlanSettings(
+                    bIsEnabled = true,
+                    strategy = SpendingStrategy.OPTIMIZE_RANK,
+                    bEnableBuyNegativeSkills = false,
+                    skillNames = emptyList(),
+                    bExcludeDoubleCircleSkills = false,
+                )
+            val candidates = listOf(SkillCandidate("Winter Runner (double)", price = 110, evaluationPoints = 174, isDoubleCircle = true))
+            val result = calculateSkillPurchases(candidates, 1000, settings)
+            assertTrue(result.any { it.first == "Winter Runner (double)" })
+        }
     }
 
     // //////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/context/BotStateContext.tsx
+++ b/src/context/BotStateContext.tsx
@@ -22,6 +22,8 @@ interface SkillPlanSettingsConfig {
     excludeRedSkills: boolean
     /** When true, all inherited unique (legacy) skills are excluded from this plan's purchases, even if listed in the plan. */
     excludeUniqueSkills: boolean
+    /** When true, double-circle (double-O) skills are skipped by the auto-strategy. Planned ones are still bought. */
+    excludeDoubleCircleSkills: boolean
 }
 
 /**
@@ -307,6 +309,7 @@ export const defaultSettings: Settings = {
                     excludeGreenSkills: false,
                     excludeRedSkills: false,
                     excludeUniqueSkills: false,
+                    excludeDoubleCircleSkills: false,
                 }
                 return acc
             },

--- a/src/context/searchConfig.ts
+++ b/src/context/searchConfig.ts
@@ -639,6 +639,13 @@ const searchConfig: SearchOption[] = [
         page: "Skills",
         parentId: "skill-point-check-plan",
     },
+    {
+        id: "exclude-double-circle-skills-SkillPlanSettingsSkillPointCheck",
+        title: "Skip All Double-O (Circle) Skills",
+        description: "Only buy the single-circle version; skip the double-circle upgrade",
+        page: "Skills",
+        parentId: "skill-point-check-plan",
+    },
 
     // ============================================================
     // Skill Plan Settings — Pre-Finals
@@ -677,6 +684,13 @@ const searchConfig: SearchOption[] = [
         page: "Skills",
         parentId: "enable-skill-plan-preFinals",
     },
+    {
+        id: "exclude-double-circle-skills-SkillPlanSettingsPreFinals",
+        title: "Skip All Double-O (Circle) Skills",
+        description: "Only buy the single-circle version; skip the double-circle upgrade",
+        page: "Skills",
+        parentId: "enable-skill-plan-preFinals",
+    },
 
     // ============================================================
     // Skill Plan Settings — Career Complete
@@ -712,6 +726,13 @@ const searchConfig: SearchOption[] = [
         id: "exclude-unique-skills-SkillPlanSettingsCareerComplete",
         title: "Skip All Unique Skills",
         description: "Exclude inherited unique (legacy) skills",
+        page: "Skills",
+        parentId: "enable-skill-plan-careerComplete",
+    },
+    {
+        id: "exclude-double-circle-skills-SkillPlanSettingsCareerComplete",
+        title: "Skip All Double-O (Circle) Skills",
+        description: "Only buy the single-circle version; skip the double-circle upgrade",
         page: "Skills",
         parentId: "enable-skill-plan-careerComplete",
     },

--- a/src/lib/messageLog/buildSettingsBanner.ts
+++ b/src/lib/messageLog/buildSettingsBanner.ts
@@ -38,11 +38,12 @@ const formatAdvancedScoringSection = (training: Settings["training"]): string =>
     return `\n\n---------- Advanced Training Scoring ----------\n${overrides.join("\n")}`
 }
 
-const formatExcludedCategories = (plan: { excludeGreenSkills: boolean; excludeRedSkills: boolean; excludeUniqueSkills: boolean }): string => {
+const formatExcludedCategories = (plan: { excludeGreenSkills: boolean; excludeRedSkills: boolean; excludeUniqueSkills: boolean; excludeDoubleCircleSkills: boolean }): string => {
     const parts: string[] = []
     if (plan.excludeGreenSkills) parts.push("Green")
     if (plan.excludeRedSkills) parts.push("Red")
     if (plan.excludeUniqueSkills) parts.push("Unique")
+    if (plan.excludeDoubleCircleSkills) parts.push("Double-O")
     return parts.length === 0 ? "None" : parts.join(", ")
 }
 

--- a/src/pages/Skills/PlanTab.tsx
+++ b/src/pages/Skills/PlanTab.tsx
@@ -78,7 +78,7 @@ const PlanTab: React.FC<PlanTabProps> = ({ planKey }) => {
 
     const combinedConfig = { ...defaultSettings.skills.plans, ...skills.plans }
     const planData = combinedConfig[planKey] ?? defaultSettings.skills.plans[planKey]
-    const { enabled, strategy, enableBuyNegativeSkills, plan, blacklist, excludeGreenSkills, excludeRedSkills, excludeUniqueSkills } = planData
+    const { enabled, strategy, enableBuyNegativeSkills, plan, blacklist, excludeGreenSkills, excludeRedSkills, excludeUniqueSkills, excludeDoubleCircleSkills } = planData
 
     const [searchQuery, setSearchQuery] = useState("")
     const [showSelected, setShowSelected] = useState(false)
@@ -238,6 +238,7 @@ const PlanTab: React.FC<PlanTabProps> = ({ planKey }) => {
     if (excludeGreenSkills) excludedCategories.push("Green")
     if (excludeRedSkills) excludedCategories.push("Red")
     if (excludeUniqueSkills) excludedCategories.push("Unique")
+    if (excludeDoubleCircleSkills) excludedCategories.push("Double-O")
     const idsToNames = (ids: number[]): string[] => ids.map((id) => skillData.find((s) => s.id === id)?.name_en ?? `Unknown (ID ${id})`)
 
     const renderSpecChipList = (ids: number[]) => {
@@ -290,6 +291,13 @@ const PlanTab: React.FC<PlanTabProps> = ({ planKey }) => {
                         title="Skip Unique Skills"
                         description="Exclude inherited unique (legacy) skills"
                         right={<Switch checked={excludeUniqueSkills} onCheckedChange={(checked) => updatePlanSetting("excludeUniqueSkills", checked)} />}
+                    />
+                </SearchableItem>
+                <SearchableItem id={`exclude-double-circle-skills-${config.name}`} title="Skip All Double-O (Circle) Skills" description="Only buy the single-circle version; skip the double-circle upgrade">
+                    <Row
+                        title="Skip Double-O (Circle) Skills"
+                        description="Skip double-circle upgrades in the auto-strategy. Ones you add to the plan are still bought."
+                        right={<Switch checked={excludeDoubleCircleSkills} onCheckedChange={(checked) => updatePlanSetting("excludeDoubleCircleSkills", checked)} />}
                     />
                 </SearchableItem>
             </Section>

--- a/src/pages/Skills/PlanTab.tsx
+++ b/src/pages/Skills/PlanTab.tsx
@@ -293,7 +293,11 @@ const PlanTab: React.FC<PlanTabProps> = ({ planKey }) => {
                         right={<Switch checked={excludeUniqueSkills} onCheckedChange={(checked) => updatePlanSetting("excludeUniqueSkills", checked)} />}
                     />
                 </SearchableItem>
-                <SearchableItem id={`exclude-double-circle-skills-${config.name}`} title="Skip All Double-O (Circle) Skills" description="Only buy the single-circle version; skip the double-circle upgrade">
+                <SearchableItem
+                    id={`exclude-double-circle-skills-${config.name}`}
+                    title="Skip All Double-O (Circle) Skills"
+                    description="Only buy the single-circle version; skip the double-circle upgrade"
+                >
                     <Row
                         title="Skip Double-O (Circle) Skills"
                         description="Skip double-circle upgrades in the auto-strategy. Ones you add to the plan are still bought."

--- a/src/pages/Skills/StyleSection.tsx
+++ b/src/pages/Skills/StyleSection.tsx
@@ -130,7 +130,11 @@ const StyleSection: React.FC = () => {
     return (
         <>
             <Section label="Style">
-                <SearchableItem id="skill-plan-running-style" title="Running Style for Skills" description="Restricts auto-purchased skills to the preferred running style across all spending strategies.">
+                <SearchableItem
+                    id="skill-plan-running-style"
+                    title="Running Style for Skills"
+                    description="Restricts auto-purchased skills to the preferred running style across all spending strategies."
+                >
                     <Row
                         title="Running Style"
                         description="Restricts auto-purchased skills to the preferred running style across all spending strategies."
@@ -138,7 +142,11 @@ const StyleSection: React.FC = () => {
                         right={chipFor(runningChip)}
                     />
                 </SearchableItem>
-                <SearchableItem id="preferred-distance-override" title="Track Distance for Skills" description="Restricts auto-purchased skills to the preferred track distance across all spending strategies.">
+                <SearchableItem
+                    id="preferred-distance-override"
+                    title="Track Distance for Skills"
+                    description="Restricts auto-purchased skills to the preferred track distance across all spending strategies."
+                >
                     <Row
                         title="Track Distance"
                         description="Restricts auto-purchased skills to the preferred track distance across all spending strategies."
@@ -146,7 +154,11 @@ const StyleSection: React.FC = () => {
                         right={chipFor(distanceChip)}
                     />
                 </SearchableItem>
-                <SearchableItem id="preferred-track-surface" title="Track Surface for Skills" description="Restricts auto-purchased skills to the preferred track surface across all spending strategies.">
+                <SearchableItem
+                    id="preferred-track-surface"
+                    title="Track Surface for Skills"
+                    description="Restricts auto-purchased skills to the preferred track surface across all spending strategies."
+                >
                     <Row
                         title="Track Surface"
                         description="Restricts auto-purchased skills to the preferred track surface across all spending strategies."

--- a/src/pages/Skills/StyleSection.tsx
+++ b/src/pages/Skills/StyleSection.tsx
@@ -130,26 +130,26 @@ const StyleSection: React.FC = () => {
     return (
         <>
             <Section label="Style">
-                <SearchableItem id="skill-plan-running-style" title="Running Style for Skills" description="Dictates which skills are considered for purchase based on the preferred running style.">
+                <SearchableItem id="skill-plan-running-style" title="Running Style for Skills" description="Restricts auto-purchased skills to the preferred running style across all spending strategies.">
                     <Row
                         title="Running Style"
-                        description="Dictates which skills are considered for purchase based on the preferred running style."
+                        description="Restricts auto-purchased skills to the preferred running style across all spending strategies."
                         onPress={() => setOpenPicker("running")}
                         right={chipFor(runningChip)}
                     />
                 </SearchableItem>
-                <SearchableItem id="preferred-distance-override" title="Track Distance for Skills" description="Dictates which skills are considered for purchase based on the track distance.">
+                <SearchableItem id="preferred-distance-override" title="Track Distance for Skills" description="Restricts auto-purchased skills to the preferred track distance across all spending strategies.">
                     <Row
                         title="Track Distance"
-                        description="Dictates which skills are considered for purchase based on the track distance."
+                        description="Restricts auto-purchased skills to the preferred track distance across all spending strategies."
                         onPress={() => setOpenPicker("distance")}
                         right={chipFor(distanceChip)}
                     />
                 </SearchableItem>
-                <SearchableItem id="preferred-track-surface" title="Track Surface for Skills" description="Dictates which skills are considered for purchase based on the terrain.">
+                <SearchableItem id="preferred-track-surface" title="Track Surface for Skills" description="Restricts auto-purchased skills to the preferred track surface across all spending strategies.">
                     <Row
                         title="Track Surface"
-                        description="Dictates which skills are considered for purchase based on the terrain."
+                        description="Restricts auto-purchased skills to the preferred track surface across all spending strategies."
                         onPress={() => setOpenPicker("surface")}
                         right={chipFor(surfaceChip)}
                     />


### PR DESCRIPTION
## Description

- This PR resolves #349 by adding a per-plan `Skip Double-O Skills` toggle that excludes double-circle skills from auto-purchase, while still buying any that are explicitly planned.
- It also makes the Style preference (`preferredRunningStyle`, `preferredTrackDistance`, `preferredTrackSurface`) a strict filter across every spending strategy, so off-preference skills are no longer auto-bought by Optimize Rank or the Optimize Skills fallback.
