### PR TITLE
Add `Disable Schedule Re-Plan Upon Race Loss` setting to Smart Race Solver

### DIFF
--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/solver/SmartRaceSolverIntegration.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/solver/SmartRaceSolverIntegration.kt
@@ -245,7 +245,10 @@ object SmartRaceSolverIntegration {
         if (!won) {
             recordRaceLost(pending.raceKey, pending.name, pending.classYear, pending.turnNumber)
             MessageLog.i(TAG, "Race \"${pending.name}\" on turn ${pending.turnNumber} did not finish 1st; recorded as a loss.")
-            broadcastCalendarSnapshot()
+            // When the user disables re-planning on a loss, keep the originally locked-in schedule instead of re-solving the remaining turns.
+            val keepSchedule = SettingsHelper.getBooleanSetting("racing", "disableScheduleReplanOnRaceLoss")
+            if (keepSchedule) MessageLog.i(TAG, "Schedule re-plan on loss is disabled; keeping the original plan.")
+            broadcastCalendarSnapshot(reuseSchedule = keepSchedule)
             return
         }
         val historyBefore = synchronized(raceHistory) { raceHistory.toList() }

--- a/src/context/BotStateContext.tsx
+++ b/src/context/BotStateContext.tsx
@@ -72,6 +72,7 @@ export interface Settings {
         // through React state inflated re-renders by ~160 KB and made every toggle re-write the
         // blobs to SQLite via the auto-save effect.
         enableSmartRaceSolver: boolean
+        disableScheduleReplanOnRaceLoss: boolean
         smartRaceSolverCharacterPreset: string
         smartRaceSolverAptitudes: string
         smartRaceSolverTargetEpithets: string
@@ -264,6 +265,7 @@ export const defaultSettings: Settings = {
         juniorYearPerDistanceStrategies: { Short: "Default", Mile: "Default", Medium: "Default", Long: "Default" },
         originalPerDistanceStrategies: { Short: "Default", Mile: "Default", Medium: "Default", Long: "Default" },
         enableSmartRaceSolver: false,
+        disableScheduleReplanOnRaceLoss: false,
         smartRaceSolverCharacterPreset: "Special Week",
         smartRaceSolverAptitudes: JSON.stringify({
             Sprint: "F",

--- a/src/context/searchConfig.ts
+++ b/src/context/searchConfig.ts
@@ -494,6 +494,13 @@ const searchConfig: SearchOption[] = [
         page: "SmartRaceSolverSettings",
     },
     {
+        id: "disable-schedule-replan-on-race-loss",
+        title: "Disable Schedule Re-Plan Upon Race Loss",
+        description: "When a race is lost, keep the original schedule instead of re-planning the remaining turns. The loss is still recorded; epithets that depended on the lost race won't be re-routed.",
+        page: "SmartRaceSolverSettings",
+        parentId: "enable-smart-race-solver",
+    },
+    {
         id: "smart-solver-how-it-works",
         title: "How it works",
         description: "Smart Race Solver overview, loss handling, race-history scrape, and notes on epithets without matchers.",

--- a/src/lib/messageLog/__tests__/buildSettingsBanner.test.ts
+++ b/src/lib/messageLog/__tests__/buildSettingsBanner.test.ts
@@ -51,6 +51,6 @@ describe("buildSettingsBanner", () => {
 
     it("includes the disable schedule re-plan on race loss line", () => {
         const banner = buildSettingsBanner(makeStubSettings())
-        expect(banner).toContain("Disable Schedule Re-Plan on Race Loss")
+        expect(banner).toContain("Disable Schedule Re-Plan Upon Race Loss")
     })
 })

--- a/src/lib/messageLog/__tests__/buildSettingsBanner.test.ts
+++ b/src/lib/messageLog/__tests__/buildSettingsBanner.test.ts
@@ -48,4 +48,9 @@ describe("buildSettingsBanner", () => {
         expect(banner).toContain("---------- Debug Options ----------")
         expect(banner).toContain("---------- Discord Options ----------")
     })
+
+    it("includes the disable schedule re-plan on race loss line", () => {
+        const banner = buildSettingsBanner(makeStubSettings())
+        expect(banner).toContain("Disable Schedule Re-Plan on Race Loss")
+    })
 })

--- a/src/lib/messageLog/buildSettingsBanner.ts
+++ b/src/lib/messageLog/buildSettingsBanner.ts
@@ -174,7 +174,7 @@ ${longTargetsString}${formatAdvancedScoringSection(settings.training)}
 
 ---------- Smart Race Solver Options ----------
 🤖 Enable Smart Race Solver: ${settings.racing.enableSmartRaceSolver ? "✅" : "❌"}
-🚫 Disable Schedule Re-Plan on Race Loss: ${settings.racing.disableScheduleReplanOnRaceLoss ? "✅" : "❌"}
+🚫 Disable Schedule Re-Plan Upon Race Loss: ${settings.racing.disableScheduleReplanOnRaceLoss ? "✅" : "❌"}
 🎭 Solver Character Preset: ${settings.racing.smartRaceSolverCharacterPreset || "(none)"}
 🐎 Solver Aptitudes: Spr ${smartRaceSolverAptitudesObj.Sprint ?? "?"}, Mile ${smartRaceSolverAptitudesObj.Mile ?? "?"}, Med ${smartRaceSolverAptitudesObj.Medium ?? "?"}, Lng ${smartRaceSolverAptitudesObj.Long ?? "?"}, Trf ${smartRaceSolverAptitudesObj.Turf ?? "?"}, Drt ${smartRaceSolverAptitudesObj.Dirt ?? "?"}
 🎯 Solver Optimize Mode: ${smartRaceSolverOptimizeMode}

--- a/src/lib/messageLog/buildSettingsBanner.ts
+++ b/src/lib/messageLog/buildSettingsBanner.ts
@@ -174,6 +174,7 @@ ${longTargetsString}${formatAdvancedScoringSection(settings.training)}
 
 ---------- Smart Race Solver Options ----------
 🤖 Enable Smart Race Solver: ${settings.racing.enableSmartRaceSolver ? "✅" : "❌"}
+🚫 Disable Schedule Re-Plan on Race Loss: ${settings.racing.disableScheduleReplanOnRaceLoss ? "✅" : "❌"}
 🎭 Solver Character Preset: ${settings.racing.smartRaceSolverCharacterPreset || "(none)"}
 🐎 Solver Aptitudes: Spr ${smartRaceSolverAptitudesObj.Sprint ?? "?"}, Mile ${smartRaceSolverAptitudesObj.Mile ?? "?"}, Med ${smartRaceSolverAptitudesObj.Medium ?? "?"}, Lng ${smartRaceSolverAptitudesObj.Long ?? "?"}, Trf ${smartRaceSolverAptitudesObj.Turf ?? "?"}, Drt ${smartRaceSolverAptitudesObj.Dirt ?? "?"}
 🎯 Solver Optimize Mode: ${smartRaceSolverOptimizeMode}

--- a/src/pages/SmartRaceSolverSettings/index.tsx
+++ b/src/pages/SmartRaceSolverSettings/index.tsx
@@ -119,6 +119,7 @@ const SmartRaceSolverSettings = () => {
     const racingSettings = { ...defaultSettings.racing, ...racing }
     const {
         enableSmartRaceSolver,
+        disableScheduleReplanOnRaceLoss,
         smartRaceSolverCharacterPreset,
         smartRaceSolverAptitudes,
         smartRaceSolverTargetEpithets,
@@ -1204,6 +1205,20 @@ const SmartRaceSolverSettings = () => {
                             </SearchableItem>
 
                             <SearchableItem
+                                id="disable-schedule-replan-on-race-loss"
+                                condition={enableSmartRaceSolver}
+                                parentId="enable-smart-race-solver"
+                                title="Disable Schedule Re-Plan Upon Race Loss"
+                                description="When a race is lost, keep the original schedule instead of re-planning the remaining turns. The loss is still recorded; epithets that depended on the lost race won't be re-routed."
+                            >
+                                <Row
+                                    title="Disable Schedule Re-Plan Upon Race Loss"
+                                    description="When a race is lost, keep the original schedule instead of re-planning the remaining turns. The loss is still recorded; epithets that depended on the lost race won't be re-routed."
+                                    right={<Switch checked={disableScheduleReplanOnRaceLoss} onCheckedChange={(checked) => updateRacingSetting("disableScheduleReplanOnRaceLoss", checked)} />}
+                                />
+                            </SearchableItem>
+
+                            <SearchableItem
                                 id="smart-solver-how-it-works"
                                 condition={enableSmartRaceSolver}
                                 parentId="enable-smart-race-solver"
@@ -1221,6 +1236,7 @@ const SmartRaceSolverSettings = () => {
                                         <SubTopic title="What happens when you lose a race">
                                             A loss is recorded against that turn and the solver immediately re-plans the remaining turns. Epithets that depended on the lost race may shift to
                                             alternative paths or drop out entirely, so later races / trainings can change to keep the rest of the run on the highest-scoring track still available.
+                                            Turn on "Disable Schedule Re-Plan Upon Race Loss" to keep the original schedule after a loss instead of re-planning.
                                         </SubTopic>
                                         <SubTopic title="Race History scrape">
                                             On bot start (and only when the career is past the pre-debut turns), the bot opens the in-game Career → Race History dialog and scrapes every past race

--- a/src/pages/SmartRaceSolverSettings/index.tsx
+++ b/src/pages/SmartRaceSolverSettings/index.tsx
@@ -1235,8 +1235,8 @@ const SmartRaceSolverSettings = () => {
                                         </SubTopic>
                                         <SubTopic title="What happens when you lose a race">
                                             A loss is recorded against that turn and the solver immediately re-plans the remaining turns. Epithets that depended on the lost race may shift to
-                                            alternative paths or drop out entirely, so later races / trainings can change to keep the rest of the run on the highest-scoring track still available.
-                                            Turn on "Disable Schedule Re-Plan Upon Race Loss" to keep the original schedule after a loss instead of re-planning.
+                                            alternative paths or drop out entirely, so later races / trainings can change to keep the rest of the run on the highest-scoring track still available. Turn
+                                            on "Disable Schedule Re-Plan Upon Race Loss" to keep the original schedule after a loss instead of re-planning.
                                         </SubTopic>
                                         <SubTopic title="Race History scrape">
                                             On bot start (and only when the career is past the pre-debut turns), the bot opens the in-game Career → Race History dialog and scrapes every past race


### PR DESCRIPTION
## Description
- This PR adds a `disableScheduleReplanOnRaceLoss` toggle (default off) to the Smart Race Solver settings that keeps the originally locked-in schedule after a race loss instead of re-planning the remaining turns.
- When enabled, the loss is still recorded but `commitPendingRace()` reuses the cached schedule via `broadcastCalendarSnapshot(reuseSchedule = true)` rather than re-solving.
