### PR TITLE
Remote Log Viewer: improved Compact toggle and per-race running style in the Race History

### DIFF
--- a/android/app/src/main/assets/log_viewer.html
+++ b/android/app/src/main/assets/log_viewer.html
@@ -2402,6 +2402,47 @@
             }
 
             /**
+             * Renders one parsed log message into the given target node, applying condensation when enabled. Mutates messageCache,
+             * visibleMessageCount, and condensationBuffer. Shared by the live append paths and rebuildLog so condensed output is identical.
+             * @param {object} parsed - The pre-parsed log object.
+             * @param {Node} target - Node to append new entries to (logContainer for single appends, a DocumentFragment for batches/rebuild).
+             */
+            function processParsedMessage(parsed, target) {
+                const canCondense = isCondensing && !condensationExclusions.has(parsed.level)
+                const match = canCondense ? condensationBuffer.find(item =>
+                    item.parsed.level === parsed.level &&
+                    item.parsed.message === parsed.message
+                ) : null
+
+                if (match) {
+                    match.count++
+                    match.parsed.timestamp = parsed.timestamp
+                    updateCondensedEntry(match.el, parsed, match.count)
+                } else {
+                    const entry = createLogEntry(parsed)
+                    messageCache.push({
+                        el: entry,
+                        text: parsed.message.toLowerCase(),
+                        level: parsed.level
+                    })
+                    if (!entry.classList.contains("hidden")) {
+                        visibleMessageCount++
+                    }
+                    target.appendChild(entry)
+                    if (canCondense) {
+                        condensationBuffer.push({
+                            el: entry,
+                            parsed: parsed,
+                            count: 1
+                        })
+                        if (condensationBuffer.length > condensationLimit) {
+                            condensationBuffer.shift()
+                        }
+                    }
+                }
+            }
+
+            /**
              * Processes and appends a single log message to the log container.
              * @param {object} parsed - The pre-parsed log object from the server.
              */
@@ -2419,43 +2460,7 @@
                 // Handle special messages for dashboard updates immediately for individual messages.
                 processSpecialLogs(parsed)
 
-                const canCondense = isCondensing && !condensationExclusions.has(parsed.level)
-                let match = canCondense ? condensationBuffer.find(item =>
-                    item.parsed.level === parsed.level &&
-                    item.parsed.message === parsed.message
-                ) : null
-
-                if (match) {
-                    match.count++
-                    match.parsed.timestamp = parsed.timestamp
-                    updateCondensedEntry(match.el, parsed, match.count)
-                } else {
-                    var entry = createLogEntry(parsed)
-
-                    // Add to message cache for fast filtering.
-                    messageCache.push({
-                        el: entry,
-                        text: parsed.message.toLowerCase(),
-                        level: parsed.level
-                    })
-
-                    if (!entry.classList.contains("hidden")) {
-                        visibleMessageCount++
-                    }
-                    logContainer.appendChild(entry)
-
-                    if (canCondense) {
-                        condensationBuffer.push({
-                            el: entry,
-                            parsed: parsed,
-                            count: 1
-                        })
-
-                        if (condensationBuffer.length > condensationLimit) {
-                            condensationBuffer.shift()
-                        }
-                    }
-                }
+                processParsedMessage(parsed, logContainer)
 
                 updateMessageCountDisplay()
 
@@ -2511,42 +2516,7 @@
                         // Collect updates into the batch state object.
                         processSpecialLogs(parsed, batchState)
 
-                        const canCondense = isCondensing && !condensationExclusions.has(parsed.level)
-                        let match = canCondense ? condensationBuffer.find(item =>
-                            item.parsed.level === parsed.level &&
-                            item.parsed.message === parsed.message
-                        ) : null
-
-                        if (match) {
-                            match.count++
-                            match.parsed.timestamp = parsed.timestamp
-                            updateCondensedEntry(match.el, parsed, match.count)
-                        } else {
-                            var entry = createLogEntry(parsed)
-
-                            // Add to message cache for fast filtering.
-                            messageCache.push({
-                                el: entry,
-                                text: parsed.message.toLowerCase(),
-                                level: parsed.level
-                            })
-
-                            if (!entry.classList.contains("hidden")) {
-                                visibleMessageCount++
-                            }
-                            fragment.appendChild(entry)
-
-                            if (canCondense) {
-                                condensationBuffer.push({
-                                    el: entry,
-                                    parsed: parsed,
-                                    count: 1
-                                })
-                                if (condensationBuffer.length > condensationLimit) {
-                                    condensationBuffer.shift()
-                                }
-                            }
-                        }
+                        processParsedMessage(parsed, fragment)
                     } catch (e) {
                         console.error("Error processing log in batch:", e, parsed)
                     }

--- a/android/app/src/main/assets/log_viewer.html
+++ b/android/app/src/main/assets/log_viewer.html
@@ -2638,6 +2638,35 @@
             // ==============================================
 
             /**
+             * Re-renders the entire log from allMessages, applying or removing condensation based on the current isCondensing flag. Used by
+             * the Compact toggle so previously-condensed lines can be expanded and re-collapsed. Active filters/search are re-applied and
+             * auto-scroll is respected. messageCount is left untouched since it already reflects allMessages.length.
+             */
+            function rebuildLog() {
+                // Drop existing entries (keep the empty-state div) and reset the per-entry caches.
+                const entries = logContainer.querySelectorAll(".log-entry")
+                entries.forEach(function (entry) {
+                    entry.remove()
+                })
+                messageCache = []
+                condensationBuffer = []
+                visibleMessageCount = 0
+
+                // Replay every stored message through the shared renderer into a single fragment.
+                const fragment = document.createDocumentFragment()
+                allMessages.forEach(function (msg) {
+                    processParsedMessage(msg.parsed, fragment)
+                })
+                logContainer.appendChild(fragment)
+
+                // Re-apply the active level filters and search, then restore scroll position.
+                applyFilters()
+                if (autoScroll) {
+                    scrollToBottom()
+                }
+            }
+
+            /**
              * Toggles the log condensation feature on or off.
              */
             function toggleCondensing() {
@@ -2647,9 +2676,9 @@
                     btn.classList.add("active")
                 } else {
                     btn.classList.remove("active")
-                    // Clear buffer when turning off so it doesn't resume from old state
-                    condensationBuffer = []
                 }
+                // Re-render the whole log so already-condensed lines expand (or re-collapse) to match the new state.
+                rebuildLog()
             }
 
             /**

--- a/android/app/src/main/assets/log_viewer.html
+++ b/android/app/src/main/assets/log_viewer.html
@@ -2964,7 +2964,7 @@
 
             /**
              * Renders the Race History calendar from a snapshot pushed by the bot.
-             * Snapshot shape: { currentTurn:int, decisions:{turn->{type,raceKey?,name?,grade?,raceTrack?,terrain?,distanceType?,distanceMeters?,fans?,contributions?}}, results:[{turn,raceKey,name,grade,outcome,...}] }
+             * Snapshot shape: { currentTurn:int, decisions:{turn->{type,raceKey?,name?,grade?,raceTrack?,terrain?,distanceType?,distanceMeters?,fans?,contributions?}}, results:[{turn,raceKey,name,grade,outcome,strategy?,...}] }
              * @param {object|null} snapshot Calendar snapshot JSON, or null to paint the empty grid.
              */
             function renderCalendar(snapshot) {
@@ -3151,6 +3151,7 @@
                     parts.push(dt)
                 }
                 if (typeof src.fans === "number") parts.push(formatNumberWithCommas(src.fans) + " fans")
+                if (src.strategy) parts.push(src.strategy)
 
                 var content = '<div class="tooltip-row"><span class="tooltip-label" style="font-weight:700">' + escapeHtml(src.name || "") + '</span></div>'
                 if (parts.length > 0) {

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Racing.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Racing.kt
@@ -2030,6 +2030,17 @@ class Racing(private val game: Game, private val campaign: Campaign) {
                     lastRaceFans = raceDataList[0].fans
                     lastRaceDistance = raceDataList[0].trackDistance
                     MessageLog.i(TAG, "[RACE] Detected scheduled race grade: $lastRaceGrade.")
+
+                    // Stage the scheduled race so finalizeRaceResults() records its win/loss in the solver's history. Without this, scheduled
+                    // races run via the in-game agenda never get committed and render as blank Race History cells in the Remote Log Viewer.
+                    if (enableSmartRaceSolver) {
+                        SmartRaceSolverIntegration.markPendingRace(
+                            raceKey = raceDataList[0].name,
+                            raceName = raceDataList[0].name,
+                            classYear = campaign.date.year.name,
+                            turnNumber = campaign.date.day,
+                        )
+                    }
                 }
             }
 

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/solver/RaceHistory.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/solver/RaceHistory.kt
@@ -41,6 +41,12 @@ object RaceHistory {
     private const val FIRST_PLACE_W = 160
     private const val FIRST_PLACE_H = 120
 
+    // Running-style chip sits just right of the LabelStrategy anchor on the same row. Offset derived from crop (190, 960) minus anchor centre (130, 980).
+    private const val STRATEGY_OFFSET_X = 60
+    private const val STRATEGY_OFFSET_Y = -20
+    private const val STRATEGY_W = 130
+    private const val STRATEGY_H = 40
+
     /**
      * One race entry parsed from the Career -> Race History dialog. The race name itself
      * is intentionally not captured - OCR on the row's primary label was unreliable, and
@@ -49,8 +55,9 @@ object RaceHistory {
      * @property nameFormatted Formatted track string (e.g. "Tokyo Turf 1600m (Mile) Left").
      * @property dateString In-game date as shown on screen (e.g. "Junior Year Early Nov").
      * @property won True if the IconRaceHistory1st laurel was found in the placement region.
+     * @property strategy Raw OCR of the running-style chip (e.g. "Front Runner"). Empty when OCR returned nothing.
      */
-    data class RaceHistoryEntry(val nameFormatted: String, val dateString: String, val won: Boolean)
+    data class RaceHistoryEntry(val nameFormatted: String, val dateString: String, val won: Boolean, val strategy: String)
 
     // //////////////////////////////////////////////////////////////////////////////////////////////////
     // //////////////////////////////////////////////////////////////////////////////////////////////////
@@ -177,6 +184,17 @@ object RaceHistory {
                     debugName = "race_history_date_$anchorY",
                 ).trim()
 
+        val strategy =
+            game.imageUtils
+                .performOCRFromReference(
+                    referencePoint = anchor,
+                    offsetX = STRATEGY_OFFSET_X,
+                    offsetY = STRATEGY_OFFSET_Y,
+                    width = game.imageUtils.relWidth(STRATEGY_W),
+                    height = game.imageUtils.relHeight(STRATEGY_H),
+                    debugName = "race_history_strategy_$anchorY",
+                ).trim()
+
         val firstPlaceRegion =
             intArrayOf(
                 anchorX + game.imageUtils.relWidth(FIRST_PLACE_OFFSET_X),
@@ -186,6 +204,6 @@ object RaceHistory {
             )
         val won: Boolean = IconRaceHistory1st.find(game.imageUtils, region = firstPlaceRegion, tries = 1).first != null
 
-        return RaceHistoryEntry(nameFormatted, dateString, won)
+        return RaceHistoryEntry(nameFormatted, dateString, won, strategy)
     }
 }

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/solver/SmartRaceSolverIntegration.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/solver/SmartRaceSolverIntegration.kt
@@ -713,7 +713,7 @@ object SmartRaceSolverIntegration {
         // Career -> Race History is sorted newest-first, so turns must strictly decrease as
         // we iterate. Any entry that breaks that invariant is OCR garbage from a
         // mid-scroll frame and is safely dropped.
-        data class MatchedEntry(val candidate: RaceCandidate, val dateString: String, val won: Boolean)
+        data class MatchedEntry(val candidate: RaceCandidate, val dateString: String, val won: Boolean, val strategy: String)
         val matched = mutableListOf<MatchedEntry>()
         var lastTurnSeen: TurnNumber = Int.MAX_VALUE
         for (entry in entries) {
@@ -739,7 +739,7 @@ object SmartRaceSolverIntegration {
                     ?: continue
             val candidate = candidates.firstOrNull { it.nameFormatted == matchedFormatted } ?: continue
 
-            matched.add(MatchedEntry(candidate, entry.dateString, entry.won))
+            matched.add(MatchedEntry(candidate, entry.dateString, entry.won, entry.strategy))
             if (entry.won) {
                 recordRaceWon(candidate.key, candidate.name, candidate.classYear, turnNumber)
             } else {
@@ -755,7 +755,7 @@ object SmartRaceSolverIntegration {
         } else {
             for (m in matched) {
                 val outcome = if (m.won) "Won" else "Lost"
-                sb.append("\n  Turn ${m.candidate.turnNumber} (${m.dateString}): $outcome - ${m.candidate.name}")
+                sb.append("\n  Turn ${m.candidate.turnNumber} (${m.dateString}): $outcome - ${m.candidate.name} [${m.strategy.ifBlank { "?" }}]")
             }
         }
         // Append the synthetic Junior Make Debut row to the scrape recap so the operator sees a

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/solver/SmartRaceSolverIntegration.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/solver/SmartRaceSolverIntegration.kt
@@ -768,7 +768,8 @@ object SmartRaceSolverIntegration {
         // duplicate trailing line later in [runStartupHooks].
         val debutDate = scrapedDebutEntry?.dateString ?: "Junior Year Late Jun"
         val debutOutcome = if (scrapedDebutEntry?.won == false) "Lost" else "Won"
-        sb.append("\n  Turn $MAKE_DEBUT_DISPLAY_TURN ($debutDate): $debutOutcome - Make Debut (Does not affect epithets)")
+        val debutStrategy = scrapedDebutEntry?.strategy?.ifBlank { "?" } ?: "?"
+        sb.append("\n  Turn $MAKE_DEBUT_DISPLAY_TURN ($debutDate): $debutOutcome - Make Debut [$debutStrategy] (Does not affect epithets)")
         debutDisplayLogged.set(true)
         MessageLog.i(TAG, sb.toString())
         return true
@@ -1372,6 +1373,8 @@ object SmartRaceSolverIntegration {
         // parts row alongside the grade and fan count. Skipped when the scrape was bypassed or
         // the row was missing (pre-debut runs).
         scrapedDebut?.nameFormatted?.takeIf { it.isNotBlank() }?.let { syntheticEntry.put("raceTrack", it) }
+        // Carry the OCR-scraped running style through so the Make Debut tooltip shows it after the fan count, matching every other race cell.
+        scrapedDebut?.strategy?.takeIf { it.isNotBlank() }?.let { syntheticEntry.put("strategy", it) }
         results.put(syntheticEntry)
 
         return JSONObject()

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/solver/SmartRaceSolverIntegration.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/solver/SmartRaceSolverIntegration.kt
@@ -116,11 +116,12 @@ object SmartRaceSolverIntegration {
      * @param raceName Race name (matches [RaceCandidate.name]).
      * @param classYear Class-year prefix at the time of the race.
      * @param turnNumber Turn the loss occurred on.
+     * @param strategy Running style OCR'd from the Race History scrape. Empty for live in-run losses.
      */
-    fun recordRaceLost(raceKey: String, raceName: String, classYear: String, turnNumber: TurnNumber) {
+    fun recordRaceLost(raceKey: String, raceName: String, classYear: String, turnNumber: TurnNumber, strategy: String = "") {
         synchronized(raceLosses) {
             if (raceLosses.none { it.raceKey == raceKey && it.turnNumber == turnNumber }) {
-                raceLosses.add(RaceLossRecord(raceKey, raceName, classYear, turnNumber))
+                raceLosses.add(RaceLossRecord(raceKey, raceName, classYear, turnNumber, strategy))
             }
         }
     }
@@ -134,11 +135,12 @@ object SmartRaceSolverIntegration {
      * @param raceName Race name (matches [RaceCandidate.name]).
      * @param classYear Class-year prefix at the time of the win.
      * @param turnNumber Turn the win occurred on.
+     * @param strategy Running style OCR'd from the Race History scrape. Empty for live in-run wins and preview-assumed wins.
      */
-    fun recordRaceWon(raceKey: String, raceName: String, classYear: String, turnNumber: TurnNumber) {
+    fun recordRaceWon(raceKey: String, raceName: String, classYear: String, turnNumber: TurnNumber, strategy: String = "") {
         synchronized(raceHistory) {
             if (raceHistory.none { it.raceKey == raceKey && it.turnNumber == turnNumber }) {
-                raceHistory.add(RaceWin(raceKey, raceName, classYear, turnNumber))
+                raceHistory.add(RaceWin(raceKey, raceName, classYear, turnNumber, strategy))
             }
         }
     }
@@ -741,9 +743,9 @@ object SmartRaceSolverIntegration {
 
             matched.add(MatchedEntry(candidate, entry.dateString, entry.won, entry.strategy))
             if (entry.won) {
-                recordRaceWon(candidate.key, candidate.name, candidate.classYear, turnNumber)
+                recordRaceWon(candidate.key, candidate.name, candidate.classYear, turnNumber, entry.strategy)
             } else {
-                recordRaceLost(candidate.key, candidate.name, candidate.classYear, turnNumber)
+                recordRaceLost(candidate.key, candidate.name, candidate.classYear, turnNumber, entry.strategy)
             }
         }
 
@@ -1335,10 +1337,10 @@ object SmartRaceSolverIntegration {
 
         val results = JSONArray()
         for (win in winsSnapshot) {
-            results.put(buildResultEntry(win.turnNumber, win.raceKey, win.name, racesByTurn, RaceOutcome.WIN, contributionsByTurn[win.turnNumber]))
+            results.put(buildResultEntry(win.turnNumber, win.raceKey, win.name, racesByTurn, RaceOutcome.WIN, contributionsByTurn[win.turnNumber], win.strategy))
         }
         for (loss in lossesSnapshot) {
-            results.put(buildResultEntry(loss.turnNumber, loss.raceKey, loss.name, racesByTurn, RaceOutcome.LOSE, null))
+            results.put(buildResultEntry(loss.turnNumber, loss.raceKey, loss.name, racesByTurn, RaceOutcome.LOSE, null, loss.strategy))
         }
 
         // Always append a synthetic entry for the in-game Junior Make Debut race. This row is purely a visual breadcrumb in the Remote Log
@@ -1390,7 +1392,8 @@ object SmartRaceSolverIntegration {
      * @param racesByTurn Candidate pool used to resolve race details.
      * @param outcome Win or loss marker.
      * @param contributions Pre-computed epithet contributions for this turn, or null.
-     * @return JSON `{turn, raceKey, name, grade, outcome, raceTrack?, terrain?, distanceType?, distanceMeters?, fans?, contributions?}`.
+     * @param strategy Running style OCR'd from the Race History scrape. Omitted from the JSON when blank.
+     * @return JSON `{turn, raceKey, name, grade, outcome, raceTrack?, terrain?, distanceType?, distanceMeters?, fans?, strategy?, contributions?}`.
      */
     private fun buildResultEntry(
         turn: TurnNumber,
@@ -1399,6 +1402,7 @@ object SmartRaceSolverIntegration {
         racesByTurn: Map<TurnNumber, List<RaceCandidate>>,
         outcome: RaceOutcome,
         contributions: JSONArray?,
+        strategy: String = "",
     ): JSONObject {
         val race = findCandidate(turn, raceKey, raceName, racesByTurn)
         val obj =
@@ -1409,6 +1413,7 @@ object SmartRaceSolverIntegration {
                 .put("grade", race?.grade?.name ?: "")
                 .put("outcome", outcome.name)
         if (race != null) addRaceDetails(obj, race)
+        if (strategy.isNotBlank()) obj.put("strategy", strategy)
         if (contributions != null) obj.put("contributions", contributions)
         return obj
     }

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/solver/SolverState.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/solver/SolverState.kt
@@ -143,12 +143,14 @@ data class RaceCandidate(
  * @property name Race name (matches [RaceCandidate.name]).
  * @property classYear Class-year prefix at the time of the win.
  * @property turnNumber Turn the win occurred on.
+ * @property strategy Running style OCR'd from the Race History scrape (e.g. "Pace"). Empty for live commits and the preview seed, which have no scrape data.
  */
 data class RaceWin(
     val raceKey: String,
     val name: String,
     val classYear: String,
     val turnNumber: TurnNumber,
+    val strategy: String = "",
 )
 
 /** Win/lose marker for a finished race surfaced to the Remote Log Viewer calendar. */
@@ -163,12 +165,14 @@ enum class RaceOutcome { WIN, LOSE }
  * @property name Display name of the race (matches [RaceCandidate.name]).
  * @property classYear Class-year prefix at the time of the race.
  * @property turnNumber Turn the loss occurred on.
+ * @property strategy Running style OCR'd from the Race History scrape (e.g. "Pace"). Empty for live commits, which have no scrape data.
  */
 data class RaceLossRecord(
     val raceKey: String,
     val name: String,
     val classYear: String,
     val turnNumber: TurnNumber,
+    val strategy: String = "",
 )
 
 /**


### PR DESCRIPTION
## Description
- This PR makes the Remote Log Viewer's `Compact` button a true toggle that fully expands previously-condensed lines and can re-collapses them.
- It records every scheduled race into the Smart Race Solver history so Race History calendar cells no longer render blank with no win/loss border or epithet progress.
- It OCRs each race's running style during the Race History scrape and surfaces it in the calendar popover tooltip.