### PR TITLE
Add Sync Priorities button to Training Settings

### DIFF
--- a/src/lib/training/__tests__/syncPriorities.test.tsx
+++ b/src/lib/training/__tests__/syncPriorities.test.tsx
@@ -1,0 +1,46 @@
+// This test uses a .tsx extension (not .ts) on purpose: syncPriorities imports shallowArrayEqual from
+// ../utils, which transitively pulls in expo-clipboard. Only the jest-expo (components) project mocks Expo,
+// and that project matches .tsx files. A plain .test.ts would run under the node project and fail to resolve expo-clipboard.
+import { computePrioritySync } from "../syncPriorities"
+
+describe("computePrioritySync", () => {
+    const source = ["Speed", "Stamina", "Power"]
+
+    it("reports no change when both targets already match the source", () => {
+        const result = computePrioritySync(source, ["Speed", "Stamina", "Power"], ["Speed", "Stamina", "Power"])
+        expect(result.changed).toBe(false)
+        expect(result.eventChoice).toEqual(source)
+        expect(result.summer).toEqual(source)
+        expect(result.eventChoice).not.toBe(result.summer)
+    })
+
+    it("reports a change when the event choice list differs", () => {
+        const result = computePrioritySync(source, ["Wit", "Speed"], ["Speed", "Stamina", "Power"])
+        expect(result.changed).toBe(true)
+    })
+
+    it("reports a change when the summer list differs", () => {
+        const result = computePrioritySync(source, ["Speed", "Stamina", "Power"], ["Wit"])
+        expect(result.changed).toBe(true)
+    })
+
+    it("is order-sensitive", () => {
+        const result = computePrioritySync(["Speed", "Power"], ["Power", "Speed"], ["Power", "Speed"])
+        expect(result.changed).toBe(true)
+    })
+
+    it("returns fresh array copies, not references to the source", () => {
+        const result = computePrioritySync(source, [], [])
+        expect(result.eventChoice).not.toBe(source)
+        expect(result.summer).not.toBe(source)
+        expect(result.eventChoice).toEqual(source)
+    })
+
+    it("handles an empty source: empty targets are in sync, non-empty targets change", () => {
+        expect(computePrioritySync([], [], []).changed).toBe(false)
+        const result = computePrioritySync([], ["Speed"], [])
+        expect(result.changed).toBe(true)
+        expect(result.eventChoice).toEqual([])
+        expect(result.summer).toEqual([])
+    })
+})

--- a/src/lib/training/syncPriorities.ts
+++ b/src/lib/training/syncPriorities.ts
@@ -1,0 +1,24 @@
+import { shallowArrayEqual } from "../utils"
+
+/** Result of computing a priority sync from the main list onto the two dependent lists. */
+export interface PrioritySyncResult {
+    /** True if at least one target list would change. False when both targets already match the source. */
+    changed: boolean
+    /** New Event Choice prioritization list - a fresh copy of the source order. */
+    eventChoice: string[]
+    /** New Summer Training prioritization list - a fresh copy of the source order. */
+    summer: string[]
+}
+
+/**
+ * Compute the result of syncing the main stat prioritization order onto the Event Choice and Summer Training lists.
+ * Returns fresh copies of the source for both targets so callers never share array references with the source.
+ * @param source The main `statPrioritization` order to copy from.
+ * @param eventChoice The current Event Choice prioritization list.
+ * @param summer The current Summer Training prioritization list.
+ * @returns A `PrioritySyncResult` with `changed` plus the new target arrays.
+ */
+export function computePrioritySync(source: string[], eventChoice: string[], summer: string[]): PrioritySyncResult {
+    const changed = !shallowArrayEqual(source, eventChoice) || !shallowArrayEqual(source, summer)
+    return { changed, eventChoice: [...source], summer: [...source] }
+}

--- a/src/pages/TrainingSettings/index.tsx
+++ b/src/pages/TrainingSettings/index.tsx
@@ -1246,7 +1246,7 @@ const TrainingSettings = () => {
                 visible={snackbarVisible}
                 onDismiss={() => setSnackbarVisible(false)}
                 action={snackbarAction ?? { label: "Close", onPress: () => setSnackbarVisible(false) }}
-                style={{ backgroundColor: "red", borderRadius: 10 }}
+                style={{ backgroundColor: colors.success, borderRadius: 10 }}
                 duration={4000}
             >
                 {snackbarMessage}

--- a/src/pages/TrainingSettings/index.tsx
+++ b/src/pages/TrainingSettings/index.tsx
@@ -64,6 +64,13 @@ const TrainingSettings = () => {
     }, [])
     const [snackbarVisible, setSnackbarVisible] = useState(false)
     const [snackbarMessage, setSnackbarMessage] = useState("")
+    const [snackbarAction, setSnackbarAction] = useState<{ label: string; onPress: () => void } | null>(null)
+    // Show the page snackbar with a message and an optional action. Defaults to a "Close" action that just dismisses.
+    const showSnackbar = useCallback((message: string, action?: { label: string; onPress: () => void }) => {
+        setSnackbarMessage(message)
+        setSnackbarAction(action ?? null)
+        setSnackbarVisible(true)
+    }, [])
     const [scoringSandboxOpen, setScoringSandboxOpen] = useState(false)
     const [advancedExpanded, setAdvancedExpanded] = useState(false)
 
@@ -515,12 +522,10 @@ const TrainingSettings = () => {
                                 currentTrainingStatTargetSettings={trainingStatTargetSettings}
                                 onOverwriteSettings={handleOverwriteSettings}
                                 onNoChangesDetected={() => {
-                                    setSnackbarMessage("Current Training settings are already the same.")
-                                    setSnackbarVisible(true)
+                                    showSnackbar("Current Training settings are already the same.")
                                 }}
                                 onError={(message) => {
-                                    setSnackbarMessage(message)
-                                    setSnackbarVisible(true)
+                                    showSnackbar(message)
                                 }}
                             />
                         </SearchableItem>
@@ -1188,12 +1193,7 @@ const TrainingSettings = () => {
             <Snackbar
                 visible={snackbarVisible}
                 onDismiss={() => setSnackbarVisible(false)}
-                action={{
-                    label: "Close",
-                    onPress: () => {
-                        setSnackbarVisible(false)
-                    },
-                }}
+                action={snackbarAction ?? { label: "Close", onPress: () => setSnackbarVisible(false) }}
                 style={{ backgroundColor: "red", borderRadius: 10 }}
                 duration={4000}
             >

--- a/src/pages/TrainingSettings/index.tsx
+++ b/src/pages/TrainingSettings/index.tsx
@@ -1245,11 +1245,11 @@ const TrainingSettings = () => {
             <Snackbar
                 visible={snackbarVisible}
                 onDismiss={() => setSnackbarVisible(false)}
-                action={snackbarAction ?? { label: "Close", onPress: () => setSnackbarVisible(false) }}
+                action={{ ...(snackbarAction ?? { label: "Close", onPress: () => setSnackbarVisible(false) }), textColor: "#000" }}
                 style={{ backgroundColor: colors.success, borderRadius: 10 }}
                 duration={4000}
             >
-                {snackbarMessage}
+                <Text style={{ color: "#000" }}>{snackbarMessage}</Text>
             </Snackbar>
         </View>
     )

--- a/src/pages/TrainingSettings/index.tsx
+++ b/src/pages/TrainingSettings/index.tsx
@@ -19,6 +19,7 @@ import { SearchPageProvider } from "../../context/SearchPageContext"
 import SearchableItem from "../../components/SearchableItem"
 import { usePerformanceLogging } from "../../hooks/usePerformanceLogging"
 import { shallowArrayEqual } from "../../lib/utils"
+import { computePrioritySync } from "../../lib/training/syncPriorities"
 import WarningContainer from "../../components/WarningContainer"
 import { Row } from "../../components/ui/row"
 import { Section } from "../../components/ui/section"
@@ -85,6 +86,30 @@ const TrainingSettings = () => {
         training?.summerTrainingStatPriority !== undefined ? training.summerTrainingStatPriority : defaultSettings.training.summerTrainingStatPriority
     )
     const [blacklistItems, setBlacklistItems] = useState<string[]>(() => (training?.trainingBlacklist !== undefined ? training.trainingBlacklist : defaultSettings.training.trainingBlacklist))
+    /**
+     * Copy the main stat prioritization order onto the Event Choice and Summer Training lists.
+     * Shows an Undo snackbar when something changed, or an "Already in sync" message when both targets already match.
+     */
+    const handleSyncPriorities = useCallback(() => {
+        const { changed, eventChoice, summer } = computePrioritySync(statPrioritizationItems, eventChoiceStatPriorityItems, summerTrainingStatPriorityItems)
+        if (!changed) {
+            showSnackbar("Already in sync")
+            return
+        }
+        const prevEventChoice = eventChoiceStatPriorityItems
+        const prevSummer = summerTrainingStatPriorityItems
+        setEventChoiceStatPriorityItems(eventChoice)
+        setSummerTrainingStatPriorityItems(summer)
+        showSnackbar("Synced Event Choice & Summer to Prioritization", {
+            label: "Undo",
+            onPress: () => {
+                setEventChoiceStatPriorityItems(prevEventChoice)
+                setSummerTrainingStatPriorityItems(prevSummer)
+                // Dismiss the snackbar right after undoing the lists.
+                setSnackbarVisible(false)
+            },
+        })
+    }, [statPrioritizationItems, eventChoiceStatPriorityItems, summerTrainingStatPriorityItems, showSnackbar])
     // Use a ref to track if the initial mount sync has been done to avoid redundant updates.
     const isMounted = useRef(false)
 
@@ -336,6 +361,19 @@ const TrainingSettings = () => {
                     paddingVertical: 2,
                 },
                 selectorChipText: { ...TYPE.caption, color: colors.brand, fontWeight: "600" as const },
+                syncPill: {
+                    flexDirection: "row",
+                    alignItems: "center",
+                    gap: 5,
+                    backgroundColor: colors.brandSubtle,
+                    borderWidth: 1,
+                    borderColor: colors.brandBorder,
+                    borderRadius: RADII.pill,
+                    overflow: "hidden",
+                    paddingHorizontal: SPACING.sm,
+                    paddingVertical: 4,
+                },
+                syncPillText: { ...TYPE.caption, color: colors.brand, fontWeight: "600" as const },
                 sliderShell: { padding: SPACING.md },
                 metaText: { ...TYPE.caption, color: colors.textMuted, paddingHorizontal: SPACING.md, paddingTop: SPACING.xs, paddingBottom: SPACING.md },
                 groupHeader: { padding: SPACING.md, paddingBottom: 0 },
@@ -532,7 +570,21 @@ const TrainingSettings = () => {
 
                         {showHeavySections && (
                             <>
-                                <Section label="Priorities">
+                                <Section
+                                    label="Priorities"
+                                    labelRight={
+                                        <Pressable
+                                            style={styles.syncPill}
+                                            onPress={handleSyncPriorities}
+                                            android_ripple={{ color: colors.ripple, foreground: true }}
+                                            accessibilityRole="button"
+                                            accessibilityLabel="Sync Priorities"
+                                        >
+                                            <Ionicons name="sync" size={13} color={colors.brand} />
+                                            <Text style={styles.syncPillText}>Sync Priorities</Text>
+                                        </Pressable>
+                                    }
+                                >
                                     {renderStatSelector(
                                         "Blacklist",
                                         blacklistItems,


### PR DESCRIPTION
## Description

- This PR adds a "Sync Priorities" button to the Training Settings "Priorities" section header that copies the main `statPrioritization` order into the `eventChoiceStatPriority` and `summerTrainingStatPriority` lists in one tap.
- Tapping it shows an Undo snackbar when the lists change, or an "Already in sync" message when they already match.
