### PR TITLE
Add mandatory career race blocking to the Smart Race Solver

### DIFF
--- a/android/app/src/main/assets/log_viewer.html
+++ b/android/app/src/main/assets/log_viewer.html
@@ -1404,6 +1404,11 @@
                 color: var(--text-muted);
             }
 
+            .calendar-cell.mandatory-race {
+                border-color: #f59e0b;
+                box-shadow: inset 0 0 0 1px rgba(245, 158, 11, 0.45);
+            }
+
             .calendar-cell.win-result {
                 border-color: rgba(34, 197, 94, 0.65);
                 box-shadow: inset 0 0 0 1px rgba(34, 197, 94, 0.35);
@@ -3060,6 +3065,10 @@
                     classes.push("lose-result")
                 }
 
+                if (raceSrc && raceSrc.mandatory) {
+                    classes.push("mandatory-race")
+                }
+
                 // Only race cells (with race details to show) get the hover handlers. Synthetic
                 // display-only cells share the same rich tooltip; showRaceCellTooltip swaps its
                 // epithet section for a "Does not affect solver" notice when src.synthetic is true.
@@ -3156,6 +3165,10 @@
                 var content = '<div class="tooltip-row"><span class="tooltip-label" style="font-weight:700">' + escapeHtml(src.name || "") + '</span></div>'
                 if (parts.length > 0) {
                     content += '<div class="tooltip-row" style="opacity:0.85"><span>' + escapeHtml(parts.join(sep)) + '</span></div>'
+                }
+
+                if (src.mandatory) {
+                    content += '<div class="tooltip-section" style="margin-top:6px;font-weight:700;color:#f59e0b">Mandatory career race</div>'
                 }
 
                 var contribs = (src.contributions && src.contributions.length > 0)

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/solver/MandatoryRaces.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/solver/MandatoryRaces.kt
@@ -1,0 +1,188 @@
+package com.steve1316.uma_android_automation.bot.solver
+
+import com.steve1316.uma_android_automation.types.RaceGrade
+import com.steve1316.uma_android_automation.types.TrackDistance
+import com.steve1316.uma_android_automation.types.TrackSurface
+import org.json.JSONObject
+
+/**
+ * One race the player can run to satisfy a mandatory objective on a given turn.
+ *
+ * @property raceName Human-readable race name, matched against the race pool by name.
+ * @property grade Race grade (G1, G2, G3, OP).
+ * @property surface Track surface: Turf or Dirt.
+ * @property distanceType Distance category: Sprint, Mile, Medium, or Long.
+ * @property fans Reward fans for this race.
+ */
+data class MandatoryRaceOption(
+    val raceName: String,
+    val grade: RaceGrade,
+    val surface: TrackSurface,
+    val distanceType: TrackDistance,
+    val fans: Int,
+)
+
+/**
+ * A turn the game forces a mandatory career race on. Most turns have a single option; "choice"
+ * turns (e.g. Oaks vs Derby) carry several and the solver picks the best-aptitude one.
+ *
+ * @property turn 1-indexed turn the mandatory race occurs on.
+ * @property isChoice True when the player picks one race among several options.
+ * @property options The candidate races for this turn (length 1 for a fixed race).
+ */
+data class CharacterMandatoryRace(
+    val turn: TurnNumber,
+    val isChoice: Boolean,
+    val options: List<MandatoryRaceOption>,
+)
+
+/**
+ * Result of applying a character's mandatory races onto the solver inputs.
+ *
+ * @property racesByTurn The race pool with mandatory candidates injected/flagged.
+ * @property lockedDecisions Locked decisions with mandatory turns forced to their race.
+ */
+data class MandatoryApplication(
+    val racesByTurn: Map<TurnNumber, List<RaceCandidate>>,
+    val lockedDecisions: Map<TurnNumber, Decision>,
+)
+
+/**
+ * Pure logic for turning scraped character objectives into locked mandatory race decisions.
+ * Mandatory races are modelled as fixed races: locking them as `RaceDecision`s lets the existing
+ * MILP / heuristic handle no-double-booking, consecutive-race spacing, and fans/epithet crediting.
+ */
+object MandatoryRaces {
+    /** Scenario that does NOT use the URA objective races (it has its own race structure). */
+    const val EXCLUDED_SCENARIO = "Trackblazer"
+
+    /**
+     * Parses `character_objectives.json` into a per-character list of mandatory races.
+     *
+     * @param json The raw JSON string (character name -> { name, mandatoryRaces }).
+     * @return Map of character name to its mandatory races. Unknown grade/surface/distance strings
+     *   fall back to OP / Turf / Medium respectively.
+     */
+    fun parse(json: String): Map<String, List<CharacterMandatoryRace>> {
+        val root = JSONObject(json)
+        val out = HashMap<String, List<CharacterMandatoryRace>>()
+        val names = root.keys()
+        while (names.hasNext()) {
+            val name = names.next()
+            val charObj = root.getJSONObject(name)
+            val arr = charObj.optJSONArray("mandatoryRaces") ?: continue
+            val races = ArrayList<CharacterMandatoryRace>()
+            for (i in 0 until arr.length()) {
+                val m = arr.getJSONObject(i)
+                val turn = m.optInt("turn", -1)
+                if (turn <= 0) continue
+                val optsArr = m.optJSONArray("options") ?: continue
+                val options = ArrayList<MandatoryRaceOption>()
+                for (j in 0 until optsArr.length()) {
+                    val o = optsArr.getJSONObject(j)
+                    options.add(
+                        MandatoryRaceOption(
+                            raceName = o.optString("raceName", ""),
+                            grade = RaceGrade.fromName(o.optString("grade", "OP").replace("-", "_")) ?: RaceGrade.OP,
+                            surface = TrackSurface.fromName(o.optString("surface", "TURF")) ?: TrackSurface.TURF,
+                            distanceType = TrackDistance.fromName(o.optString("distanceType", "MEDIUM")) ?: TrackDistance.MEDIUM,
+                            fans = o.optInt("fans", 0),
+                        ),
+                    )
+                }
+                if (options.isNotEmpty()) {
+                    races.add(CharacterMandatoryRace(turn = turn, isChoice = m.optBoolean("isChoice", options.size > 1), options = options))
+                }
+            }
+            if (races.isNotEmpty()) out[name] = races
+        }
+        return out
+    }
+
+    /**
+     * Picks the option that best fits the run's aptitudes: best worst-of-(surface, distance) first,
+     * then best combined, then most fans. The `Aptitude` enum is declared worst-first, so a higher ordinal means a better aptitude; the ordinals are negated so `minWithOrNull` selects the best option.
+     *
+     * @param options Candidate races for the turn (must be non-empty).
+     * @param aptitudes The run's aptitudes.
+     * @return The best-fitting option.
+     */
+    fun selectBestOption(options: List<MandatoryRaceOption>, aptitudes: Aptitudes): MandatoryRaceOption =
+        options.minWithOrNull(
+            compareBy<MandatoryRaceOption>(
+                { -minOf(aptitudes.forSurface(it.surface).ordinal, aptitudes.forDistance(it.distanceType).ordinal) },
+                { -(aptitudes.forSurface(it.surface).ordinal + aptitudes.forDistance(it.distanceType).ordinal) },
+                { -it.fans },
+            ),
+        ) ?: options.first()
+
+    /**
+     * Applies a character's mandatory races onto the race pool and locked decisions.
+     *
+     * @param scenario Active scenario. Returns inputs unchanged when it is [EXCLUDED_SCENARIO].
+     * @param characterPreset Selected character name, or null. Null returns inputs unchanged.
+     * @param aptitudes The run's aptitudes, used to pick choice-turn options.
+     * @param racesByTurn The base race pool.
+     * @param baseLocks Existing locked decisions (e.g. user manual locks).
+     * @param objectives Parsed objectives keyed by character name.
+     * @return The augmented pool and locks. Mandatory locks override any base lock on the same turn.
+     */
+    fun apply(
+        scenario: String,
+        characterPreset: String?,
+        aptitudes: Aptitudes,
+        racesByTurn: Map<TurnNumber, List<RaceCandidate>>,
+        baseLocks: Map<TurnNumber, Decision>,
+        objectives: Map<String, List<CharacterMandatoryRace>>,
+    ): MandatoryApplication {
+        if (scenario == EXCLUDED_SCENARIO || characterPreset == null) {
+            return MandatoryApplication(racesByTurn, baseLocks)
+        }
+        val charObjectives = objectives[characterPreset] ?: return MandatoryApplication(racesByTurn, baseLocks)
+        val races = racesByTurn.toMutableMap()
+        val locks = baseLocks.toMutableMap()
+        // The objectives data groups by turn, so each character has at most one mandatory race per turn.
+        for (m in charObjectives) {
+            if (m.options.isEmpty()) continue
+            val opt = selectBestOption(m.options, aptitudes)
+            val turnRaces = races[m.turn].orEmpty()
+            val existing = turnRaces.firstOrNull { it.name == opt.raceName }
+            val candidate = existing?.copy(isMandatory = true) ?: syntheticCandidate(m.turn, opt)
+            races[m.turn] = turnRaces.filter { it.name != opt.raceName } + candidate
+            locks[m.turn] = Decision.RaceDecision(candidate.key)
+        }
+        return MandatoryApplication(races, locks)
+    }
+
+    /**
+     * Builds a synthetic [RaceCandidate] for a mandatory race that is not in the race pool
+     * (e.g. a race not present in races.json for that turn).
+     *
+     * @param turn The turn the race occurs on.
+     * @param opt The chosen mandatory race option.
+     * @return A mandatory-flagged candidate with a unique key.
+     */
+    private fun syntheticCandidate(turn: TurnNumber, opt: MandatoryRaceOption): RaceCandidate {
+        val classYear =
+            when {
+                turn <= 24 -> "Junior"
+                turn <= 48 -> "Classic"
+                else -> "Senior"
+            }
+        return RaceCandidate(
+            key = "mandatory-$turn-${opt.raceName}",
+            name = opt.raceName,
+            nameFormatted = opt.raceName,
+            date = "",
+            classYear = classYear,
+            raceTrack = "",
+            grade = opt.grade,
+            terrain = opt.surface,
+            distanceType = opt.distanceType,
+            distanceMeters = 0, // not scraped for objective races
+            fans = opt.fans,
+            turnNumber = turn,
+            isMandatory = true,
+        )
+    }
+}

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/solver/SmartRaceSolverIntegration.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/solver/SmartRaceSolverIntegration.kt
@@ -65,6 +65,10 @@ object SmartRaceSolverIntegration {
      *  `(hash, parsedValue)`. */
     @Volatile private var cachedInlineEpithets: Pair<Int, List<Epithet>>? = null
 
+    @Volatile private var cachedObjectives: Map<String, List<CharacterMandatoryRace>>? = null
+
+    @Volatile private var cachedInlineObjectives: Pair<Int, Map<String, List<CharacterMandatoryRace>>>? = null
+
     /** Race staged by [markPendingRace] awaiting an outcome confirmation via [commitPendingRace]. */
     @Volatile private var pendingRace: RaceWin? = null
 
@@ -572,22 +576,32 @@ object SmartRaceSolverIntegration {
                 ?: loadEpithets()
                 ?: emptyList()
 
+        val scenario = config.optString("scenario", "Trackblazer")
+        val characterPreset = config.optStringOrNull("characterPreset")
+        val aptitudes = parseAptitudesObj(config.optJSONObject("aptitudes"))
+        val manualLocks = parseManualLocks(config.optJSONObject("manualLocks"), racesByTurn)
+        val objectives =
+            parseObjectivesJsonField(config.optStringOrNull("objectivesDataJson"))
+                ?: loadObjectives()
+                ?: emptyMap()
+        val applied = MandatoryRaces.apply(scenario, characterPreset, aptitudes, racesByTurn, manualLocks, objectives)
+
         val state =
             SolverState(
                 currentTurn = 1,
-                scenario = config.optString("scenario", "Trackblazer"),
-                characterPreset = config.optStringOrNull("characterPreset"),
-                aptitudes = parseAptitudesObj(config.optJSONObject("aptitudes")),
-                racesByTurn = racesByTurn,
+                scenario = scenario,
+                characterPreset = characterPreset,
+                aptitudes = aptitudes,
+                racesByTurn = applied.racesByTurn,
                 epithets = epithets,
                 forcedEpithets = jsonStringList(config.optJSONArray("forcedEpithets")).toSet(),
                 targetEpithets = jsonStringList(config.optJSONArray("targetEpithets")).toSet(),
-                lockedDecisions = parseManualLocks(config.optJSONObject("manualLocks"), racesByTurn),
+                lockedDecisions = applied.lockedDecisions,
                 weights = parseWeightsObj(config.optJSONObject("weights")),
             )
 
         val schedule = SmartRaceSolver.solve(state)
-        return serializeSchedule(schedule, racesByTurn)
+        return serializeSchedule(schedule, applied.racesByTurn)
     }
 
     /**
@@ -611,20 +625,25 @@ object SmartRaceSolverIntegration {
         racesByTurn: Map<TurnNumber, List<RaceCandidate>>,
         raceHistorySnapshot: List<RaceWin> = synchronized(raceHistory) { raceHistory.toList() },
         lockedDecisions: Map<TurnNumber, Decision>? = null,
-    ): SolverState =
-        SolverState(
+    ): SolverState {
+        val characterPreset = SettingsHelper.getStringSetting("racing", "smartRaceSolverCharacterPreset").ifEmpty { null }
+        val aptitudes = readUserAptitudes()
+        val baseLocks = lockedDecisions ?: loadManualLocksFromSettings(racesByTurn)
+        val applied = MandatoryRaces.apply(scenario, characterPreset, aptitudes, racesByTurn, baseLocks, loadObjectives() ?: emptyMap())
+        return SolverState(
             currentTurn = currentTurn,
             scenario = scenario,
-            characterPreset = SettingsHelper.getStringSetting("racing", "smartRaceSolverCharacterPreset").ifEmpty { null },
-            aptitudes = readUserAptitudes(),
-            racesByTurn = racesByTurn,
+            characterPreset = characterPreset,
+            aptitudes = aptitudes,
+            racesByTurn = applied.racesByTurn,
             epithets = epithetsForActiveContext(epithets, scenario),
             raceHistory = raceHistorySnapshot,
             forcedEpithets = readStringSet("smartRaceSolverForcedEpithets"),
             targetEpithets = readStringSet("smartRaceSolverTargetEpithets"),
-            lockedDecisions = lockedDecisions ?: loadManualLocksFromSettings(racesByTurn),
+            lockedDecisions = applied.lockedDecisions,
             weights = readWeights(),
         )
+    }
 
     /**
      * Filters [epithets] down to those obtainable in the active scenario AND for the active
@@ -1137,6 +1156,37 @@ object SmartRaceSolverIntegration {
     }
 
     /**
+     * Lazily loads and caches the per-character mandatory races from the `characterObjectivesData` setting.
+     *
+     * @return Map of character name to its mandatory races, or null when the setting is empty or unparseable.
+     */
+    private fun loadObjectives(): Map<String, List<CharacterMandatoryRace>>? {
+        cachedObjectives?.let { return it }
+        val json = SettingsHelper.getStringSetting("racing", "characterObjectivesData")
+        if (json.isEmpty()) return null
+        return runCatching { MandatoryRaces.parse(json) }
+            .onFailure { MessageLog.e(TAG, "Failed to parse characterObjectivesData: ${it.message}") }
+            .getOrNull()
+            ?.also { cachedObjectives = it }
+    }
+
+    /**
+     * Parses the inline objectives payload from a preview config, hash-caching the result like the races and epithets fields.
+     *
+     * @param json The inline objectives JSON, or null/empty to reuse the last cached payload.
+     * @return Parsed objectives map, or null when nothing has been parsed yet.
+     */
+    private fun parseObjectivesJsonField(json: String?): Map<String, List<CharacterMandatoryRace>>? {
+        if (json.isNullOrEmpty()) return cachedInlineObjectives?.second
+        val hash = json.hashCode()
+        cachedInlineObjectives?.let { (cachedHash, value) -> if (cachedHash == hash) return value }
+        return runCatching { MandatoryRaces.parse(json) }
+            .onFailure { MessageLog.e(TAG, "Failed to parse inline objectivesDataJson: ${it.message}") }
+            .getOrNull()
+            ?.also { cachedInlineObjectives = hash to it }
+    }
+
+    /**
      * Parses a races JSON document into a turn-keyed candidate pool. Each entry must include
      * a `turnNumber` field - entries with `turnNumber <= 0` are silently dropped.
      *
@@ -1245,6 +1295,7 @@ object SmartRaceSolverIntegration {
                     entry.put("raceKey", decision.raceKey)
                     entry.put("name", race?.name ?: decision.raceKey)
                     entry.put("grade", race?.grade?.name ?: "")
+                    if (race?.isMandatory == true) entry.put("mandatory", true)
                 }
                 Decision.Train -> entry.put("type", "Train")
                 Decision.Rest -> entry.put("type", "Rest")
@@ -1315,18 +1366,19 @@ object SmartRaceSolverIntegration {
 
         val winsSnapshot = synchronized(raceHistory) { raceHistory.toList() }
         val lossesSnapshot = synchronized(raceLosses) { raceLosses.toList() }
-        val contributionsByTurn = computeEpithetContributionsByTurn(state.epithets, racesByTurn, schedule, winsSnapshot)
+        val contributionsByTurn = computeEpithetContributionsByTurn(state.epithets, state.racesByTurn, schedule, winsSnapshot)
 
         val decisions = JSONObject()
         for ((turn, decision) in schedule.decisions) {
             val entry = JSONObject()
             when (decision) {
                 is Decision.RaceDecision -> {
-                    val race = findCandidate(turn, decision.raceKey, decision.raceKey, racesByTurn)
+                    val race = findCandidate(turn, decision.raceKey, decision.raceKey, state.racesByTurn)
                     entry.put("type", "Race")
                     entry.put("raceKey", decision.raceKey)
                     entry.put("name", race?.name ?: decision.raceKey)
                     entry.put("grade", race?.grade?.name ?: "")
+                    if (race?.isMandatory == true) entry.put("mandatory", true)
                     if (race != null) addRaceDetails(entry, race)
                     contributionsByTurn[turn]?.let { entry.put("contributions", it) }
                 }
@@ -1338,10 +1390,10 @@ object SmartRaceSolverIntegration {
 
         val results = JSONArray()
         for (win in winsSnapshot) {
-            results.put(buildResultEntry(win.turnNumber, win.raceKey, win.name, racesByTurn, RaceOutcome.WIN, contributionsByTurn[win.turnNumber], win.strategy))
+            results.put(buildResultEntry(win.turnNumber, win.raceKey, win.name, state.racesByTurn, RaceOutcome.WIN, contributionsByTurn[win.turnNumber], win.strategy))
         }
         for (loss in lossesSnapshot) {
-            results.put(buildResultEntry(loss.turnNumber, loss.raceKey, loss.name, racesByTurn, RaceOutcome.LOSE, null, loss.strategy))
+            results.put(buildResultEntry(loss.turnNumber, loss.raceKey, loss.name, state.racesByTurn, RaceOutcome.LOSE, null, loss.strategy))
         }
 
         // Always append a synthetic entry for the in-game Junior Make Debut race. This row is purely a visual breadcrumb in the Remote Log
@@ -1415,6 +1467,7 @@ object SmartRaceSolverIntegration {
                 .put("name", race?.name ?: raceName)
                 .put("grade", race?.grade?.name ?: "")
                 .put("outcome", outcome.name)
+        if (race?.isMandatory == true) obj.put("mandatory", true)
         if (race != null) addRaceDetails(obj, race)
         if (strategy.isNotBlank()) obj.put("strategy", strategy)
         if (contributions != null) obj.put("contributions", contributions)

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/solver/SolverState.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/solver/SolverState.kt
@@ -120,6 +120,8 @@ data class Weights(
  * @property distanceMeters Race distance in meters.
  * @property fans Reward fans count. Scaled by [Weights.fanWeight] in [ScoringFunctions.raceValue].
  * @property turnNumber Turn the race takes place on (1..72).
+ * @property isMandatory True when this candidate is a forced career-objective race the solver
+ *   locked onto its turn (not an optional race from the pool). Drives the calendar's mandatory styling.
  */
 data class RaceCandidate(
     val key: String,
@@ -134,6 +136,7 @@ data class RaceCandidate(
     val distanceMeters: Int,
     val fans: Int,
     val turnNumber: TurnNumber,
+    val isMandatory: Boolean = false,
 )
 
 /**

--- a/android/app/src/test/java/com/steve1316/uma_android_automation/bot/solver/MandatoryRacesTest.kt
+++ b/android/app/src/test/java/com/steve1316/uma_android_automation/bot/solver/MandatoryRacesTest.kt
@@ -1,0 +1,114 @@
+package com.steve1316.uma_android_automation.bot.solver
+
+import com.steve1316.uma_android_automation.bot.solver.TestFixtures.race
+import com.steve1316.uma_android_automation.types.Aptitude
+import com.steve1316.uma_android_automation.types.RaceGrade
+import com.steve1316.uma_android_automation.types.TrackDistance
+import com.steve1316.uma_android_automation.types.TrackSurface
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class MandatoryRacesTest {
+    private val sampleJson =
+        """
+        {
+          "Taiki Shuttle": {
+            "name": "Taiki Shuttle",
+            "mandatoryRaces": [
+              { "turn": 25, "isChoice": false, "options": [
+                { "raceName": "Shinzan Kinen", "grade": "G3", "surface": "Turf", "distanceType": "Mile", "fans": 3800 }
+              ] },
+              { "turn": 34, "isChoice": true, "options": [
+                { "raceName": "Japanese Oaks", "grade": "G1", "surface": "Turf", "distanceType": "Medium", "fans": 20000 },
+                { "raceName": "Tokyo Yushun", "grade": "G1", "surface": "Dirt", "distanceType": "Medium", "fans": 20000 }
+              ] }
+            ]
+          }
+        }
+        """.trimIndent()
+
+    @Test
+    fun parsesObjectivesByCharacter() {
+        val parsed = MandatoryRaces.parse(sampleJson)
+        val taiki = parsed["Taiki Shuttle"]
+        assertNotNull(taiki)
+        assertEquals(2, taiki!!.size)
+        assertEquals(25, taiki[0].turn)
+        assertEquals(RaceGrade.G3, taiki[0].options[0].grade)
+        assertEquals(TrackSurface.TURF, taiki[0].options[0].surface)
+        assertEquals(TrackDistance.MILE, taiki[0].options[0].distanceType)
+        assertEquals(3800, taiki[0].options[0].fans)
+        assertTrue(taiki[1].isChoice)
+    }
+
+    @Test
+    fun selectsBestAptitudeOption() {
+        val parsed = MandatoryRaces.parse(sampleJson)
+        val choice = parsed["Taiki Shuttle"]!![1]
+        // Turf A vs Dirt G -> the Turf option (Japanese Oaks) wins.
+        val apt = Aptitudes(Aptitude.A, Aptitude.A, Aptitude.A, Aptitude.A, Aptitude.A, Aptitude.G)
+        assertEquals("Japanese Oaks", MandatoryRaces.selectBestOption(choice.options, apt).raceName)
+    }
+
+    @Test
+    fun trackblazerScenarioAppliesNothing() {
+        val parsed = MandatoryRaces.parse(sampleJson)
+        val races = mapOf(25 to listOf(race("Shinzan Kinen", 25)))
+        val result = MandatoryRaces.apply("Trackblazer", "Taiki Shuttle", Aptitudes.DEFAULT_A, races, emptyMap(), parsed)
+        assertTrue(result.lockedDecisions.isEmpty())
+    }
+
+    @Test
+    fun nullPresetAppliesNothing() {
+        val parsed = MandatoryRaces.parse(sampleJson)
+        val result = MandatoryRaces.apply("URA Finale", null, Aptitudes.DEFAULT_A, emptyMap(), emptyMap(), parsed)
+        assertTrue(result.lockedDecisions.isEmpty())
+    }
+
+    @Test
+    fun unknownPresetAppliesNothing() {
+        val parsed = MandatoryRaces.parse(sampleJson)
+        val races = mapOf(25 to listOf(race("Shinzan Kinen", 25)))
+        val result = MandatoryRaces.apply("URA Finale", "Nonexistent Character", Aptitudes.DEFAULT_A, races, emptyMap(), parsed)
+        assertTrue(result.lockedDecisions.isEmpty())
+        assertEquals(races, result.racesByTurn)
+    }
+
+    @Test
+    fun locksExistingRaceAndFlagsItMandatory() {
+        val parsed = MandatoryRaces.parse(sampleJson)
+        val existing = race("Shinzan Kinen", 25)
+        val races = mapOf(25 to listOf(existing))
+        val result = MandatoryRaces.apply("URA Finale", "Taiki Shuttle", Aptitudes.DEFAULT_A, races, emptyMap(), parsed)
+        val locked = result.lockedDecisions[25]
+        assertTrue(locked is Decision.RaceDecision)
+        val key = (locked as Decision.RaceDecision).raceKey
+        val candidate = result.racesByTurn[25]!!.first { it.key == key }
+        assertTrue(candidate.isMandatory)
+        assertEquals("Shinzan Kinen", candidate.name)
+    }
+
+    @Test
+    fun injectsSyntheticCandidateWhenRaceMissing() {
+        val parsed = MandatoryRaces.parse(sampleJson)
+        // Turn 25 has no candidate in the pool -> a synthetic one is injected and locked.
+        val result = MandatoryRaces.apply("URA Finale", "Taiki Shuttle", Aptitudes.DEFAULT_A, emptyMap(), emptyMap(), parsed)
+        val locked = result.lockedDecisions[25] as Decision.RaceDecision
+        val candidate = result.racesByTurn[25]!!.first { it.key == locked.raceKey }
+        assertTrue(candidate.isMandatory)
+        assertEquals(RaceGrade.G3, candidate.grade)
+        assertEquals(25, candidate.turnNumber)
+    }
+
+    @Test
+    fun mandatoryOverridesManualLock() {
+        val parsed = MandatoryRaces.parse(sampleJson)
+        val existing = race("Shinzan Kinen", 25)
+        val races = mapOf(25 to listOf(existing))
+        val manual = mapOf(25 to Decision.Train as Decision)
+        val result = MandatoryRaces.apply("URA Finale", "Taiki Shuttle", Aptitudes.DEFAULT_A, races, manual, parsed)
+        assertTrue(result.lockedDecisions[25] is Decision.RaceDecision)
+    }
+}

--- a/scripts/data-scraper/main.py
+++ b/scripts/data-scraper/main.py
@@ -1,4 +1,4 @@
-from selenium import webdriver
+﻿from selenium import webdriver
 from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.common.by import By
 from selenium.common.exceptions import NoSuchElementException, ElementClickInterceptedException, WebDriverException
@@ -2082,6 +2082,121 @@ class CharacterPresetScraper(BaseScraper):
         return out if out else None
 
 
+class CharacterObjectivesScraper(BaseScraper):
+    """Scrapes each character's mandatory career-objective races (URA scenario) from GameTora.
+
+    GameTora exposes the URA objectives as a structured manifest data file (`ura-objectives`),
+    joined to character names by `char_id` via the `characters` manifest. The Smart Race Solver
+    uses these to lock the turns the game forces a mandatory race so it never double-books them.
+
+    Output schema (one entry per EN-playable character) -> `src/data/character_objectives.json`:
+
+        {
+            "<character name>": {
+                "name": "<character name>",
+                "mandatoryRaces": [
+                    {
+                        "turn": 25,
+                        "isChoice": false,
+                        "options": [
+                            { "raceName": "Shinzan Kinen", "grade": "G3", "surface": "Turf",
+                              "distanceType": "Mile", "fans": 3800 }
+                        ]
+                    }
+                ]
+            }
+        }
+    """
+
+    # GameTora numeric codes. Debut (900) is intentionally dropped: the Junior Make Debut turn is
+    # pre-debut and already shown via the solver's synthetic display row.
+    GRADE_CODES = {100: "G1", 200: "G2", 300: "G3", 400: "OP", 900: "Debut"}
+    TERRAIN_CODES = {1: "Turf", 2: "Dirt"}
+
+    def __init__(self):
+        super().__init__("", "character_objectives.json")
+
+    @staticmethod
+    def _distance_type(meters: int) -> str:
+        """Buckets a race distance in meters to the app's distance category.
+
+        Mirrors the Kotlin `TrackDistance` thresholds: Sprint <= 1400, Mile <= 1800,
+        Medium <= 2400, otherwise Long.
+
+        Args:
+            meters: Race distance in meters.
+
+        Returns:
+            One of 'Sprint', 'Mile', 'Medium', 'Long'.
+        """
+        if meters <= 1400:
+            return "Sprint"
+        if meters <= 1800:
+            return "Mile"
+        if meters <= 2400:
+            return "Medium"
+        return "Long"
+
+    def start(self):
+        """Fetches the URA objectives + characters manifests and writes the mandatory-race file."""
+        # Full rebuild every run (small, static-ish dataset). Ignore the delta-merge baseline so
+        # characters that left the EN server do not linger in the output.
+        self.data = {}
+
+        objectives = fetch_gametora_manifest_data("ura-objectives")
+        characters = fetch_gametora_manifest_data("characters")
+
+        id_to_name = {c["char_id"]: c.get("en_name") for c in characters if c.get("char_id") and c.get("en_name")}
+        en_playable = {c["char_id"] for c in characters if c.get("char_id") and c.get("playable_en") and c.get("en_name")}
+
+        for entry in objectives:
+            char_id = entry.get("char_id")
+            name = id_to_name.get(char_id)
+            if not name or char_id not in en_playable:
+                continue
+
+            by_turn: Dict[int, List[Dict[str, Any]]] = {}
+            for obj in entry.get("objectives", []):
+                # target_type 1 is a race-placement objective. target_type 3 is the URA Finals.
+                if obj.get("target_type") != 1:
+                    continue
+                turn = obj.get("turn")
+                if not isinstance(turn, int) or turn > 72:  # 72 is the final turn of a URA career.
+                    continue
+                for r in obj.get("races", []):
+                    grade = self.GRADE_CODES.get(r.get("grade"))
+                    if grade is None or grade == "Debut":
+                        continue
+                    meters = r.get("distance", 0)
+                    by_turn.setdefault(turn, []).append(
+                        {
+                            "raceName": r.get("name_en", ""),
+                            "grade": grade,
+                            "surface": self.TERRAIN_CODES.get(r.get("terrain"), "Turf"),
+                            "distanceType": self._distance_type(meters),
+                            "fans": r.get("fans_gained", 0),
+                        }
+                    )
+
+            mandatory_races: List[Dict[str, Any]] = []
+            for turn in sorted(by_turn.keys()):
+                seen = set()
+                deduped: List[Dict[str, Any]] = []
+                for o in by_turn[turn]:
+                    k = (o["raceName"], o["distanceType"], o["surface"])
+                    if k in seen:
+                        continue
+                    seen.add(k)
+                    deduped.append(o)
+                mandatory_races.append({"turn": turn, "isChoice": len(deduped) > 1, "options": deduped})
+
+            if mandatory_races:
+                self.data[name] = {"name": name, "mandatoryRaces": mandatory_races}
+
+        logging.info(f"Scraped mandatory objectives for {len(self.data)} EN-playable characters.")
+        self.save_data()
+
+
 if __name__ == "__main__":
     logging.basicConfig(format="%(asctime)s - %(levelname)s - %(message)s", level=logging.INFO)
     start_time = time.time()
@@ -2105,6 +2220,9 @@ if __name__ == "__main__":
 
     character_preset_scraper = CharacterPresetScraper()
     character_preset_scraper.start()
+
+    character_objectives_scraper = CharacterObjectivesScraper()
+    character_objectives_scraper.start()
 
     end_time = round(time.time() - start_time, 2)
     logging.info(f"Total time for processing all applications: {end_time} seconds or {round(end_time / 60, 2)} minutes.")

--- a/src/data/README.md
+++ b/src/data/README.md
@@ -19,3 +19,4 @@ See [`scripts/data-scraper/README.md`](../../scripts/data-scraper/README.md) for
 - `scenarios.json`: Scenario-specific event data (e.g., URA, Unity Cup, Trackblazer). This is updated manually to include special event overrides and logic for each scenario.
 - `epithets.json`: Smart Race Solver nickname / epithet definitions. Scraper-owned fields are refreshed; `dependsOn` and `matchers` are hand-curated and preserved across re-scrapes.
 - `characterPresets.json`: Smart Race Solver starting aptitudes per character.
+- `character_objectives.json`: Per-character mandatory career-objective races for the URA scenario. Produced by the `CharacterObjectivesScraper` in `scripts/data-scraper/main.py`. Consumed by the Smart Race Solver to lock the turns the game forces a mandatory race so it does not schedule optional races or training on those turns.

--- a/src/data/character_objectives.json
+++ b/src/data/character_objectives.json
@@ -1,0 +1,6272 @@
+{
+    "Admire Vega": {
+        "name": "Admire Vega",
+        "mandatoryRaces": [
+            {
+                "turn": 24,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Hopeful Stakes",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 7000
+                    }
+                ]
+            },
+            {
+                "turn": 31,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Satsuki Sho",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 11000
+                    }
+                ]
+            },
+            {
+                "turn": 34,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tokyo Yushun (Japanese Derby)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 20000
+                    }
+                ]
+            },
+            {
+                "turn": 44,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Kikuka Sho",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 12000
+                    }
+                ]
+            },
+            {
+                "turn": 60,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Takarazuka Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 68,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tenno Sho (Autumn)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 70,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Japan Cup",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 30000
+                    }
+                ]
+            }
+        ]
+    },
+    "Agnes Digital": {
+        "name": "Agnes Digital",
+        "mandatoryRaces": [
+            {
+                "turn": 28,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Hyacinth Stakes",
+                        "grade": "OP",
+                        "surface": "Dirt",
+                        "distanceType": "Mile",
+                        "fans": 1900
+                    }
+                ]
+            },
+            {
+                "turn": 33,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "NHK Mile Cup",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Mile",
+                        "fans": 10500
+                    }
+                ]
+            },
+            {
+                "turn": 37,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Japan Dirt Derby",
+                        "grade": "G1",
+                        "surface": "Dirt",
+                        "distanceType": "Medium",
+                        "fans": 4500
+                    }
+                ]
+            },
+            {
+                "turn": 46,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Mile Championship",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Mile",
+                        "fans": 11000
+                    }
+                ]
+            },
+            {
+                "turn": 68,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tenno Sho (Autumn)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 15000
+                    }
+                ]
+            }
+        ]
+    },
+    "Agnes Tachyon": {
+        "name": "Agnes Tachyon",
+        "mandatoryRaces": [
+            {
+                "turn": 29,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Yayoi Sho",
+                        "grade": "G2",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 5400
+                    }
+                ]
+            },
+            {
+                "turn": 31,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Satsuki Sho",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 11000
+                    }
+                ]
+            },
+            {
+                "turn": 33,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "NHK Mile Cup",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Mile",
+                        "fans": 10500
+                    }
+                ]
+            },
+            {
+                "turn": 34,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tokyo Yushun (Japanese Derby)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 20000
+                    }
+                ]
+            },
+            {
+                "turn": 44,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Kikuka Sho",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 12000
+                    }
+                ]
+            },
+            {
+                "turn": 54,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Osaka Hai",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 13500
+                    }
+                ]
+            },
+            {
+                "turn": 60,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Takarazuka Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 68,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tenno Sho (Autumn)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 72,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Arima Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 30000
+                    }
+                ]
+            }
+        ]
+    },
+    "Air Groove": {
+        "name": "Air Groove",
+        "mandatoryRaces": [
+            {
+                "turn": 23,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Hanshin Juvenile Fillies",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Mile",
+                        "fans": 6500
+                    }
+                ]
+            },
+            {
+                "turn": 31,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Oka Sho",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Mile",
+                        "fans": 10500
+                    }
+                ]
+            },
+            {
+                "turn": 34,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Japanese Oaks",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 11000
+                    }
+                ]
+            },
+            {
+                "turn": 44,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Shuka Sho",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 10000
+                    }
+                ]
+            },
+            {
+                "turn": 54,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Osaka Hai",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 13500
+                    }
+                ]
+            },
+            {
+                "turn": 60,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Takarazuka Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 64,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Sapporo Kinen",
+                        "grade": "G2",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 7000
+                    }
+                ]
+            },
+            {
+                "turn": 68,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tenno Sho (Autumn)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 15000
+                    }
+                ]
+            }
+        ]
+    },
+    "Biwa Hayahide": {
+        "name": "Biwa Hayahide",
+        "mandatoryRaces": [
+            {
+                "turn": 23,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Asahi Hai Futurity Stakes",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Mile",
+                        "fans": 7000
+                    }
+                ]
+            },
+            {
+                "turn": 31,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Satsuki Sho",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 11000
+                    }
+                ]
+            },
+            {
+                "turn": 34,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tokyo Yushun (Japanese Derby)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 20000
+                    }
+                ]
+            },
+            {
+                "turn": 44,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Kikuka Sho",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 12000
+                    }
+                ]
+            },
+            {
+                "turn": 56,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tenno Sho (Spring)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 60,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Takarazuka Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 68,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tenno Sho (Autumn)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 72,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Arima Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 30000
+                    }
+                ]
+            }
+        ]
+    },
+    "Curren Chan": {
+        "name": "Curren Chan",
+        "mandatoryRaces": [
+            {
+                "turn": 29,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Fillies' Revue",
+                        "grade": "G2",
+                        "surface": "Turf",
+                        "distanceType": "Sprint",
+                        "fans": 5200
+                    }
+                ]
+            },
+            {
+                "turn": 34,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Aoi Stakes",
+                        "grade": "G3",
+                        "surface": "Turf",
+                        "distanceType": "Sprint",
+                        "fans": 3800
+                    }
+                ]
+            },
+            {
+                "turn": 36,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Hakodate Sprint Stakes",
+                        "grade": "G3",
+                        "surface": "Turf",
+                        "distanceType": "Sprint",
+                        "fans": 3900
+                    }
+                ]
+            },
+            {
+                "turn": 42,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Sprinters Stakes",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Sprint",
+                        "fans": 13000
+                    }
+                ]
+            },
+            {
+                "turn": 53,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Ocean Stakes",
+                        "grade": "G3",
+                        "surface": "Turf",
+                        "distanceType": "Sprint",
+                        "fans": 4100
+                    }
+                ]
+            },
+            {
+                "turn": 54,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Takamatsunomiya Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Sprint",
+                        "fans": 13000
+                    }
+                ]
+            },
+            {
+                "turn": 66,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Sprinters Stakes",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Sprint",
+                        "fans": 13000
+                    }
+                ]
+            }
+        ]
+    },
+    "Daiwa Scarlet": {
+        "name": "Daiwa Scarlet",
+        "mandatoryRaces": [
+            {
+                "turn": 29,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tulip Sho",
+                        "grade": "G2",
+                        "surface": "Turf",
+                        "distanceType": "Mile",
+                        "fans": 5200
+                    }
+                ]
+            },
+            {
+                "turn": 31,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Oka Sho",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Mile",
+                        "fans": 10500
+                    }
+                ]
+            },
+            {
+                "turn": 34,
+                "isChoice": true,
+                "options": [
+                    {
+                        "raceName": "Japanese Oaks",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 11000
+                    },
+                    {
+                        "raceName": "Tokyo Yushun (Japanese Derby)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 20000
+                    }
+                ]
+            },
+            {
+                "turn": 44,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Shuka Sho",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 10000
+                    }
+                ]
+            },
+            {
+                "turn": 45,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Queen Elizabeth II Cup",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 10500
+                    }
+                ]
+            },
+            {
+                "turn": 54,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Osaka Hai",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 13500
+                    }
+                ]
+            },
+            {
+                "turn": 68,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tenno Sho (Autumn)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 72,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Arima Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 30000
+                    }
+                ]
+            }
+        ]
+    },
+    "Eishin Flash": {
+        "name": "Eishin Flash",
+        "mandatoryRaces": [
+            {
+                "turn": 25,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Keisei Hai",
+                        "grade": "G3",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 3800
+                    }
+                ]
+            },
+            {
+                "turn": 31,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Satsuki Sho",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 11000
+                    }
+                ]
+            },
+            {
+                "turn": 34,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tokyo Yushun (Japanese Derby)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 20000
+                    }
+                ]
+            },
+            {
+                "turn": 46,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Japan Cup",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 30000
+                    }
+                ]
+            },
+            {
+                "turn": 48,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Arima Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 30000
+                    }
+                ]
+            },
+            {
+                "turn": 54,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Osaka Hai",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 13500
+                    }
+                ]
+            },
+            {
+                "turn": 56,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tenno Sho (Spring)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 68,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tenno Sho (Autumn)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 72,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Arima Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 30000
+                    }
+                ]
+            }
+        ]
+    },
+    "El Condor Pasa": {
+        "name": "El Condor Pasa",
+        "mandatoryRaces": [
+            {
+                "turn": 27,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Kyodo News Hai",
+                        "grade": "G3",
+                        "surface": "Turf",
+                        "distanceType": "Mile",
+                        "fans": 3800
+                    }
+                ]
+            },
+            {
+                "turn": 33,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "NHK Mile Cup",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Mile",
+                        "fans": 10500
+                    }
+                ]
+            },
+            {
+                "turn": 34,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tokyo Yushun (Japanese Derby)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 20000
+                    }
+                ]
+            },
+            {
+                "turn": 43,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Mainichi Okan",
+                        "grade": "G2",
+                        "surface": "Turf",
+                        "distanceType": "Mile",
+                        "fans": 6700
+                    }
+                ]
+            },
+            {
+                "turn": 60,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Takarazuka Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 70,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Japan Cup",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 30000
+                    }
+                ]
+            },
+            {
+                "turn": 72,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Arima Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 30000
+                    }
+                ]
+            }
+        ]
+    },
+    "Fine Motion": {
+        "name": "Fine Motion",
+        "mandatoryRaces": [
+            {
+                "turn": 31,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Oka Sho",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Mile",
+                        "fans": 10500
+                    }
+                ]
+            },
+            {
+                "turn": 34,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Japanese Oaks",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 11000
+                    }
+                ]
+            },
+            {
+                "turn": 44,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Shuka Sho",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 10000
+                    }
+                ]
+            },
+            {
+                "turn": 45,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Queen Elizabeth II Cup",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 10500
+                    }
+                ]
+            },
+            {
+                "turn": 54,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Osaka Hai",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 13500
+                    }
+                ]
+            },
+            {
+                "turn": 60,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Takarazuka Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 64,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Sapporo Kinen",
+                        "grade": "G2",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 7000
+                    }
+                ]
+            },
+            {
+                "turn": 68,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tenno Sho (Autumn)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 69,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Queen Elizabeth II Cup",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 10500
+                    }
+                ]
+            },
+            {
+                "turn": 70,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Mile Championship",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Mile",
+                        "fans": 11000
+                    }
+                ]
+            },
+            {
+                "turn": 72,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Arima Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 30000
+                    }
+                ]
+            }
+        ]
+    },
+    "Fuji Kiseki": {
+        "name": "Fuji Kiseki",
+        "mandatoryRaces": [
+            {
+                "turn": 23,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Asahi Hai Futurity Stakes",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Mile",
+                        "fans": 7000
+                    }
+                ]
+            },
+            {
+                "turn": 29,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Yayoi Sho",
+                        "grade": "G2",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 5400
+                    }
+                ]
+            },
+            {
+                "turn": 31,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Satsuki Sho",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 11000
+                    }
+                ]
+            },
+            {
+                "turn": 33,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "NHK Mile Cup",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Mile",
+                        "fans": 10500
+                    }
+                ]
+            },
+            {
+                "turn": 34,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tokyo Yushun (Japanese Derby)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 20000
+                    }
+                ]
+            },
+            {
+                "turn": 44,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Kikuka Sho",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 12000
+                    }
+                ]
+            },
+            {
+                "turn": 46,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Mile Championship",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Mile",
+                        "fans": 11000
+                    }
+                ]
+            },
+            {
+                "turn": 54,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Takamatsunomiya Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Sprint",
+                        "fans": 13000
+                    }
+                ]
+            },
+            {
+                "turn": 59,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Yasuda Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Mile",
+                        "fans": 13000
+                    }
+                ]
+            },
+            {
+                "turn": 68,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tenno Sho (Autumn)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 72,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Arima Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 30000
+                    }
+                ]
+            }
+        ]
+    },
+    "Gold City": {
+        "name": "Gold City",
+        "mandatoryRaces": [
+            {
+                "turn": 23,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Hanshin Juvenile Fillies",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Mile",
+                        "fans": 6500
+                    }
+                ]
+            },
+            {
+                "turn": 31,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Satsuki Sho",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 11000
+                    }
+                ]
+            },
+            {
+                "turn": 34,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tokyo Yushun (Japanese Derby)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 20000
+                    }
+                ]
+            },
+            {
+                "turn": 44,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Kikuka Sho",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 12000
+                    }
+                ]
+            },
+            {
+                "turn": 48,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Arima Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 30000
+                    }
+                ]
+            },
+            {
+                "turn": 54,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Osaka Hai",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 13500
+                    }
+                ]
+            },
+            {
+                "turn": 56,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tenno Sho (Spring)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 60,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Takarazuka Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 70,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Japan Cup",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 30000
+                    }
+                ]
+            }
+        ]
+    },
+    "Gold Ship": {
+        "name": "Gold Ship",
+        "mandatoryRaces": [
+            {
+                "turn": 24,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Hopeful Stakes",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 7000
+                    }
+                ]
+            },
+            {
+                "turn": 31,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Satsuki Sho",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 11000
+                    }
+                ]
+            },
+            {
+                "turn": 44,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Kikuka Sho",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 12000
+                    }
+                ]
+            },
+            {
+                "turn": 48,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Arima Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 30000
+                    }
+                ]
+            },
+            {
+                "turn": 56,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tenno Sho (Spring)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 60,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Takarazuka Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 68,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tenno Sho (Autumn)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 72,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Arima Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 30000
+                    }
+                ]
+            }
+        ]
+    },
+    "Grass Wonder": {
+        "name": "Grass Wonder",
+        "mandatoryRaces": [
+            {
+                "turn": 23,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Asahi Hai Futurity Stakes",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Mile",
+                        "fans": 7000
+                    }
+                ]
+            },
+            {
+                "turn": 34,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tokyo Yushun (Japanese Derby)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 20000
+                    }
+                ]
+            },
+            {
+                "turn": 46,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Japan Cup",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 30000
+                    }
+                ]
+            },
+            {
+                "turn": 48,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Arima Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 30000
+                    }
+                ]
+            },
+            {
+                "turn": 60,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Takarazuka Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 67,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Mainichi Okan",
+                        "grade": "G2",
+                        "surface": "Turf",
+                        "distanceType": "Mile",
+                        "fans": 6700
+                    }
+                ]
+            },
+            {
+                "turn": 72,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Arima Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 30000
+                    }
+                ]
+            }
+        ]
+    },
+    "Haru Urara": {
+        "name": "Haru Urara",
+        "mandatoryRaces": [
+            {
+                "turn": 50,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Negishi Stakes",
+                        "grade": "G3",
+                        "surface": "Dirt",
+                        "distanceType": "Sprint",
+                        "fans": 3800
+                    }
+                ]
+            },
+            {
+                "turn": 52,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "February Stakes",
+                        "grade": "G1",
+                        "surface": "Dirt",
+                        "distanceType": "Mile",
+                        "fans": 10000
+                    }
+                ]
+            },
+            {
+                "turn": 63,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Elm Stakes",
+                        "grade": "G3",
+                        "surface": "Dirt",
+                        "distanceType": "Mile",
+                        "fans": 3600
+                    }
+                ]
+            },
+            {
+                "turn": 69,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "JBC Sprint",
+                        "grade": "G1",
+                        "surface": "Dirt",
+                        "distanceType": "Sprint",
+                        "fans": 6000
+                    }
+                ]
+            },
+            {
+                "turn": 72,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Arima Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 30000
+                    }
+                ]
+            }
+        ]
+    },
+    "Hishi Akebono": {
+        "name": "Hishi Akebono",
+        "mandatoryRaces": [
+            {
+                "turn": 42,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Sprinters Stakes",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Sprint",
+                        "fans": 13000
+                    }
+                ]
+            },
+            {
+                "turn": 44,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Swan Stakes",
+                        "grade": "G2",
+                        "surface": "Turf",
+                        "distanceType": "Sprint",
+                        "fans": 5900
+                    }
+                ]
+            },
+            {
+                "turn": 46,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Mile Championship",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Mile",
+                        "fans": 11000
+                    }
+                ]
+            },
+            {
+                "turn": 54,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Takamatsunomiya Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Sprint",
+                        "fans": 13000
+                    }
+                ]
+            },
+            {
+                "turn": 59,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Yasuda Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Mile",
+                        "fans": 13000
+                    }
+                ]
+            },
+            {
+                "turn": 66,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Sprinters Stakes",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Sprint",
+                        "fans": 13000
+                    }
+                ]
+            },
+            {
+                "turn": 70,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Mile Championship",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Mile",
+                        "fans": 11000
+                    }
+                ]
+            }
+        ]
+    },
+    "Hishi Amazon": {
+        "name": "Hishi Amazon",
+        "mandatoryRaces": [
+            {
+                "turn": 23,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Hanshin Juvenile Fillies",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Mile",
+                        "fans": 6500
+                    }
+                ]
+            },
+            {
+                "turn": 31,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Oka Sho",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Mile",
+                        "fans": 10500
+                    }
+                ]
+            },
+            {
+                "turn": 34,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Japanese Oaks",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 11000
+                    }
+                ]
+            },
+            {
+                "turn": 44,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Shuka Sho",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 10000
+                    }
+                ]
+            },
+            {
+                "turn": 48,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Arima Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 30000
+                    }
+                ]
+            },
+            {
+                "turn": 54,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Osaka Hai",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 13500
+                    }
+                ]
+            },
+            {
+                "turn": 59,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Yasuda Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Mile",
+                        "fans": 13000
+                    }
+                ]
+            },
+            {
+                "turn": 70,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Japan Cup",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 30000
+                    }
+                ]
+            },
+            {
+                "turn": 72,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Arima Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 30000
+                    }
+                ]
+            }
+        ]
+    },
+    "Inari One": {
+        "name": "Inari One",
+        "mandatoryRaces": [
+            {
+                "turn": 37,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Japan Dirt Derby",
+                        "grade": "G1",
+                        "surface": "Dirt",
+                        "distanceType": "Medium",
+                        "fans": 4500
+                    }
+                ]
+            },
+            {
+                "turn": 48,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tokyo Daishoten",
+                        "grade": "G1",
+                        "surface": "Dirt",
+                        "distanceType": "Medium",
+                        "fans": 8000
+                    }
+                ]
+            },
+            {
+                "turn": 56,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tenno Sho (Spring)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 60,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Takarazuka Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 67,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Mainichi Okan",
+                        "grade": "G2",
+                        "surface": "Turf",
+                        "distanceType": "Mile",
+                        "fans": 6700
+                    }
+                ]
+            },
+            {
+                "turn": 68,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tenno Sho (Autumn)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 72,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Arima Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 30000
+                    }
+                ]
+            }
+        ]
+    },
+    "Ines Fujin": {
+        "name": "Ines Fujin",
+        "mandatoryRaces": [
+            {
+                "turn": 23,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Asahi Hai Futurity Stakes",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Mile",
+                        "fans": 7000
+                    }
+                ]
+            },
+            {
+                "turn": 31,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Satsuki Sho",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 11000
+                    }
+                ]
+            },
+            {
+                "turn": 34,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tokyo Yushun (Japanese Derby)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 20000
+                    }
+                ]
+            },
+            {
+                "turn": 44,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Kikuka Sho",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 12000
+                    }
+                ]
+            },
+            {
+                "turn": 54,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Osaka Hai",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 13500
+                    }
+                ]
+            },
+            {
+                "turn": 60,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Takarazuka Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 68,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tenno Sho (Autumn)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 70,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Japan Cup",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 30000
+                    }
+                ]
+            },
+            {
+                "turn": 72,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Arima Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 30000
+                    }
+                ]
+            }
+        ]
+    },
+    "Kawakami Princess": {
+        "name": "Kawakami Princess",
+        "mandatoryRaces": [
+            {
+                "turn": 34,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Japanese Oaks",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 11000
+                    }
+                ]
+            },
+            {
+                "turn": 44,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Shuka Sho",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 10000
+                    }
+                ]
+            },
+            {
+                "turn": 45,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Queen Elizabeth II Cup",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 10500
+                    }
+                ]
+            },
+            {
+                "turn": 53,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Kinko Sho",
+                        "grade": "G2",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 6700
+                    }
+                ]
+            },
+            {
+                "turn": 57,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Victoria Mile",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Mile",
+                        "fans": 10500
+                    }
+                ]
+            },
+            {
+                "turn": 60,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Takarazuka Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 69,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Queen Elizabeth II Cup",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 10500
+                    }
+                ]
+            }
+        ]
+    },
+    "King Halo": {
+        "name": "King Halo",
+        "mandatoryRaces": [
+            {
+                "turn": 24,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Hopeful Stakes",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 7000
+                    }
+                ]
+            },
+            {
+                "turn": 31,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Satsuki Sho",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 11000
+                    }
+                ]
+            },
+            {
+                "turn": 34,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tokyo Yushun (Japanese Derby)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 20000
+                    }
+                ]
+            },
+            {
+                "turn": 44,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Kikuka Sho",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 12000
+                    }
+                ]
+            },
+            {
+                "turn": 54,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Takamatsunomiya Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Sprint",
+                        "fans": 13000
+                    }
+                ]
+            },
+            {
+                "turn": 59,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Yasuda Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Mile",
+                        "fans": 13000
+                    }
+                ]
+            },
+            {
+                "turn": 66,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Sprinters Stakes",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Sprint",
+                        "fans": 13000
+                    }
+                ]
+            },
+            {
+                "turn": 68,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tenno Sho (Autumn)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 15000
+                    }
+                ]
+            }
+        ]
+    },
+    "Kitasan Black": {
+        "name": "Kitasan Black",
+        "mandatoryRaces": [
+            {
+                "turn": 42,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "St. Lite Kinen",
+                        "grade": "G2",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 5400
+                    }
+                ]
+            },
+            {
+                "turn": 44,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Kikuka Sho",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 12000
+                    }
+                ]
+            },
+            {
+                "turn": 48,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Arima Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 30000
+                    }
+                ]
+            },
+            {
+                "turn": 54,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Osaka Hai",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 13500
+                    }
+                ]
+            },
+            {
+                "turn": 56,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tenno Sho (Spring)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 60,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Takarazuka Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 68,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tenno Sho (Autumn)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 70,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Japan Cup",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 30000
+                    }
+                ]
+            },
+            {
+                "turn": 72,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Arima Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 30000
+                    }
+                ]
+            }
+        ]
+    },
+    "Manhattan Cafe": {
+        "name": "Manhattan Cafe",
+        "mandatoryRaces": [
+            {
+                "turn": 29,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Yayoi Sho",
+                        "grade": "G2",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 5400
+                    }
+                ]
+            },
+            {
+                "turn": 42,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "St. Lite Kinen",
+                        "grade": "G2",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 5400
+                    }
+                ]
+            },
+            {
+                "turn": 44,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Kikuka Sho",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 12000
+                    }
+                ]
+            },
+            {
+                "turn": 48,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Arima Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 30000
+                    }
+                ]
+            },
+            {
+                "turn": 56,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tenno Sho (Spring)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 60,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Takarazuka Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 70,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Japan Cup",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 30000
+                    }
+                ]
+            },
+            {
+                "turn": 72,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Arima Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 30000
+                    }
+                ]
+            }
+        ]
+    },
+    "Maruzensky": {
+        "name": "Maruzensky",
+        "mandatoryRaces": [
+            {
+                "turn": 23,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Asahi Hai Futurity Stakes",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Mile",
+                        "fans": 7000
+                    }
+                ]
+            },
+            {
+                "turn": 30,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Spring Stakes",
+                        "grade": "G2",
+                        "surface": "Turf",
+                        "distanceType": "Mile",
+                        "fans": 5400
+                    }
+                ]
+            },
+            {
+                "turn": 31,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Satsuki Sho",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 11000
+                    }
+                ]
+            },
+            {
+                "turn": 34,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tokyo Yushun (Japanese Derby)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 20000
+                    }
+                ]
+            },
+            {
+                "turn": 48,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Arima Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 30000
+                    }
+                ]
+            },
+            {
+                "turn": 54,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Osaka Hai",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 13500
+                    }
+                ]
+            },
+            {
+                "turn": 59,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Yasuda Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Mile",
+                        "fans": 13000
+                    }
+                ]
+            },
+            {
+                "turn": 68,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tenno Sho (Autumn)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 15000
+                    }
+                ]
+            }
+        ]
+    },
+    "Matikanefukukitaru": {
+        "name": "Matikanefukukitaru",
+        "mandatoryRaces": [
+            {
+                "turn": 29,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Yayoi Sho",
+                        "grade": "G2",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 5400
+                    }
+                ]
+            },
+            {
+                "turn": 30,
+                "isChoice": true,
+                "options": [
+                    {
+                        "raceName": "Spring Stakes",
+                        "grade": "G2",
+                        "surface": "Turf",
+                        "distanceType": "Mile",
+                        "fans": 5400
+                    },
+                    {
+                        "raceName": "Mainichi Hai",
+                        "grade": "G3",
+                        "surface": "Turf",
+                        "distanceType": "Mile",
+                        "fans": 3800
+                    }
+                ]
+            },
+            {
+                "turn": 34,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tokyo Yushun (Japanese Derby)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 20000
+                    }
+                ]
+            },
+            {
+                "turn": 44,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Kikuka Sho",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 12000
+                    }
+                ]
+            },
+            {
+                "turn": 53,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Kinko Sho",
+                        "grade": "G2",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 6700
+                    }
+                ]
+            },
+            {
+                "turn": 60,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Takarazuka Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 61,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Hakodate Kinen",
+                        "grade": "G3",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 4100
+                    }
+                ]
+            },
+            {
+                "turn": 63,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Kokura Kinen",
+                        "grade": "G3",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 4100
+                    }
+                ]
+            },
+            {
+                "turn": 64,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Sapporo Kinen",
+                        "grade": "G2",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 7000
+                    }
+                ]
+            },
+            {
+                "turn": 72,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Arima Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 30000
+                    }
+                ]
+            }
+        ]
+    },
+    "Matikanetannhauser": {
+        "name": "Matikanetannhauser",
+        "mandatoryRaces": [
+            {
+                "turn": 31,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Satsuki Sho",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 11000
+                    }
+                ]
+            },
+            {
+                "turn": 34,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tokyo Yushun (Japanese Derby)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 20000
+                    }
+                ]
+            },
+            {
+                "turn": 44,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Kikuka Sho",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 12000
+                    }
+                ]
+            },
+            {
+                "turn": 52,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Diamond Stakes",
+                        "grade": "G3",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 4100
+                    }
+                ]
+            },
+            {
+                "turn": 56,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tenno Sho (Spring)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 60,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Takarazuka Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 70,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Japan Cup",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 30000
+                    }
+                ]
+            },
+            {
+                "turn": 72,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Arima Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 30000
+                    }
+                ]
+            }
+        ]
+    },
+    "Mayano Top Gun": {
+        "name": "Mayano Top Gun",
+        "mandatoryRaces": [
+            {
+                "turn": 44,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Kikuka Sho",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 12000
+                    }
+                ]
+            },
+            {
+                "turn": 48,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Arima Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 30000
+                    }
+                ]
+            },
+            {
+                "turn": 54,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Hanshin Daishoten",
+                        "grade": "G2",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 6700
+                    }
+                ]
+            },
+            {
+                "turn": 56,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tenno Sho (Spring)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 60,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Takarazuka Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 68,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tenno Sho (Autumn)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 72,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Arima Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 30000
+                    }
+                ]
+            }
+        ]
+    },
+    "Meisho Doto": {
+        "name": "Meisho Doto",
+        "mandatoryRaces": [
+            {
+                "turn": 49,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Nikkei Shinshun Hai",
+                        "grade": "G2",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 5700
+                    }
+                ]
+            },
+            {
+                "turn": 53,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Kinko Sho",
+                        "grade": "G2",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 6700
+                    }
+                ]
+            },
+            {
+                "turn": 60,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Takarazuka Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 68,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tenno Sho (Autumn)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 70,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Japan Cup",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 30000
+                    }
+                ]
+            },
+            {
+                "turn": 72,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Arima Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 30000
+                    }
+                ]
+            }
+        ]
+    },
+    "Mejiro Ardan": {
+        "name": "Mejiro Ardan",
+        "mandatoryRaces": [
+            {
+                "turn": 32,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Aoba Sho",
+                        "grade": "G2",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 5400
+                    }
+                ]
+            },
+            {
+                "turn": 34,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tokyo Yushun (Japanese Derby)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 20000
+                    }
+                ]
+            },
+            {
+                "turn": 44,
+                "isChoice": true,
+                "options": [
+                    {
+                        "raceName": "Kikuka Sho",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 12000
+                    },
+                    {
+                        "raceName": "Tenno Sho (Autumn)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 54,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Osaka Hai",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 13500
+                    }
+                ]
+            },
+            {
+                "turn": 60,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Takarazuka Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 67,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Mainichi Okan",
+                        "grade": "G2",
+                        "surface": "Turf",
+                        "distanceType": "Mile",
+                        "fans": 6700
+                    }
+                ]
+            },
+            {
+                "turn": 68,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tenno Sho (Autumn)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 15000
+                    }
+                ]
+            }
+        ]
+    },
+    "Mejiro Bright": {
+        "name": "Mejiro Bright",
+        "mandatoryRaces": [
+            {
+                "turn": 24,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Hopeful Stakes",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 7000
+                    }
+                ]
+            },
+            {
+                "turn": 31,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Satsuki Sho",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 11000
+                    }
+                ]
+            },
+            {
+                "turn": 34,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tokyo Yushun (Japanese Derby)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 20000
+                    }
+                ]
+            },
+            {
+                "turn": 44,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Kikuka Sho",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 12000
+                    }
+                ]
+            },
+            {
+                "turn": 47,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Stayers Stakes",
+                        "grade": "G2",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 6200
+                    }
+                ]
+            },
+            {
+                "turn": 56,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tenno Sho (Spring)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 68,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tenno Sho (Autumn)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 72,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Arima Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 30000
+                    }
+                ]
+            }
+        ]
+    },
+    "Mejiro Dober": {
+        "name": "Mejiro Dober",
+        "mandatoryRaces": [
+            {
+                "turn": 23,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Hanshin Juvenile Fillies",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Mile",
+                        "fans": 6500
+                    }
+                ]
+            },
+            {
+                "turn": 31,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Oka Sho",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Mile",
+                        "fans": 10500
+                    }
+                ]
+            },
+            {
+                "turn": 34,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Japanese Oaks",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 11000
+                    }
+                ]
+            },
+            {
+                "turn": 44,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Shuka Sho",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 10000
+                    }
+                ]
+            },
+            {
+                "turn": 48,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Arima Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 30000
+                    }
+                ]
+            },
+            {
+                "turn": 54,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Osaka Hai",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 13500
+                    }
+                ]
+            },
+            {
+                "turn": 60,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Takarazuka Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 67,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Fuchu Umamusume Stakes",
+                        "grade": "G2",
+                        "surface": "Turf",
+                        "distanceType": "Mile",
+                        "fans": 5500
+                    }
+                ]
+            },
+            {
+                "turn": 69,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Queen Elizabeth II Cup",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 10500
+                    }
+                ]
+            }
+        ]
+    },
+    "Mejiro McQueen": {
+        "name": "Mejiro McQueen",
+        "mandatoryRaces": [
+            {
+                "turn": 42,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Kobe Shimbun Hai",
+                        "grade": "G2",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 5400
+                    }
+                ]
+            },
+            {
+                "turn": 44,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Kikuka Sho",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 12000
+                    }
+                ]
+            },
+            {
+                "turn": 56,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tenno Sho (Spring)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 60,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Takarazuka Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 68,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tenno Sho (Autumn)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 15000
+                    }
+                ]
+            }
+        ]
+    },
+    "Mejiro Palmer": {
+        "name": "Mejiro Palmer",
+        "mandatoryRaces": [
+            {
+                "turn": 37,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Hakodate Kinen",
+                        "grade": "G3",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 4100
+                    }
+                ]
+            },
+            {
+                "turn": 49,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Nikkei Shinshun Hai",
+                        "grade": "G2",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 5700
+                    }
+                ]
+            },
+            {
+                "turn": 56,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tenno Sho (Spring)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 60,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Takarazuka Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 68,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tenno Sho (Autumn)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 72,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Arima Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 30000
+                    }
+                ]
+            }
+        ]
+    },
+    "Mejiro Ryan": {
+        "name": "Mejiro Ryan",
+        "mandatoryRaces": [
+            {
+                "turn": 25,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Junior Cup",
+                        "grade": "OP",
+                        "surface": "Turf",
+                        "distanceType": "Mile",
+                        "fans": 2000
+                    }
+                ]
+            },
+            {
+                "turn": 31,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Satsuki Sho",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 11000
+                    }
+                ]
+            },
+            {
+                "turn": 34,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tokyo Yushun (Japanese Derby)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 20000
+                    }
+                ]
+            },
+            {
+                "turn": 44,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Kikuka Sho",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 12000
+                    }
+                ]
+            },
+            {
+                "turn": 48,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Arima Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 30000
+                    }
+                ]
+            },
+            {
+                "turn": 56,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tenno Sho (Spring)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 60,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Takarazuka Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 72,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Arima Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 30000
+                    }
+                ]
+            }
+        ]
+    },
+    "Mihono Bourbon": {
+        "name": "Mihono Bourbon",
+        "mandatoryRaces": [
+            {
+                "turn": 23,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Asahi Hai Futurity Stakes",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Mile",
+                        "fans": 7000
+                    }
+                ]
+            },
+            {
+                "turn": 30,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Spring Stakes",
+                        "grade": "G2",
+                        "surface": "Turf",
+                        "distanceType": "Mile",
+                        "fans": 5400
+                    }
+                ]
+            },
+            {
+                "turn": 31,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Satsuki Sho",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 11000
+                    }
+                ]
+            },
+            {
+                "turn": 34,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tokyo Yushun (Japanese Derby)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 20000
+                    }
+                ]
+            },
+            {
+                "turn": 44,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Kikuka Sho",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 12000
+                    }
+                ]
+            },
+            {
+                "turn": 56,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tenno Sho (Spring)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 70,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Japan Cup",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 30000
+                    }
+                ]
+            },
+            {
+                "turn": 72,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Arima Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 30000
+                    }
+                ]
+            }
+        ]
+    },
+    "Narita Brian": {
+        "name": "Narita Brian",
+        "mandatoryRaces": [
+            {
+                "turn": 23,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Asahi Hai Futurity Stakes",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Mile",
+                        "fans": 7000
+                    }
+                ]
+            },
+            {
+                "turn": 31,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Satsuki Sho",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 11000
+                    }
+                ]
+            },
+            {
+                "turn": 34,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tokyo Yushun (Japanese Derby)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 20000
+                    }
+                ]
+            },
+            {
+                "turn": 44,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Kikuka Sho",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 12000
+                    }
+                ]
+            },
+            {
+                "turn": 48,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Arima Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 30000
+                    }
+                ]
+            },
+            {
+                "turn": 54,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Hanshin Daishoten",
+                        "grade": "G2",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 6700
+                    }
+                ]
+            },
+            {
+                "turn": 56,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tenno Sho (Spring)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 68,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tenno Sho (Autumn)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 70,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Japan Cup",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 30000
+                    }
+                ]
+            },
+            {
+                "turn": 72,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Arima Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 30000
+                    }
+                ]
+            }
+        ]
+    },
+    "Narita Taishin": {
+        "name": "Narita Taishin",
+        "mandatoryRaces": [
+            {
+                "turn": 24,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Hopeful Stakes",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 7000
+                    }
+                ]
+            },
+            {
+                "turn": 31,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Satsuki Sho",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 11000
+                    }
+                ]
+            },
+            {
+                "turn": 34,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tokyo Yushun (Japanese Derby)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 20000
+                    }
+                ]
+            },
+            {
+                "turn": 44,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Kikuka Sho",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 12000
+                    }
+                ]
+            },
+            {
+                "turn": 54,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Nikkei Sho",
+                        "grade": "G2",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 6700
+                    }
+                ]
+            },
+            {
+                "turn": 56,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tenno Sho (Spring)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 68,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tenno Sho (Autumn)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 72,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Arima Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 30000
+                    }
+                ]
+            }
+        ]
+    },
+    "Nice Nature": {
+        "name": "Nice Nature",
+        "mandatoryRaces": [
+            {
+                "turn": 26,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Wakagoma Stakes",
+                        "grade": "OP",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 2000
+                    }
+                ]
+            },
+            {
+                "turn": 39,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Kokura Kinen",
+                        "grade": "G3",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 4100
+                    }
+                ]
+            },
+            {
+                "turn": 44,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Kikuka Sho",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 12000
+                    }
+                ]
+            },
+            {
+                "turn": 48,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Arima Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 30000
+                    }
+                ]
+            },
+            {
+                "turn": 60,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Takarazuka Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 68,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tenno Sho (Autumn)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 71,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Chunichi Shimbun Hai",
+                        "grade": "G3",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 4100
+                    }
+                ]
+            },
+            {
+                "turn": 72,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Arima Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 30000
+                    }
+                ]
+            }
+        ]
+    },
+    "Nishino Flower": {
+        "name": "Nishino Flower",
+        "mandatoryRaces": [
+            {
+                "turn": 23,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Hanshin Juvenile Fillies",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Mile",
+                        "fans": 6500
+                    }
+                ]
+            },
+            {
+                "turn": 31,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Oka Sho",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Mile",
+                        "fans": 10500
+                    }
+                ]
+            },
+            {
+                "turn": 34,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Japanese Oaks",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 11000
+                    }
+                ]
+            },
+            {
+                "turn": 42,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Sprinters Stakes",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Sprint",
+                        "fans": 13000
+                    }
+                ]
+            },
+            {
+                "turn": 54,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Takamatsunomiya Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Sprint",
+                        "fans": 13000
+                    }
+                ]
+            },
+            {
+                "turn": 56,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Milers Cup",
+                        "grade": "G2",
+                        "surface": "Turf",
+                        "distanceType": "Mile",
+                        "fans": 5900
+                    }
+                ]
+            },
+            {
+                "turn": 59,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Yasuda Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Mile",
+                        "fans": 13000
+                    }
+                ]
+            },
+            {
+                "turn": 66,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Sprinters Stakes",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Sprint",
+                        "fans": 13000
+                    }
+                ]
+            }
+        ]
+    },
+    "Oguri Cap": {
+        "name": "Oguri Cap",
+        "mandatoryRaces": [
+            {
+                "turn": 33,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "NHK Mile Cup",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Mile",
+                        "fans": 10500
+                    }
+                ]
+            },
+            {
+                "turn": 46,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Mile Championship",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Mile",
+                        "fans": 11000
+                    }
+                ]
+            },
+            {
+                "turn": 48,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Arima Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 30000
+                    }
+                ]
+            },
+            {
+                "turn": 68,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tenno Sho (Autumn)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 72,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Arima Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 30000
+                    }
+                ]
+            }
+        ]
+    },
+    "Rice Shower": {
+        "name": "Rice Shower",
+        "mandatoryRaces": [
+            {
+                "turn": 30,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Spring Stakes",
+                        "grade": "G2",
+                        "surface": "Turf",
+                        "distanceType": "Mile",
+                        "fans": 5400
+                    }
+                ]
+            },
+            {
+                "turn": 34,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tokyo Yushun (Japanese Derby)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 20000
+                    }
+                ]
+            },
+            {
+                "turn": 44,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Kikuka Sho",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 12000
+                    }
+                ]
+            },
+            {
+                "turn": 54,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Nikkei Sho",
+                        "grade": "G2",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 6700
+                    }
+                ]
+            },
+            {
+                "turn": 56,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tenno Sho (Spring)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 60,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Takarazuka Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 72,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Arima Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 30000
+                    }
+                ]
+            }
+        ]
+    },
+    "Sakura Bakushin O": {
+        "name": "Sakura Bakushin O",
+        "mandatoryRaces": [
+            {
+                "turn": 21,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Keio Hai Junior Stakes",
+                        "grade": "G2",
+                        "surface": "Turf",
+                        "distanceType": "Sprint",
+                        "fans": 3800
+                    }
+                ]
+            },
+            {
+                "turn": 30,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Spring Stakes",
+                        "grade": "G2",
+                        "surface": "Turf",
+                        "distanceType": "Mile",
+                        "fans": 5400
+                    }
+                ]
+            },
+            {
+                "turn": 34,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Aoi Stakes",
+                        "grade": "G3",
+                        "surface": "Turf",
+                        "distanceType": "Sprint",
+                        "fans": 3800
+                    }
+                ]
+            },
+            {
+                "turn": 42,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Sprinters Stakes",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Sprint",
+                        "fans": 13000
+                    }
+                ]
+            },
+            {
+                "turn": 54,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Takamatsunomiya Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Sprint",
+                        "fans": 13000
+                    }
+                ]
+            },
+            {
+                "turn": 60,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Hakodate Sprint Stakes",
+                        "grade": "G3",
+                        "surface": "Turf",
+                        "distanceType": "Sprint",
+                        "fans": 3900
+                    }
+                ]
+            },
+            {
+                "turn": 61,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "CBC Sho",
+                        "grade": "G3",
+                        "surface": "Turf",
+                        "distanceType": "Sprint",
+                        "fans": 3900
+                    }
+                ]
+            },
+            {
+                "turn": 65,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Centaur Stakes",
+                        "grade": "G2",
+                        "surface": "Turf",
+                        "distanceType": "Sprint",
+                        "fans": 5900
+                    }
+                ]
+            },
+            {
+                "turn": 66,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Sprinters Stakes",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Sprint",
+                        "fans": 13000
+                    }
+                ]
+            },
+            {
+                "turn": 70,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Mile Championship",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Mile",
+                        "fans": 11000
+                    }
+                ]
+            }
+        ]
+    },
+    "Sakura Chiyono O": {
+        "name": "Sakura Chiyono O",
+        "mandatoryRaces": [
+            {
+                "turn": 23,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Asahi Hai Futurity Stakes",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Mile",
+                        "fans": 7000
+                    }
+                ]
+            },
+            {
+                "turn": 31,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Satsuki Sho",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 11000
+                    }
+                ]
+            },
+            {
+                "turn": 34,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tokyo Yushun (Japanese Derby)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 20000
+                    }
+                ]
+            },
+            {
+                "turn": 44,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tenno Sho (Autumn)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 59,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Yasuda Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Mile",
+                        "fans": 13000
+                    }
+                ]
+            },
+            {
+                "turn": 60,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Takarazuka Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 68,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tenno Sho (Autumn)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 70,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Japan Cup",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 30000
+                    }
+                ]
+            }
+        ]
+    },
+    "Satono Diamond": {
+        "name": "Satono Diamond",
+        "mandatoryRaces": [
+            {
+                "turn": 31,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Satsuki Sho",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 11000
+                    }
+                ]
+            },
+            {
+                "turn": 34,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tokyo Yushun (Japanese Derby)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 20000
+                    }
+                ]
+            },
+            {
+                "turn": 44,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Kikuka Sho",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 12000
+                    }
+                ]
+            },
+            {
+                "turn": 48,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Arima Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 30000
+                    }
+                ]
+            },
+            {
+                "turn": 54,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Osaka Hai",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 13500
+                    }
+                ]
+            },
+            {
+                "turn": 56,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tenno Sho (Spring)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 67,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Kyoto Daishoten",
+                        "grade": "G2",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 6700
+                    }
+                ]
+            },
+            {
+                "turn": 68,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tenno Sho (Autumn)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 72,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Arima Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 30000
+                    }
+                ]
+            }
+        ]
+    },
+    "Seiun Sky": {
+        "name": "Seiun Sky",
+        "mandatoryRaces": [
+            {
+                "turn": 31,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Satsuki Sho",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 11000
+                    }
+                ]
+            },
+            {
+                "turn": 34,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tokyo Yushun (Japanese Derby)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 20000
+                    }
+                ]
+            },
+            {
+                "turn": 44,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Kikuka Sho",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 12000
+                    }
+                ]
+            },
+            {
+                "turn": 48,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Arima Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 30000
+                    }
+                ]
+            },
+            {
+                "turn": 56,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tenno Sho (Spring)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 60,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Takarazuka Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 68,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tenno Sho (Autumn)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 72,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Arima Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 30000
+                    }
+                ]
+            }
+        ]
+    },
+    "Silence Suzuka": {
+        "name": "Silence Suzuka",
+        "mandatoryRaces": [
+            {
+                "turn": 29,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Yayoi Sho",
+                        "grade": "G2",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 5400
+                    }
+                ]
+            },
+            {
+                "turn": 42,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Kobe Shimbun Hai",
+                        "grade": "G2",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 5400
+                    }
+                ]
+            },
+            {
+                "turn": 53,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Kinko Sho",
+                        "grade": "G2",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 6700
+                    }
+                ]
+            },
+            {
+                "turn": 60,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Takarazuka Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 67,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Mainichi Okan",
+                        "grade": "G2",
+                        "surface": "Turf",
+                        "distanceType": "Mile",
+                        "fans": 6700
+                    }
+                ]
+            },
+            {
+                "turn": 68,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tenno Sho (Autumn)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 15000
+                    }
+                ]
+            }
+        ]
+    },
+    "Smart Falcon": {
+        "name": "Smart Falcon",
+        "mandatoryRaces": [
+            {
+                "turn": 31,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Satsuki Sho",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 11000
+                    }
+                ]
+            },
+            {
+                "turn": 37,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Japan Dirt Derby",
+                        "grade": "G1",
+                        "surface": "Dirt",
+                        "distanceType": "Medium",
+                        "fans": 4500
+                    }
+                ]
+            },
+            {
+                "turn": 45,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "JBC Classic",
+                        "grade": "G1",
+                        "surface": "Dirt",
+                        "distanceType": "Medium",
+                        "fans": 8000
+                    }
+                ]
+            },
+            {
+                "turn": 48,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tokyo Daishoten",
+                        "grade": "G1",
+                        "surface": "Dirt",
+                        "distanceType": "Medium",
+                        "fans": 8000
+                    }
+                ]
+            },
+            {
+                "turn": 52,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "February Stakes",
+                        "grade": "G1",
+                        "surface": "Dirt",
+                        "distanceType": "Mile",
+                        "fans": 10000
+                    }
+                ]
+            },
+            {
+                "turn": 60,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Teio Sho",
+                        "grade": "G1",
+                        "surface": "Dirt",
+                        "distanceType": "Medium",
+                        "fans": 6000
+                    }
+                ]
+            },
+            {
+                "turn": 69,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "JBC Classic",
+                        "grade": "G1",
+                        "surface": "Dirt",
+                        "distanceType": "Medium",
+                        "fans": 8000
+                    }
+                ]
+            },
+            {
+                "turn": 71,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Champions Cup",
+                        "grade": "G1",
+                        "surface": "Dirt",
+                        "distanceType": "Mile",
+                        "fans": 10000
+                    }
+                ]
+            },
+            {
+                "turn": 72,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tokyo Daishoten",
+                        "grade": "G1",
+                        "surface": "Dirt",
+                        "distanceType": "Medium",
+                        "fans": 8000
+                    }
+                ]
+            }
+        ]
+    },
+    "Special Week": {
+        "name": "Special Week",
+        "mandatoryRaces": [
+            {
+                "turn": 27,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Kisaragi Sho",
+                        "grade": "G3",
+                        "surface": "Turf",
+                        "distanceType": "Mile",
+                        "fans": 3800
+                    }
+                ]
+            },
+            {
+                "turn": 34,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tokyo Yushun (Japanese Derby)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 20000
+                    }
+                ]
+            },
+            {
+                "turn": 44,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Kikuka Sho",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 12000
+                    }
+                ]
+            },
+            {
+                "turn": 56,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tenno Sho (Spring)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 70,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Japan Cup",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 30000
+                    }
+                ]
+            },
+            {
+                "turn": 72,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Arima Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 30000
+                    }
+                ]
+            }
+        ]
+    },
+    "Super Creek": {
+        "name": "Super Creek",
+        "mandatoryRaces": [
+            {
+                "turn": 28,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Sumire Stakes",
+                        "grade": "OP",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 2000
+                    }
+                ]
+            },
+            {
+                "turn": 44,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Kikuka Sho",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 12000
+                    }
+                ]
+            },
+            {
+                "turn": 48,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Arima Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 30000
+                    }
+                ]
+            },
+            {
+                "turn": 54,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Osaka Hai",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 13500
+                    }
+                ]
+            },
+            {
+                "turn": 56,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tenno Sho (Spring)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 68,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tenno Sho (Autumn)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 72,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Arima Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 30000
+                    }
+                ]
+            }
+        ]
+    },
+    "Sweep Tosho": {
+        "name": "Sweep Tosho",
+        "mandatoryRaces": [
+            {
+                "turn": 23,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Hanshin Juvenile Fillies",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Mile",
+                        "fans": 6500
+                    }
+                ]
+            },
+            {
+                "turn": 31,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Oka Sho",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Mile",
+                        "fans": 10500
+                    }
+                ]
+            },
+            {
+                "turn": 34,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Japanese Oaks",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 11000
+                    }
+                ]
+            },
+            {
+                "turn": 44,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Shuka Sho",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 10000
+                    }
+                ]
+            },
+            {
+                "turn": 45,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Queen Elizabeth II Cup",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 10500
+                    }
+                ]
+            },
+            {
+                "turn": 59,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Yasuda Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Mile",
+                        "fans": 13000
+                    }
+                ]
+            },
+            {
+                "turn": 60,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Takarazuka Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 68,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tenno Sho (Autumn)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 69,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Queen Elizabeth II Cup",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 10500
+                    }
+                ]
+            }
+        ]
+    },
+    "Symboli Rudolf": {
+        "name": "Symboli Rudolf",
+        "mandatoryRaces": [
+            {
+                "turn": 19,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Saudi Arabia Royal Cup",
+                        "grade": "G3",
+                        "surface": "Turf",
+                        "distanceType": "Mile",
+                        "fans": 3300
+                    }
+                ]
+            },
+            {
+                "turn": 31,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Satsuki Sho",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 11000
+                    }
+                ]
+            },
+            {
+                "turn": 34,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tokyo Yushun (Japanese Derby)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 20000
+                    }
+                ]
+            },
+            {
+                "turn": 44,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Kikuka Sho",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 12000
+                    }
+                ]
+            },
+            {
+                "turn": 48,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Arima Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 30000
+                    }
+                ]
+            },
+            {
+                "turn": 56,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tenno Sho (Spring)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 70,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Japan Cup",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 30000
+                    }
+                ]
+            },
+            {
+                "turn": 72,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Arima Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 30000
+                    }
+                ]
+            }
+        ]
+    },
+    "TM Opera O": {
+        "name": "TM Opera O",
+        "mandatoryRaces": [
+            {
+                "turn": 31,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Satsuki Sho",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 11000
+                    }
+                ]
+            },
+            {
+                "turn": 34,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tokyo Yushun (Japanese Derby)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 20000
+                    }
+                ]
+            },
+            {
+                "turn": 48,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Arima Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 30000
+                    }
+                ]
+            },
+            {
+                "turn": 56,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tenno Sho (Spring)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 60,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Takarazuka Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 70,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Japan Cup",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 30000
+                    }
+                ]
+            },
+            {
+                "turn": 72,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Arima Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 30000
+                    }
+                ]
+            }
+        ]
+    },
+    "Taiki Shuttle": {
+        "name": "Taiki Shuttle",
+        "mandatoryRaces": [
+            {
+                "turn": 25,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Shinzan Kinen",
+                        "grade": "G3",
+                        "surface": "Turf",
+                        "distanceType": "Mile",
+                        "fans": 3800
+                    }
+                ]
+            },
+            {
+                "turn": 33,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "NHK Mile Cup",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Mile",
+                        "fans": 10500
+                    }
+                ]
+            },
+            {
+                "turn": 36,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Unicorn Stakes",
+                        "grade": "G3",
+                        "surface": "Dirt",
+                        "distanceType": "Mile",
+                        "fans": 3500
+                    }
+                ]
+            },
+            {
+                "turn": 46,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Mile Championship",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Mile",
+                        "fans": 11000
+                    }
+                ]
+            },
+            {
+                "turn": 59,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Yasuda Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Mile",
+                        "fans": 13000
+                    }
+                ]
+            },
+            {
+                "turn": 66,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Sprinters Stakes",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Sprint",
+                        "fans": 13000
+                    }
+                ]
+            },
+            {
+                "turn": 70,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Mile Championship",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Mile",
+                        "fans": 11000
+                    }
+                ]
+            }
+        ]
+    },
+    "Tamamo Cross": {
+        "name": "Tamamo Cross",
+        "mandatoryRaces": [
+            {
+                "turn": 54,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Hanshin Daishoten",
+                        "grade": "G2",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 6700
+                    }
+                ]
+            },
+            {
+                "turn": 56,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tenno Sho (Spring)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 60,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Takarazuka Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 68,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tenno Sho (Autumn)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 72,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Arima Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 30000
+                    }
+                ]
+            }
+        ]
+    },
+    "Tokai Teio": {
+        "name": "Tokai Teio",
+        "mandatoryRaces": [
+            {
+                "turn": 26,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Wakagoma Stakes",
+                        "grade": "OP",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 2000
+                    }
+                ]
+            },
+            {
+                "turn": 31,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Satsuki Sho",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 11000
+                    }
+                ]
+            },
+            {
+                "turn": 34,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tokyo Yushun (Japanese Derby)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 20000
+                    }
+                ]
+            },
+            {
+                "turn": 44,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Kikuka Sho",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 12000
+                    }
+                ]
+            },
+            {
+                "turn": 56,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tenno Sho (Spring)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 70,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Japan Cup",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 30000
+                    }
+                ]
+            },
+            {
+                "turn": 72,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Arima Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 30000
+                    }
+                ]
+            }
+        ]
+    },
+    "Tosen Jordan": {
+        "name": "Tosen Jordan",
+        "mandatoryRaces": [
+            {
+                "turn": 24,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Hopeful Stakes",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 7000
+                    }
+                ]
+            },
+            {
+                "turn": 31,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Satsuki Sho",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 11000
+                    }
+                ]
+            },
+            {
+                "turn": 45,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Copa Republica Argentina",
+                        "grade": "G2",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 5700
+                    }
+                ]
+            },
+            {
+                "turn": 48,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Arima Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 30000
+                    }
+                ]
+            },
+            {
+                "turn": 54,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Osaka Hai",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 13500
+                    }
+                ]
+            },
+            {
+                "turn": 56,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tenno Sho (Spring)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 60,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Takarazuka Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 68,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tenno Sho (Autumn)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 15000
+                    }
+                ]
+            }
+        ]
+    },
+    "Vodka": {
+        "name": "Vodka",
+        "mandatoryRaces": [
+            {
+                "turn": 23,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Hanshin Juvenile Fillies",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Mile",
+                        "fans": 6500
+                    }
+                ]
+            },
+            {
+                "turn": 29,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tulip Sho",
+                        "grade": "G2",
+                        "surface": "Turf",
+                        "distanceType": "Mile",
+                        "fans": 5200
+                    }
+                ]
+            },
+            {
+                "turn": 31,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Oka Sho",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Mile",
+                        "fans": 10500
+                    }
+                ]
+            },
+            {
+                "turn": 34,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tokyo Yushun (Japanese Derby)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 20000
+                    }
+                ]
+            },
+            {
+                "turn": 44,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Shuka Sho",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 10000
+                    }
+                ]
+            },
+            {
+                "turn": 48,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Arima Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 30000
+                    }
+                ]
+            },
+            {
+                "turn": 57,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Victoria Mile",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Mile",
+                        "fans": 10500
+                    }
+                ]
+            },
+            {
+                "turn": 59,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Yasuda Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Mile",
+                        "fans": 13000
+                    }
+                ]
+            },
+            {
+                "turn": 68,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tenno Sho (Autumn)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 15000
+                    }
+                ]
+            }
+        ]
+    },
+    "Winning Ticket": {
+        "name": "Winning Ticket",
+        "mandatoryRaces": [
+            {
+                "turn": 24,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Hopeful Stakes",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 7000
+                    }
+                ]
+            },
+            {
+                "turn": 29,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Yayoi Sho",
+                        "grade": "G2",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 5400
+                    }
+                ]
+            },
+            {
+                "turn": 31,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Satsuki Sho",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 11000
+                    }
+                ]
+            },
+            {
+                "turn": 34,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tokyo Yushun (Japanese Derby)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 20000
+                    }
+                ]
+            },
+            {
+                "turn": 44,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Kikuka Sho",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 12000
+                    }
+                ]
+            },
+            {
+                "turn": 54,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Osaka Hai",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 13500
+                    }
+                ]
+            },
+            {
+                "turn": 60,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Takarazuka Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 72,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Arima Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 30000
+                    }
+                ]
+            }
+        ]
+    },
+    "Yaeno Muteki": {
+        "name": "Yaeno Muteki",
+        "mandatoryRaces": [
+            {
+                "turn": 30,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Mainichi Hai",
+                        "grade": "G3",
+                        "surface": "Turf",
+                        "distanceType": "Mile",
+                        "fans": 3800
+                    }
+                ]
+            },
+            {
+                "turn": 31,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Satsuki Sho",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 11000
+                    }
+                ]
+            },
+            {
+                "turn": 34,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tokyo Yushun (Japanese Derby)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 20000
+                    }
+                ]
+            },
+            {
+                "turn": 44,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Kikuka Sho",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Long",
+                        "fans": 12000
+                    }
+                ]
+            },
+            {
+                "turn": 54,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Osaka Hai",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 13500
+                    }
+                ]
+            },
+            {
+                "turn": 59,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Yasuda Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Mile",
+                        "fans": 13000
+                    }
+                ]
+            },
+            {
+                "turn": 60,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Takarazuka Kinen",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 15000
+                    }
+                ]
+            },
+            {
+                "turn": 68,
+                "isChoice": false,
+                "options": [
+                    {
+                        "raceName": "Tenno Sho (Autumn)",
+                        "grade": "G1",
+                        "surface": "Turf",
+                        "distanceType": "Medium",
+                        "fans": 15000
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/src/hooks/useBootstrap.tsx
+++ b/src/hooks/useBootstrap.tsx
@@ -195,6 +195,12 @@ export const useBootstrap = () => {
             await yieldToFrame()
             await databaseManager.saveSetting("racing", "characterPresetsData", characterPresetsData, true)
             logWithTimestamp(`[Bootstrap] Successfully saved character presets data (${Object.keys(characterPresetsData).length} presets) to SQLite`)
+            await yieldToFrame()
+
+            const characterObjectivesData = require("../data/character_objectives.json")
+            await yieldToFrame()
+            await databaseManager.saveSetting("racing", "characterObjectivesData", characterObjectivesData, true)
+            logWithTimestamp(`[Bootstrap] Successfully saved character objectives data (${Object.keys(characterObjectivesData).length} characters) to SQLite`)
 
             logWithTimestamp("[Bootstrap] Solver data population complete")
         } catch (error) {

--- a/src/hooks/useSettingsFileManager.tsx
+++ b/src/hooks/useSettingsFileManager.tsx
@@ -69,7 +69,7 @@ const compareSettings = (current: Settings, imported: Settings) => {
         for (const key of Object.keys(importedCategory)) {
             // Skip large settings fields that shouldn't be shown in preview, plus the Discord token (excluded from import entirely; see `useSettingsManager.importSettings`).
             if (
-                (category === "racing" && (key === "epithetsData" || key === "characterPresetsData" || key === "racesData")) ||
+                (category === "racing" && (key === "epithetsData" || key === "characterPresetsData" || key === "racesData" || key === "characterObjectivesData")) ||
                 (category === "misc" && key === "formattedSettingsString") ||
                 (category === "discord" && key === "discordToken")
             ) {

--- a/src/lib/settingsUtils.ts
+++ b/src/lib/settingsUtils.ts
@@ -43,6 +43,7 @@ export const DB_OWNED_KEYS: ReadonlyArray<readonly [string, string]> = [
     ["racing", "racesData"],
     ["racing", "epithetsData"],
     ["racing", "characterPresetsData"],
+    ["racing", "characterObjectivesData"],
     ["racing", "racingPlanData"],
     ["trainingEvent", "characterEventData"],
     ["trainingEvent", "supportEventData"],

--- a/src/lib/solver/preview.ts
+++ b/src/lib/solver/preview.ts
@@ -51,6 +51,8 @@ export interface SolverConfigSnapshot {
     racesDataJson?: string
     /** Bundled epithets.json passed inline for the same reason as `racesDataJson`. */
     epithetsDataJson?: string
+    /** Bundled character_objectives.json passed inline for the same reason as `racesDataJson`. */
+    objectivesDataJson?: string
 }
 
 /** Decision the solver picked for a given turn: race a real race, do generic training, or rest. */
@@ -65,6 +67,8 @@ export interface ScheduleEntry {
     name?: string
     /** Race grade string (e.g. "G1", "OP"). Present only when `type === "Race"`; same shape as `RaceEntry.grade`. */
     grade?: string
+    /** True when this race is a forced mandatory career objective the solver locked, not a chosen optional race. */
+    mandatory?: boolean
 }
 
 export interface SchedulePreview {

--- a/src/pages/SmartRaceSolverSettings/index.tsx
+++ b/src/pages/SmartRaceSolverSettings/index.tsx
@@ -40,6 +40,7 @@ import WarningContainer from "../../components/WarningContainer"
 import { Input } from "../../components/ui/input"
 import racesData from "../../data/races.json"
 import epithetsData from "../../data/epithets.json"
+import characterObjectivesData from "../../data/character_objectives.json"
 import characterPresetsData from "../../data/characterPresets.json"
 import PageHeader from "../../components/PageHeader"
 import { usePerformanceLogging } from "../../hooks/usePerformanceLogging"
@@ -59,6 +60,7 @@ import { RADII } from "../../lib/radii"
 // Stringify the bundled JSON once at module load so we don't pay the serialisation cost on every debounced preview call.
 const RACES_DATA_JSON = JSON.stringify(racesData)
 const EPITHETS_DATA_JSON = JSON.stringify(epithetsData)
+const OBJECTIVES_DATA_JSON = JSON.stringify(characterObjectivesData)
 
 // Remembers the last preview so re-opening this page shows the previous calendar instantly instead of a blank screen while the solver re-runs.
 // Keyed on a JSON snapshot of the solver-relevant settings. Cleared only on app reload.
@@ -472,6 +474,7 @@ const SmartRaceSolverSettings = () => {
         // Only ship the bundled JSON the first time; Kotlin caches it after that.
         racesDataJson: bridgeDataPrimed ? undefined : RACES_DATA_JSON,
         epithetsDataJson: bridgeDataPrimed ? undefined : EPITHETS_DATA_JSON,
+        objectivesDataJson: bridgeDataPrimed ? undefined : OBJECTIVES_DATA_JSON,
     })
 
     /** Snapshot key of the settings that produced `preview`. Used to detect whether the current preview is stale relative to the live settings. */
@@ -823,6 +826,11 @@ const SmartRaceSolverSettings = () => {
                     borderWidth: 2,
                     borderColor: colors.brand,
                 },
+                calendarCellMandatory: {
+                    borderWidth: 2,
+                    borderColor: "#f59e0b",
+                    backgroundColor: "rgba(245, 158, 11, 0.12)",
+                },
                 popoverColumn: { flexShrink: 1 },
                 popoverHeader: { flexShrink: 0 },
                 popoverBodyScroll: { flexShrink: 1, marginTop: 4 },
@@ -849,6 +857,7 @@ const SmartRaceSolverSettings = () => {
                 popoverAltName: { fontSize: 12, fontWeight: "600", color: colors.text },
                 popoverAltMeta: { fontSize: 10, color: colors.textMuted },
                 popoverHint: { fontSize: 10, color: colors.textMuted, fontStyle: "italic", marginTop: 8, textAlign: "center" },
+                popoverMandatoryNote: { fontSize: 12, color: colors.warningText, fontWeight: "700", marginTop: 4 },
                 recalcFab: { position: "absolute", bottom: 16, right: 16, zIndex: 10, alignItems: "flex-end" },
                 recalcFabLabel: {
                     backgroundColor: colors.surface,
@@ -928,6 +937,7 @@ const SmartRaceSolverSettings = () => {
         const matched = race && preview ? epithetsForRace(race).filter((ep) => allowedEpithetNames.has(ep.name) && turnsContributingToEpithet(ep, preview, racesByKey).has(turn)) : []
         const lockedValue: string | undefined = manualLocks[String(turn)]
         const isLocked = lockedValue != null
+        const isMandatory = isRace && entry?.mandatory === true
         const alternatives = (eligibleRacesForTurn.get(turn) ?? []).filter((r) => !race || r.name !== race.name)
 
         // Cap the popover at the screen minus its 60px top/bottom insets, then hand the body whatever the pinned header and footer leave behind.
@@ -946,7 +956,7 @@ const SmartRaceSolverSettings = () => {
                     }}
                 >
                     <Text style={styles.popoverTitle}>
-                        {isLocked ? "🔒 " : ""}T{turn} · {fullDateLabel}
+                        {isMandatory ? "📌 " : isLocked ? "🔒 " : ""}T{turn} · {fullDateLabel}
                     </Text>
                     {isRace && race ? (
                         <>
@@ -956,9 +966,15 @@ const SmartRaceSolverSettings = () => {
                                 {race.fans.toLocaleString()} fans
                             </Text>
                         </>
+                    ) : isRace ? (
+                        <Text style={styles.popoverMeta}>
+                            {entry?.name ?? "Mandatory race"}
+                            {entry?.grade ? ` · ${entry.grade.replace("PRE_OP", "Pre-OP")}` : ""}
+                        </Text>
                     ) : (
                         <Text style={styles.popoverMeta}>{entry?.type === "Rest" ? "Rest" : "No race scheduled — solver chose Train."}</Text>
                     )}
+                    {isMandatory ? <Text style={styles.popoverMandatoryNote}>Mandatory career race. The game forces this race on this turn.</Text> : null}
                 </View>
 
                 {/* Body - epithet progression and eligible races, the only scrollable region */}
@@ -995,33 +1011,37 @@ const SmartRaceSolverSettings = () => {
                         </>
                     )}
 
-                    <Divider style={{ marginTop: 16 }} />
+                    {!isMandatory && (
+                        <>
+                            <Divider style={{ marginTop: 16 }} />
 
-                    <Text style={styles.popoverSection}>Switch to an eligible race</Text>
-                    {alternatives.length === 0 ? (
-                        <Text style={styles.popoverEmpty}>No other eligible races on this turn.</Text>
-                    ) : (
-                        alternatives.map((alt) => {
-                            const altColor = GRADE_COLORS[alt.grade] ?? colors.brand
-                            return (
-                                <Pressable
-                                    key={`${alt.name}-${alt.date}`}
-                                    style={styles.popoverAltRow}
-                                    onPress={() => switchTurnRace(turn, alt.name)}
-                                    android_ripple={{ color: colors.ripple, foreground: true }}
-                                >
-                                    <View style={[styles.popoverAltBadge, { backgroundColor: altColor }]}>
-                                        <Text style={styles.calendarBadgeText}>{alt.grade.replace("PRE_OP", "Pre").replace("PRE-OP", "Pre")}</Text>
-                                    </View>
-                                    <View style={{ flex: 1 }}>
-                                        <Text style={styles.popoverAltName}>{alt.name}</Text>
-                                        <Text style={styles.popoverAltMeta}>
-                                            {alt.raceTrack} · {alt.terrain} · {alt.distanceType} ({alt.distanceMeters}m) · {alt.fans.toLocaleString()} fans
-                                        </Text>
-                                    </View>
-                                </Pressable>
-                            )
-                        })
+                            <Text style={styles.popoverSection}>Switch to an eligible race</Text>
+                            {alternatives.length === 0 ? (
+                                <Text style={styles.popoverEmpty}>No other eligible races on this turn.</Text>
+                            ) : (
+                                alternatives.map((alt) => {
+                                    const altColor = GRADE_COLORS[alt.grade] ?? colors.brand
+                                    return (
+                                        <Pressable
+                                            key={`${alt.name}-${alt.date}`}
+                                            style={styles.popoverAltRow}
+                                            onPress={() => switchTurnRace(turn, alt.name)}
+                                            android_ripple={{ color: colors.ripple, foreground: true }}
+                                        >
+                                            <View style={[styles.popoverAltBadge, { backgroundColor: altColor }]}>
+                                                <Text style={styles.calendarBadgeText}>{alt.grade.replace("PRE_OP", "Pre").replace("PRE-OP", "Pre")}</Text>
+                                            </View>
+                                            <View style={{ flex: 1 }}>
+                                                <Text style={styles.popoverAltName}>{alt.name}</Text>
+                                                <Text style={styles.popoverAltMeta}>
+                                                    {alt.raceTrack} · {alt.terrain} · {alt.distanceType} ({alt.distanceMeters}m) · {alt.fans.toLocaleString()} fans
+                                                </Text>
+                                            </View>
+                                        </Pressable>
+                                    )
+                                })
+                            )}
+                        </>
                     )}
                 </ScrollView>
 
@@ -1034,14 +1054,24 @@ const SmartRaceSolverSettings = () => {
                     }}
                 >
                     <View style={styles.popoverButtonRow}>
-                        {isRace && (
-                            <CustomButton variant="destructive" size="sm" onPress={() => lockTurnToTrain(turn)}>
-                                Delete
-                            </CustomButton>
+                        {isMandatory ? (
+                            <Text style={styles.popoverHint}>This turn is locked to a mandatory race and cannot be changed.</Text>
+                        ) : (
+                            <>
+                                {isRace && (
+                                    <CustomButton variant="destructive" size="sm" onPress={() => lockTurnToTrain(turn)}>
+                                        Delete
+                                    </CustomButton>
+                                )}
+                                <CustomButton
+                                    variant={isLocked ? "secondary" : "default"}
+                                    size="sm"
+                                    onPress={() => toggleLockForTurn(turn, isLocked, isRace ? (race?.name ?? entry?.name ?? null) : null)}
+                                >
+                                    {isLocked ? "Unlock" : "Lock"}
+                                </CustomButton>
+                            </>
                         )}
-                        <CustomButton variant={isLocked ? "secondary" : "default"} size="sm" onPress={() => toggleLockForTurn(turn, isLocked, isRace ? (race?.name ?? entry?.name ?? null) : null)}>
-                            {isLocked ? "Unlock" : "Lock"}
-                        </CustomButton>
                     </View>
                     <Text style={styles.popoverHint}>Changes take effect after tapping Recalculate.</Text>
                 </View>
@@ -1065,6 +1095,7 @@ const SmartRaceSolverSettings = () => {
         const isPreDebut = turn <= 13
         const isSummerBlocked = !weights.allowSummerRacing && ((turn >= 37 && turn <= 40) || (turn >= 61 && turn <= 64))
         const isLocked = manualLocks[String(turn)] != null
+        const isMandatory = isRace && entry?.mandatory === true
         const highlightHit = isRace && contributingTurnsForHighlight.has(turn)
 
         if (isPreDebut || isSummerBlocked) {
@@ -1096,7 +1127,13 @@ const SmartRaceSolverSettings = () => {
                 <Popover>
                     <PopoverTrigger asChild>
                         <Pressable
-                            style={[styles.calendarCell, isRace && styles.calendarCellRace, isLocked && styles.calendarCellLocked, highlightHit && styles.calendarCellHighlighted]}
+                            style={[
+                                styles.calendarCell,
+                                isRace && styles.calendarCellRace,
+                                isMandatory && styles.calendarCellMandatory,
+                                isLocked && styles.calendarCellLocked,
+                                highlightHit && styles.calendarCellHighlighted,
+                            ]}
                             android_ripple={{ color: colors.ripple, foreground: true }}
                         >
                             {cellInner}
@@ -1114,7 +1151,7 @@ const SmartRaceSolverSettings = () => {
                     </PopoverContent>
                 </Popover>
                 <Text style={styles.calendarDateLabel}>
-                    {isLocked ? "🔒 " : ""}
+                    {isMandatory ? "📌 " : isLocked ? "🔒 " : ""}
                     {dateLabel}
                 </Text>
             </View>


### PR DESCRIPTION
## Description
- This PR adds a `CharacterObjectivesScraper` that scrapes each character's mandatory career-objective races into `character_objectives.json` and feeds them into the Smart Race Solver, which now locks those turns instead of scheduling optional races or training on them.
- Mandatory races are surfaced distinctly in both the calendar preview and the Remote Log Viewer, and apply to every scenario except `Trackblazer`.