### PR TITLE
Add a maximum extra races cap to the Smart Race Solver

### DIFF
--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/solver/Heuristic.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/solver/Heuristic.kt
@@ -100,8 +100,19 @@ object Heuristic {
                 .filter { it.key !in alreadyWon }
 
         val children = ArrayList<Beam>(racesHere.size + 2)
-        for (race in racesHere) {
-            children += applyDecision(beam, turn, Decision.RaceDecision(race.key), state)
+        // Count only optional races already scheduled (a race turn that is not a locked RaceDecision). Locked/mandatory
+        // races short-circuit above and so never count toward the cap.
+        val cap = state.maxRaces
+        val optionalRacesSoFar =
+            if (cap == null) {
+                0
+            } else {
+                beam.decisions.count { (t, d) -> d is Decision.RaceDecision && state.lockedDecisions[t] !is Decision.RaceDecision }
+            }
+        if (cap == null || optionalRacesSoFar < cap) {
+            for (race in racesHere) {
+                children += applyDecision(beam, turn, Decision.RaceDecision(race.key), state)
+            }
         }
         children += applyDecision(beam, turn, Decision.Train, state)
         children += applyDecision(beam, turn, Decision.Rest, state)

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/solver/MilpSolver.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/solver/MilpSolver.kt
@@ -112,6 +112,7 @@ object MilpSolver {
             wireXrConsistency()
             wireSummerHardBlock()
             wireManualLocks()
+            wireMaxRaces()
             wireConsecutiveRaceIndicators()
             wireEpithetMatchers()
             wireDependsOn()
@@ -167,6 +168,21 @@ object MilpSolver {
                     Decision.Train, Decision.Rest -> xVars[turn]!!.upper(0.0)
                 }
             }
+        }
+
+        /**
+         * Caps the number of optional races: `sum(x[t]) <= maxRaces + lockedRaceCount`. Locked Race turns are forced x=1
+         * by [wireManualLocks], so they are added back into the bound and never consume the user's budget. No-op when
+         * [SolverState.maxRaces] is null.
+         */
+        private fun wireMaxRaces() {
+            val cap = state.maxRaces ?: return
+            val lockedRaceTurns =
+                state.lockedDecisions.count { (turn, decision) ->
+                    turn in turns && decision is Decision.RaceDecision && raceVars[turn]?.get(decision.raceKey) != null
+                }
+            val expr = model.newExpression("max_races").upper((cap + lockedRaceTurns).toDouble())
+            for ((_, v) in xVars) expr.set(v, 1.0)
         }
 
         /**

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/solver/SmartRaceSolverIntegration.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/solver/SmartRaceSolverIntegration.kt
@@ -621,6 +621,7 @@ object SmartRaceSolverIntegration {
                 targetEpithets = jsonStringList(config.optJSONArray("targetEpithets")).toSet(),
                 lockedDecisions = applied.lockedDecisions,
                 weights = parseWeightsObj(config.optJSONObject("weights")),
+                maxRaces = config.optInt("maxRaces", -1).takeIf { it > 0 },
             )
 
         val schedule = SmartRaceSolver.solve(state)
@@ -665,6 +666,7 @@ object SmartRaceSolverIntegration {
             targetEpithets = readStringSet("smartRaceSolverTargetEpithets"),
             lockedDecisions = applied.lockedDecisions,
             weights = readWeights(),
+            maxRaces = readMaxRaces(),
         )
     }
 
@@ -900,6 +902,13 @@ object SmartRaceSolverIntegration {
         if (json.isEmpty()) return Weights()
         return runCatching { parseWeightsObj(JSONObject(json)) }.getOrElse { Weights() }
     }
+
+    /**
+     * Reads the user's maximum-optional-races cap. Returns null (no limit) when unset or non-positive.
+     *
+     * @return The cap as a positive Int, or null when the solver should plan races without an upper bound.
+     */
+    private fun readMaxRaces(): Int? = SettingsHelper.getIntSetting("racing", "smartRaceSolverMaxRaces", -1).takeIf { it > 0 }
 
     /**
      * Parses a weights JSON object. Each field falls back to the corresponding [Weights] default when missing.

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/solver/SolverState.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/solver/SolverState.kt
@@ -199,6 +199,7 @@ data class RaceLossRecord(
  * @property lockedDecisions User-locked turn -> decision overrides.
  * @property summerBlockTurns No-race turns. Defaults to [DEFAULT_SUMMER_BLOCKS].
  * @property weights Active scoring weights.
+ * @property maxRaces Maximum number of optional races the solver may schedule, or null for no limit. Locked/mandatory races always run and do not count toward this cap.
  */
 data class SolverState(
     val currentTurn: TurnNumber,
@@ -215,6 +216,7 @@ data class SolverState(
     val lockedDecisions: Map<TurnNumber, Decision> = emptyMap(),
     val summerBlockTurns: Set<TurnNumber> = DEFAULT_SUMMER_BLOCKS,
     val weights: Weights = Weights(),
+    val maxRaces: Int? = null,
 ) {
     val epithetsByName: Map<String, Epithet> by lazy { epithets.associateBy { it.name } }
 

--- a/src/context/BotStateContext.tsx
+++ b/src/context/BotStateContext.tsx
@@ -78,6 +78,7 @@ export interface Settings {
         smartRaceSolverTargetEpithets: string
         smartRaceSolverForcedEpithets: string
         smartRaceSolverManualLocks: string
+        smartRaceSolverMaxRaces: number
         smartRaceSolverWeights: string
     }
 
@@ -281,6 +282,7 @@ export const defaultSettings: Settings = {
         smartRaceSolverTargetEpithets: "[]",
         smartRaceSolverForcedEpithets: "[]",
         smartRaceSolverManualLocks: "{}",
+        smartRaceSolverMaxRaces: 0,
         smartRaceSolverWeights: JSON.stringify({
             raceValue: 1.0,
             epithetValue: 1.0,

--- a/src/context/searchConfig.ts
+++ b/src/context/searchConfig.ts
@@ -501,6 +501,13 @@ const searchConfig: SearchOption[] = [
         parentId: "enable-smart-race-solver",
     },
     {
+        id: "smart-solver-max-races",
+        title: "Maximum Extra Races",
+        description: "Caps how many optional races the solver schedules across the whole career. Mandatory career races always run and don't count toward this. 0 = no limit.",
+        page: "SmartRaceSolverSettings",
+        parentId: "enable-smart-race-solver",
+    },
+    {
         id: "smart-solver-how-it-works",
         title: "How it works",
         description: "Smart Race Solver overview, loss handling, race-history scrape, and notes on epithets without matchers.",

--- a/src/lib/messageLog/buildSettingsBanner.ts
+++ b/src/lib/messageLog/buildSettingsBanner.ts
@@ -175,6 +175,7 @@ ${longTargetsString}${formatAdvancedScoringSection(settings.training)}
 ---------- Smart Race Solver Options ----------
 🤖 Enable Smart Race Solver: ${settings.racing.enableSmartRaceSolver ? "✅" : "❌"}
 🚫 Disable Schedule Re-Plan Upon Race Loss: ${settings.racing.disableScheduleReplanOnRaceLoss ? "✅" : "❌"}
+🏁 Solver Max Extra Races: ${settings.racing.smartRaceSolverMaxRaces > 0 ? settings.racing.smartRaceSolverMaxRaces : "No limit"}
 🎭 Solver Character Preset: ${settings.racing.smartRaceSolverCharacterPreset || "(none)"}
 🐎 Solver Aptitudes: Spr ${smartRaceSolverAptitudesObj.Sprint ?? "?"}, Mile ${smartRaceSolverAptitudesObj.Mile ?? "?"}, Med ${smartRaceSolverAptitudesObj.Medium ?? "?"}, Lng ${smartRaceSolverAptitudesObj.Long ?? "?"}, Trf ${smartRaceSolverAptitudesObj.Turf ?? "?"}, Drt ${smartRaceSolverAptitudesObj.Dirt ?? "?"}
 🎯 Solver Optimize Mode: ${smartRaceSolverOptimizeMode}

--- a/src/lib/solver/preview.ts
+++ b/src/lib/solver/preview.ts
@@ -47,6 +47,8 @@ export interface SolverConfigSnapshot {
         /** When true, races during the Classic / Senior summer training camps are not blocked. */
         allowSummerRacing: boolean
     }
+    /** Maximum number of optional races the solver may schedule. Mandatory races always run and do not count. 0 (or less) means no limit. */
+    maxRaces: number
     /** Bundled races.json passed inline so the bridge does not depend on SettingsHelper persistence having reached SQLite by the time the preview fires. */
     racesDataJson?: string
     /** Bundled epithets.json passed inline for the same reason as `racesDataJson`. */

--- a/src/pages/SmartRaceSolverSettings/index.tsx
+++ b/src/pages/SmartRaceSolverSettings/index.tsx
@@ -45,6 +45,7 @@ import characterPresetsData from "../../data/characterPresets.json"
 import PageHeader from "../../components/PageHeader"
 import { usePerformanceLogging } from "../../hooks/usePerformanceLogging"
 import SearchableItem from "../../components/SearchableItem"
+import CustomSlider from "../../components/CustomSlider"
 import { useNavigation, useFocusEffect } from "@react-navigation/native"
 import { AptitudeRow, EpithetChip } from "./components/Helpers"
 import { GlassFab } from "../../components/ui/glass-fab"
@@ -127,6 +128,7 @@ const SmartRaceSolverSettings = () => {
         smartRaceSolverTargetEpithets,
         smartRaceSolverForcedEpithets,
         smartRaceSolverManualLocks,
+        smartRaceSolverMaxRaces,
         smartRaceSolverWeights,
     } = racingSettings
 
@@ -471,6 +473,7 @@ const SmartRaceSolverSettings = () => {
         forcedEpithets,
         manualLocks,
         weights,
+        maxRaces: smartRaceSolverMaxRaces,
         // Only ship the bundled JSON the first time; Kotlin caches it after that.
         racesDataJson: bridgeDataPrimed ? undefined : RACES_DATA_JSON,
         epithetsDataJson: bridgeDataPrimed ? undefined : EPITHETS_DATA_JSON,
@@ -490,8 +493,9 @@ const SmartRaceSolverSettings = () => {
                 forcedEpithets,
                 manualLocks,
                 weights,
+                maxRaces: smartRaceSolverMaxRaces,
             }),
-        [general?.scenario, smartRaceSolverCharacterPreset, aptitudes, targetEpithets, forcedEpithets, manualLocks, weights]
+        [general?.scenario, smartRaceSolverCharacterPreset, aptitudes, targetEpithets, forcedEpithets, manualLocks, weights, smartRaceSolverMaxRaces]
     )
 
     /**
@@ -1254,6 +1258,27 @@ const SmartRaceSolverSettings = () => {
                                     right={<Switch checked={disableScheduleReplanOnRaceLoss} onCheckedChange={(checked) => updateRacingSetting("disableScheduleReplanOnRaceLoss", checked)} />}
                                 />
                             </SearchableItem>
+
+                            {enableSmartRaceSolver && (
+                                <View style={[sectionsDisabledStyle, { paddingHorizontal: SPACING.md, paddingVertical: SPACING.sm }]}>
+                                    <CustomSlider
+                                        searchId="smart-solver-max-races"
+                                        searchCondition={enableSmartRaceSolver}
+                                        parentId="enable-smart-race-solver"
+                                        value={smartRaceSolverMaxRaces}
+                                        placeholder={defaultSettings.racing.smartRaceSolverMaxRaces}
+                                        onValueChange={(value) => updateRacingSetting("smartRaceSolverMaxRaces", value)}
+                                        onSlidingComplete={(value) => updateRacingSetting("smartRaceSolverMaxRaces", value)}
+                                        min={0}
+                                        max={40}
+                                        step={1}
+                                        label="Maximum Extra Races"
+                                        description="Caps how many optional races the solver schedules across the whole career. Mandatory career races always run and don't count toward this. 0 = no limit."
+                                        labelUnit=""
+                                        showValue={true}
+                                    />
+                                </View>
+                            )}
 
                             <SearchableItem
                                 id="smart-solver-how-it-works"


### PR DESCRIPTION
## Description
- This PR adds a `Maximum Extra Races` slider to the Smart Race Solver settings that caps how many optional races the solver schedules.
- Mandatory career races always run and never count toward the cap, so a low value can never make a schedule unsolvable, and a value of `0` keeps the previous unlimited behavior.