### PR TITLE
Add an internal storage fallback for the first-run storage step

### DIFF
--- a/android/app/src/main/java/com/steve1316/uma_android_automation/StorageBridgeModule.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/StorageBridgeModule.kt
@@ -71,11 +71,21 @@ class StorageBridgeModule(reactContext: ReactApplicationContext) :
             promise.reject("PICKER_BUSY", "A folder picker is already in progress.")
             return
         }
+        if (appContext.currentActivity == null) {
+            promise.reject("NO_ACTIVITY", "There is no foreground activity to host the folder picker.")
+            return
+        }
         try {
             val intent =
                 Intent(Intent.ACTION_OPEN_DOCUMENT_TREE).apply {
                     addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION or Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION)
                 }
+            // Some devices (cloud phones, heavily-stripped images) ship without a DocumentsUI to handle this intent.
+            // Launching anyway silently no-ops and leaves the promise pending forever, so reject up front instead.
+            if (intent.resolveActivity(appContext.packageManager) == null) {
+                promise.reject("NO_PICKER", "This device has no document picker available.")
+                return
+            }
             pendingPickPromise = promise
             appContext.startActivityForResult(intent, REQUEST_CODE_PICK_FOLDER, null)
         } catch (e: Exception) {

--- a/src/lib/storageBridge.ts
+++ b/src/lib/storageBridge.ts
@@ -8,6 +8,10 @@ export interface PickedFolder {
     name: string
 }
 
+/** Sentinel `PickedFolder` for the internal-storage fallback. Its empty `uri` marks it as not a real SAF folder, and the native side
+ * already writes under `getExternalFilesDir()` whenever the tree Uri is null. */
+export const INTERNAL_STORAGE_FOLDER: PickedFolder = { uri: "", name: "App default (internal storage)" }
+
 /** File counts under the legacy `getExternalFilesDir` paths. */
 export interface LegacyCounts {
     /** Number of files under `getExternalFilesDir/logs`. */

--- a/src/pages/FirstRunWizard/index.tsx
+++ b/src/pages/FirstRunWizard/index.tsx
@@ -7,7 +7,7 @@ import { useTheme } from "../../context/ThemeContext"
 import { useLegacyFileScan } from "../../hooks/useLegacyFileScan"
 import { RADII } from "../../lib/radii"
 import { SPACING } from "../../lib/spacing"
-import { storageBridge, PickedFolder } from "../../lib/storageBridge"
+import { storageBridge, PickedFolder, INTERNAL_STORAGE_FOLDER } from "../../lib/storageBridge"
 import { TYPE } from "../../lib/type"
 
 const styles = StyleSheet.create({
@@ -128,7 +128,7 @@ const FirstRunWizard = ({ onComplete }: Props) => {
     const { colors } = useTheme()
     const { counts, hasLegacyFiles } = useLegacyFileScan()
     const [picked, setPicked] = useState<PickedFolder | null>(null)
-    const [pickError, setPickError] = useState<string | null>(null)
+    const [pickError, setPickError] = useState<{ message: string; canRetry: boolean } | null>(null)
     const [migrationChoice, setMigrationChoice] = useState<MigrationChoice | null>(null)
     const [migrationBusy, setMigrationBusy] = useState<MigrationChoice | null>(null)
     const [migrationError, setMigrationError] = useState<string | null>(null)
@@ -173,9 +173,25 @@ const FirstRunWizard = ({ onComplete }: Props) => {
                 setPicked(folder)
                 setAccessError(null)
             }
-        } catch {
-            setPickError("Couldn't open the folder picker. Retry?")
+        } catch (e) {
+            // NO_PICKER means the device has no document picker app, so retrying is pointless - steer them to the fallback below.
+            if ((e as { code?: string })?.code === "NO_PICKER") {
+                setPickError({ message: "This device has no compatible folder picker functionality. Use app default storage below.", canRetry: false })
+            } else {
+                setPickError({ message: "Couldn't open the folder picker. Retry?", canRetry: true })
+            }
         }
+    }, [])
+
+    const handleUseInternalStorage = useCallback(async () => {
+        setPickError(null)
+        try {
+            await storageBridge.clearFolder()
+        } catch (e) {
+            console.warn("[FirstRunWizard] clearFolder failed", e)
+        }
+        setPicked(INTERNAL_STORAGE_FOLDER)
+        setAccessError(null)
     }, [])
 
     const handleMigrationChoice = useCallback(
@@ -206,6 +222,7 @@ const FirstRunWizard = ({ onComplete }: Props) => {
     )
 
     const folderComplete = picked !== null
+    const usingInternalDefault = picked?.uri === ""
     const migrationComplete = !hasLegacyFiles || migrationChoice !== null
     const permissionsComplete = permissionsGranted !== null && permissionsGranted.accessibility && permissionsGranted.overlay && permissionsGranted.battery
     const canFinish = folderComplete && migrationComplete && permissionsComplete
@@ -216,11 +233,16 @@ const FirstRunWizard = ({ onComplete }: Props) => {
         if (!canFinish) return
         setSaveError(null)
         setFinishing(true)
+        // Internal storage has no SAF Uri to probe, and validateAccess() reports false for a null tree, so accept it directly.
         let ok = false
-        try {
-            ok = await storageBridge.validateAccess()
-        } catch {
-            ok = false
+        if (usingInternalDefault) {
+            ok = true
+        } else {
+            try {
+                ok = await storageBridge.validateAccess()
+            } catch {
+                ok = false
+            }
         }
         if (!ok) {
             setFinishing(false)
@@ -236,7 +258,7 @@ const FirstRunWizard = ({ onComplete }: Props) => {
             setSaveError("Couldn't save your setup. Tap Finish to retry.")
             setFinishing(false)
         }
-    }, [canFinish, onComplete])
+    }, [canFinish, onComplete, usingInternalDefault])
 
     const migrationConfirmationLabel = useMemo(() => {
         if (migrationChoice === "move") return "Moved to new folder"
@@ -283,12 +305,17 @@ const FirstRunWizard = ({ onComplete }: Props) => {
                                 </CustomButton>
                                 {pickError && (
                                     <View style={styles.errorBlock}>
-                                        <Text style={[styles.error, { color: colors.error }]}>{pickError}</Text>
-                                        <CustomButton variant="primary" onPress={handlePick}>
-                                            Retry
-                                        </CustomButton>
+                                        <Text style={[styles.error, { color: colors.error }]}>{pickError.message}</Text>
+                                        {pickError.canRetry && (
+                                            <CustomButton variant="primary" onPress={handlePick}>
+                                                Retry
+                                            </CustomButton>
+                                        )}
                                     </View>
                                 )}
+                                <Pressable onPress={handleUseInternalStorage} style={styles.changeLinkPressable} hitSlop={8}>
+                                    <Text style={[styles.changeLink, { color: colors.primary }]}>Use app default storage instead</Text>
+                                </Pressable>
                             </>
                         ) : (
                             <View style={[styles.selected, { borderColor: colors.success }]}>
@@ -296,7 +323,7 @@ const FirstRunWizard = ({ onComplete }: Props) => {
                                 <Text style={[styles.selectedName, { color: colors.text }]}>{picked.name}</Text>
                                 <Text style={[styles.selectedSub, { color: colors.textMuted }]}>logs/{"\n"}recordings/</Text>
                                 <Pressable onPress={handlePick} style={styles.changeLinkPressable} hitSlop={8}>
-                                    <Text style={[styles.changeLink, { color: colors.primary }]}>Change folder</Text>
+                                    <Text style={[styles.changeLink, { color: colors.primary }]}>{usingInternalDefault ? "Pick a folder instead" : "Change folder"}</Text>
                                 </Pressable>
                             </View>
                         )}


### PR DESCRIPTION
## Description
- This PR resolves #377 by letting users on devices without a working document picker (such as Redfinger cloud phones, where pressing "Pick a folder" did nothing) finish first-time setup by choosing internal storage instead.
