### PR TITLE
Retry mandatory races including Debut race whenever possible

### DIFF
--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Racing.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Racing.kt
@@ -1028,9 +1028,10 @@ class Racing(private val game: Game, private val campaign: Campaign) {
     /**
      * Executes the race with retry logic.
      *
+     * @param isMandatory True if this is a mandatory race, which always retries until 1st place whenever possible.
      * @return True if the bot completed the race; otherwise false.
      */
-    fun runRaceWithRetries(): Boolean {
+    fun runRaceWithRetries(isMandatory: Boolean = false): Boolean {
         MessageLog.i(TAG, "[RACE] Proceeding to handle the race...")
         game.wait(0.5, skipWaitingForLoading = true)
 
@@ -1183,6 +1184,16 @@ class Racing(private val game: Game, private val campaign: Campaign) {
                         game.wait(3.0)
                         retriesThisRace++
                         raceRetries--
+                    }
+                }
+
+                // Mandatory races always retry until 1st place whenever possible.
+                isMandatory &&
+                    ButtonTryAgainAlt.checkDisabled(game.imageUtils, sourceBitmap = bitmap) == false &&
+                    !LabelCongratulations.check(game.imageUtils, sourceBitmap = bitmap) -> {
+                    MessageLog.i(TAG, "[RACE] Mandatory race finished below 1st place. Retrying for the win...")
+                    if (ButtonTryAgainAlt.click(game.imageUtils, sourceBitmap = bitmap)) {
+                        game.wait(3.0)
                     }
                 }
 
@@ -1684,7 +1695,7 @@ class Racing(private val game: Game, private val campaign: Campaign) {
         game.waitForLoading()
 
         // Skip the race if possible, otherwise run it manually.
-        runRaceWithRetries()
+        runRaceWithRetries(isMandatory = true)
         finalizeRaceResults()
 
         MessageLog.v(TAG, "[RACE] Racing process for Mandatory Race is completed. Grade: ${lastRaceGrade ?: "Mandatory"}")


### PR DESCRIPTION
## Description
- This PR addresses #355 by making mandatory races (including the debut race handled by `handleMandatoryRace()`) always retry via the in-game Try Again button when they finish below 1st place, regardless of the retry settings.
- Previously every retry branch in `runRaceWithRetries()` required an eligible race `grade`, so a non-graded mandatory race like the debut was never retried even with retries available:

```
[RACE] No retries remaining or eligible race conditions not met.
[RACE] Reached race results screen. Exiting race retry loop...
[RACE] Race result detected - 1st place: false.
```
