### PR TITLE
Distinguish same-track races by fan count for the solver

### DIFF
--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Racing.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Racing.kt
@@ -2104,6 +2104,7 @@ class Racing(private val game: Game, private val campaign: Campaign) {
 
         if (plannedKey != null) {
             MessageLog.i(TAG, "[RACE] Smart Race Solver wants \"$plannedKey\" for turn ${campaign.date.day} — scanning until matched.")
+            val sourceBitmap = game.imageUtils.getSourceBitmap()
             for (location in doublePredictionLocations) {
                 val raceName = game.imageUtils.extractRaceName(location)
                 val raceDataList = lookupRaceInDatabase(campaign.date.day, raceName)
@@ -2116,6 +2117,19 @@ class Racing(private val game: Game, private val campaign: Campaign) {
                 }
                 val match = raceDataList.firstOrNull { SmartRaceSolverIntegration.isRaceKeyMatch(it, plannedKey) }
                 if (match != null) {
+                    // Two races can share this row's track string (e.g. Oaks vs Derby). Confirm the planned race by its OCR'd fan count before tapping.
+                    if (raceDataList.size > 1) {
+                        val rowFans = game.imageUtils.determineExtraRaceFans(location, sourceBitmap, forceRacing = true).fans
+                        if (!SmartRaceSolverIntegration.isCorrectCollisionRow(match.fans, rowFans)) {
+                            MessageLog.i(TAG, "[RACE] Same-track sibling at this row (fans=$rowFans != planned ${match.fans}). Continuing scan for \"${match.name}\".")
+                            continue
+                        }
+                        if (rowFans == -1) {
+                            MessageLog.w(TAG, "[WARN] processSmartRacing:: Same-track collision but fan OCR failed; tapping scanned row for \"${match.name}\".")
+                        } else {
+                            MessageLog.i(TAG, "[RACE] Same-track collision resolved by fans=$rowFans for \"${match.name}\".")
+                        }
+                    }
                     MessageLog.v(TAG, "[RACE] Smart Race Solver selected \"${match.name}\". Selecting it.")
                     SmartRaceSolverIntegration.markPendingRace(
                         raceKey = match.name,

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/Trackblazer.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/Trackblazer.kt
@@ -545,6 +545,35 @@ class Trackblazer(game: Game) : Campaign(game) {
         }
 
     /**
+     * Decides whether to tap [race]'s scanned row, disambiguating same-track siblings by fan count. Only the solver-matched race needs this.
+     * When two races on a turn share one track string (e.g. Japanese Oaks and Tokyo Yushun are both "Tokyo Turf 2400m"), the planned race's name
+     * can attach to the wrong physical row, so the row is accepted only when its OCR'd fan count matches the planned race.
+     * A failed OCR accepts the row so behavior never regresses below the prior tap-the-scanned-row logic.
+     *
+     * @param detectedName The row's OCR'd track string, for logging.
+     * @param race The solver-matched race being considered at this row.
+     * @param matches All database races resolved from [detectedName]. A single match means there is no collision to resolve.
+     * @param location On-screen location of this row's double-star prediction.
+     * @param sb The analysis buffer that records skipped siblings.
+     * @param sourceBitmap Optional current screenshot to crop from. Captured on demand when omitted.
+     * @return True when this row should be tapped for [race].
+     */
+    private fun shouldTapSolverRow(detectedName: String, race: Racing.RaceData, matches: List<Racing.RaceData>, location: Point, sb: StringBuilder, sourceBitmap: Bitmap? = null): Boolean {
+        if (matches.size <= 1) return true
+        val rowFans = game.imageUtils.determineExtraRaceFans(location, sourceBitmap ?: game.imageUtils.getSourceBitmap(), forceRacing = true).fans
+        if (SmartRaceSolverIntegration.isCorrectCollisionRow(race.fans, rowFans)) {
+            if (rowFans == -1) {
+                MessageLog.w(TAG, "[WARN] findSuitableRace:: Same-track collision on \"$detectedName\"; fan OCR failed, tapping scanned row for \"${race.name}\".")
+            } else {
+                MessageLog.i(TAG, "[RACE] Same-track collision on \"$detectedName\" resolved by fans=$rowFans for \"${race.name}\".")
+            }
+            return true
+        }
+        sb.appendLine("\n- Skipped same-track sibling \"${race.name}\" (planned fans=${race.fans}, row fans=$rowFans).")
+        return false
+    }
+
+    /**
      * Searches the race list for a suitable Trackblazer race based on double-star predictions and grade criteria.
      *
      * Junior Year: G1/G2/G3 with double predictions. Classic/Senior: Priority racing, but if consecutive race count >= 3, only G1/G2/G3.
@@ -649,7 +678,7 @@ class Trackblazer(game: Game) : Campaign(game) {
                             allSuitableRaces.add(candidate)
                             val suffix = if (solverMatched) " [Smart Race Solver override]" else ""
                             sb.appendLine("\n- Found Suitable Race: \"${race.name}\" (${race.grade}) Rival: $rivalFound$suffix")
-                            if (solverMatched) {
+                            if (solverMatched && shouldTapSolverRow(detectedName, race, matches, screenPoint, sb)) {
                                 solverMatchedCandidate = candidate
                             }
                         } else {
@@ -714,7 +743,7 @@ class Trackblazer(game: Game) : Campaign(game) {
                     if (isSuitable) {
                         val candidate = Candidate(location, race, detectedName, rivalFound)
                         allSuitableRaces.add(candidate)
-                        if (solverMatched) {
+                        if (solverMatched && shouldTapSolverRow(detectedName, race, matches, location, sb, sourceBitmap)) {
                             solverMatchedCandidate = candidate
                         }
                     }

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/solver/SmartRaceSolverIntegration.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/solver/SmartRaceSolverIntegration.kt
@@ -570,6 +570,17 @@ object SmartRaceSolverIntegration {
     fun isRaceKeyMatch(raceData: RaceData, raceKey: String): Boolean = raceData.name == raceKey || raceData.name == raceNameFromKey(raceKey)
 
     /**
+     * Decides whether a scanned race row is the planned race when two races on a turn share the same on-screen track string.
+     * Such siblings (e.g. Japanese Oaks and Tokyo Yushun are both "Tokyo Turf 2400m") differ in fan count, so the row's OCR'd fan count is the tie-breaker.
+     * A failed OCR ([ocrFans] == -1) accepts the row so behavior never regresses below the prior tap-the-scanned-row logic.
+     *
+     * @param plannedFans Fan count of the solver-planned race from the database.
+     * @param ocrFans Fan count OCR'd from the scanned row, or -1 if the OCR failed.
+     * @return True when the scanned row is (or is assumed to be) the planned race.
+     */
+    fun isCorrectCollisionRow(plannedFans: Int, ocrFans: Int): Boolean = ocrFans == -1 || ocrFans == plannedFans
+
+    /**
      * Computes a preview schedule from the user-supplied [configJson], without consulting any
      * runtime race history. Used by the settings UI to render a calendar preview of what the
      * solver would do if a fresh run started today with the current configuration.


### PR DESCRIPTION
## Description
- This PR resolves #359 due to the Smart Race Solver running the wrong race when two races on the same turn share an identical on-screen track string (e.g. `Japanese Oaks` and `Tokyo Yushun (Japanese Derby)` are both "Tokyo Turf 2400m"), so locking `Japanese Oaks` could still run the Derby.
- When `lookupRaceInDatabase()` returns more than one race for the same track string and the planned race is among them, the bot now OCRs each candidate row's fan count via `determineExtraRaceFans()` and taps only the row whose fans match the planned race (new `isCorrectCollisionRow()` helper); a failed OCR taps the scanned row as before so behavior never regresses.

Previously the log reported the correct race while the bot tapped the wrong row:

```
[INFO] Extracted race name: "Tokyo Turf 2400m (Med) Left"
[RACE] Found 2 exact matches with same name but different fan counts:
[RACE]     - "Japanese Oaks" (Fans: 11000)
[RACE]     - "Tokyo Yushun (Japanese Derby)" (Fans: 20000)
Selected Race: Japanese Oaks (G1) Rival: true [Smart Race Solver pick]
```
