### PR TITLE
Cap consecutive races in the Smart Race Solver and fix calendar off-by-ones

### DIFF
--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/solver/Heuristic.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/solver/Heuristic.kt
@@ -109,7 +109,12 @@ object Heuristic {
             } else {
                 beam.decisions.count { (t, d) -> d is Decision.RaceDecision && state.lockedDecisions[t] !is Decision.RaceDecision }
             }
-        if (cap == null || optionalRacesSoFar < cap) {
+        // Hard cap on back-to-back races: skip race candidates once the chain would exceed maxConsecutiveRaces, unless the
+        // landing turn is a Late-Dec free turn (where the cap is waived so a chain may run into year-end).
+        val consecutiveCap = state.maxConsecutiveRaces
+        val consecutiveCapBlocks =
+            consecutiveCap != null && beam.consecutiveRaces + 1 > consecutiveCap && turn !in ScoringFunctions.LATE_DEC_FREE_TURNS
+        if ((cap == null || optionalRacesSoFar < cap) && !consecutiveCapBlocks) {
             for (race in racesHere) {
                 children += applyDecision(beam, turn, Decision.RaceDecision(race.key), state)
             }

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/solver/MilpSolver.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/solver/MilpSolver.kt
@@ -17,16 +17,16 @@ import org.ojalgo.optimisation.Variable
  * Objective (maximize):
  *   sum(r[turn][race] * raceValue(race))
  *   + sum(y[epithet] * epithetContribution(epithet))
- *   - sum(z[turn] * consecutiveRacePenalty)   (zero on Late-Dec turns 23, 47, 71)
+ *   - sum(z[turn] * consecutiveRacePenalty)   (zero on Late-Dec turns 24, 48, 72)
  *   - sum(x[summer turn] * summerPenalty)
  *
  * Each [EpithetMatcher] becomes one or two linear inequalities tying y[e] to the relevant
  * sum of r-variables and a history-derived constant.
  */
 object MilpSolver {
-    /** End-of-year halves (Junior/Classic/Senior Dec-2). The 3-race conditioning penalty is
+    /** End-of-year halves (Junior/Classic/Senior Late Dec). The 3-race conditioning penalty is
      *  waived on these turns to match the reference solver's exemption. */
-    private val LATE_DEC_FREE_TURNS: Set<TurnNumber> = setOf(23, 47, 71)
+    private val LATE_DEC_FREE_TURNS: Set<TurnNumber> = setOf(24, 48, 72)
 
     /** Classic + Senior summer race-blocked turns (Early Jul -> Late Aug). */
     private val CLASSIC_SENIOR_SUMMER_TURNS: Set<TurnNumber> = setOf(37, 38, 39, 40, 61, 62, 63, 64)

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/solver/MilpSolver.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/solver/MilpSolver.kt
@@ -24,10 +24,6 @@ import org.ojalgo.optimisation.Variable
  * sum of r-variables and a history-derived constant.
  */
 object MilpSolver {
-    /** End-of-year halves (Junior/Classic/Senior Late Dec). The 3-race conditioning penalty is
-     *  waived on these turns to match the reference solver's exemption. */
-    private val LATE_DEC_FREE_TURNS: Set<TurnNumber> = setOf(24, 48, 72)
-
     /** Classic + Senior summer race-blocked turns (Early Jul -> Late Aug). */
     private val CLASSIC_SENIOR_SUMMER_TURNS: Set<TurnNumber> = setOf(37, 38, 39, 40, 61, 62, 63, 64)
 
@@ -113,6 +109,7 @@ object MilpSolver {
             wireSummerHardBlock()
             wireManualLocks()
             wireMaxRaces()
+            wireConsecutiveRaceHardCap()
             wireConsecutiveRaceIndicators()
             wireEpithetMatchers()
             wireDependsOn()
@@ -183,6 +180,21 @@ object MilpSolver {
                 }
             val expr = model.newExpression("max_races").upper((cap + lockedRaceTurns).toDouble())
             for ((_, v) in xVars) expr.set(v, 1.0)
+        }
+
+        /**
+         * Hard cap on consecutive races. For every window of (cap + 1) turns ending at turn t, sum(x[t-cap..t]) <= cap, so
+         * no chain exceeds [SolverState.maxConsecutiveRaces]. The window whose landing turn is a Late-Dec free turn is
+         * skipped so a chain may run into year-end, matching the soft penalty's exemption. No-op when the cap is null.
+         */
+        private fun wireConsecutiveRaceHardCap() {
+            val cap = state.maxConsecutiveRaces?.takeIf { it >= 1 } ?: return
+            for (t in turns) {
+                if (t - cap < turns.first) continue
+                if (t in ScoringFunctions.LATE_DEC_FREE_TURNS) continue
+                val expr = model.newExpression("consec_cap_$t").upper(cap.toDouble())
+                for (i in (t - cap)..t) expr.set(xVars[i]!!, 1.0)
+            }
         }
 
         /**
@@ -289,7 +301,7 @@ object MilpSolver {
                 v.weight(ScoringFunctions.epithetContribution(epithet, state.weights))
             }
             for ((t, v) in zVars) {
-                if (t in LATE_DEC_FREE_TURNS) continue
+                if (t in ScoringFunctions.LATE_DEC_FREE_TURNS) continue
                 v.weight(-state.weights.consecutiveRacePenalty)
             }
         }

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/solver/ScoringFunctions.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/solver/ScoringFunctions.kt
@@ -152,10 +152,11 @@ object ScoringFunctions {
     }
 
     /**
-     * Turns where landing the third+ consecutive race incurs zero conditioning penalty. These are the
-     * Late-December halves (last turn) of each class year - Junior (24), Classic (48), and Senior (72).
+     * Turns where landing the third+ consecutive race incurs zero conditioning penalty, and where the consecutive-race
+     * hard cap is waived. These are the Late-December halves (last turn) of each class year - Junior (24), Classic (48),
+     * and Senior (72). Shared by the soft penalty, the MILP objective, and the consecutive-race hard cap.
      */
-    private val LATE_DEC_FREE_TURNS: Set<TurnNumber> = setOf(24, 48, 72)
+    val LATE_DEC_FREE_TURNS: Set<TurnNumber> = setOf(24, 48, 72)
 
     /**
      * Penalty applied when scheduling a third (or later) consecutive race. The reference

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/solver/ScoringFunctions.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/solver/ScoringFunctions.kt
@@ -152,17 +152,16 @@ object ScoringFunctions {
     }
 
     /**
-     * Turns where landing the third+ consecutive race incurs zero conditioning penalty. These
-     * are the Late-December halves at the end of each class year - Junior Dec-2 (turn 23),
-     * Classic Dec-2 (47), and Senior Dec-2 (71). Mirrors the reference solver's `LATE_DEC_WINDOWS`.
+     * Turns where landing the third+ consecutive race incurs zero conditioning penalty. These are the
+     * Late-December halves (last turn) of each class year - Junior (24), Classic (48), and Senior (72).
      */
-    private val LATE_DEC_FREE_TURNS: Set<TurnNumber> = setOf(23, 47, 71)
+    private val LATE_DEC_FREE_TURNS: Set<TurnNumber> = setOf(24, 48, 72)
 
     /**
      * Penalty applied when scheduling a third (or later) consecutive race. The reference
      * solver penalises the *start* of a 3-race chain. We apply it on every additional race
      * past the second to keep beams deterministic and incremental. Returns zero on Late-Dec
-     * windows (turns 23, 47, 71) to match the reference's end-of-year exemption.
+     * turns (24, 48, 72) to match the reference's end-of-year exemption.
      *
      * @param consecutiveRaceCount Number of consecutive races including the current one.
      * @param turn Turn the third+ race lands on. Checked against [LATE_DEC_FREE_TURNS].

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/solver/SmartRaceSolverIntegration.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/solver/SmartRaceSolverIntegration.kt
@@ -633,6 +633,7 @@ object SmartRaceSolverIntegration {
                 lockedDecisions = applied.lockedDecisions,
                 weights = parseWeightsObj(config.optJSONObject("weights")),
                 maxRaces = config.optInt("maxRaces", -1).takeIf { it > 0 },
+                maxConsecutiveRaces = config.optInt("maxConsecutiveRaces", 3).takeIf { it > 0 },
             )
 
         val schedule = SmartRaceSolver.solve(state)
@@ -678,6 +679,7 @@ object SmartRaceSolverIntegration {
             lockedDecisions = applied.lockedDecisions,
             weights = readWeights(),
             maxRaces = readMaxRaces(),
+            maxConsecutiveRaces = readMaxConsecutiveRaces(),
         )
     }
 
@@ -920,6 +922,14 @@ object SmartRaceSolverIntegration {
      * @return The cap as a positive Int, or null when the solver should plan races without an upper bound.
      */
     private fun readMaxRaces(): Int? = SettingsHelper.getIntSetting("racing", "smartRaceSolverMaxRaces", -1).takeIf { it > 0 }
+
+    /**
+     * Reads the user's maximum consecutive-races cap. Defaults to 3 when unset so the cap is active out of the box.
+     * Returns null (no limit) only when the user explicitly sets 0 or a negative value.
+     *
+     * @return The cap as a positive Int, or null when consecutive races should be unbounded.
+     */
+    private fun readMaxConsecutiveRaces(): Int? = SettingsHelper.getIntSetting("racing", "smartRaceSolverMaxConsecutiveRaces", 3).takeIf { it > 0 }
 
     /**
      * Parses a weights JSON object. Each field falls back to the corresponding [Weights] default when missing.

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/solver/SolverState.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/solver/SolverState.kt
@@ -222,22 +222,19 @@ data class SolverState(
 
     companion object {
         /**
-         * Default summer training blocks (no-race turns). Junior: Early Jul -> Early Aug.
-         * Classic and Senior: Early Jul -> Late Aug. Mirrors the reference solver's constant.
+         * Default summer training blocks (no-race turns), as 1-based turn numbers. Summer camp runs Early Jul -> Late Aug
+         * in Classic (37-40) and Senior (61-64) only. Junior year has no summer camp.
          */
         val DEFAULT_SUMMER_BLOCKS: Set<TurnNumber> =
             setOf(
-                12,
-                13,
-                14,
-                36,
                 37,
                 38,
                 39,
-                60,
+                40,
                 61,
                 62,
                 63,
+                64,
             )
     }
 }

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/solver/SolverState.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/solver/SolverState.kt
@@ -200,6 +200,7 @@ data class RaceLossRecord(
  * @property summerBlockTurns No-race turns. Defaults to [DEFAULT_SUMMER_BLOCKS].
  * @property weights Active scoring weights.
  * @property maxRaces Maximum number of optional races the solver may schedule, or null for no limit. Locked/mandatory races always run and do not count toward this cap.
+ * @property maxConsecutiveRaces Maximum races allowed in back-to-back turns, or null for no limit. Late-December turns (24, 48, 72) are exempt so a chain may run into year-end.
  */
 data class SolverState(
     val currentTurn: TurnNumber,
@@ -217,6 +218,7 @@ data class SolverState(
     val summerBlockTurns: Set<TurnNumber> = DEFAULT_SUMMER_BLOCKS,
     val weights: Weights = Weights(),
     val maxRaces: Int? = null,
+    val maxConsecutiveRaces: Int? = null,
 ) {
     val epithetsByName: Map<String, Epithet> by lazy { epithets.associateBy { it.name } }
 

--- a/android/app/src/test/java/com/steve1316/uma_android_automation/bot/solver/ConsecutiveRaceCapTest.kt
+++ b/android/app/src/test/java/com/steve1316/uma_android_automation/bot/solver/ConsecutiveRaceCapTest.kt
@@ -1,0 +1,83 @@
+package com.steve1316.uma_android_automation.bot.solver
+
+import com.steve1316.uma_android_automation.bot.solver.TestFixtures.race
+import com.steve1316.uma_android_automation.bot.solver.TestFixtures.state
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("Consecutive-race hard cap")
+class ConsecutiveRaceCapTest {
+    /** Longest run of back-to-back RaceDecision turns across the 72-turn calendar. */
+    private fun longestRaceRun(schedule: Schedule): Int {
+        var longest = 0
+        var current = 0
+        for (t in 1..72) {
+            if (schedule.decisions[t] is Decision.RaceDecision) {
+                current++
+                longest = maxOf(longest, current)
+            } else {
+                current = 0
+            }
+        }
+        return longest
+    }
+
+    /** G1 races on five back-to-back Senior turns (Late Jan -> Late Mar). None are Late-Dec exempt. */
+    private fun fiveInARowState(maxConsecutiveRaces: Int?): SolverState =
+        state(
+            currentTurn = 49,
+            races = (50..54).map { race("Senior G1 $it", it) },
+        ).copy(maxConsecutiveRaces = maxConsecutiveRaces)
+
+    @Test
+    fun milpChainsAllFiveWithoutCap() {
+        val schedule = MilpSolver.solve(fiveInARowState(null))
+        assertEquals(5, longestRaceRun(schedule), "Without a cap the solver should chain all five eligible G1 races")
+    }
+
+    @Test
+    fun milpCapsConsecutiveRacesAtThree() {
+        val schedule = MilpSolver.solve(fiveInARowState(3))
+        assertTrue(longestRaceRun(schedule) <= 3, "MILP must not schedule more than 3 races in a row when capped")
+    }
+
+    @Test
+    fun beamSearchCapsConsecutiveRacesAtThree() {
+        val schedule = Heuristic.search(fiveInARowState(3))
+        assertTrue(longestRaceRun(schedule) <= 3, "Beam search must not schedule more than 3 races in a row when capped")
+    }
+
+    @Test
+    fun facadeCapsConsecutiveRacesAtThree() {
+        val schedule = SmartRaceSolver.solve(fiveInARowState(3))
+        assertTrue(longestRaceRun(schedule) <= 3, "The solver facade must respect the consecutive-race cap")
+    }
+
+    @Test
+    fun lateDecemberTurnIsExemptFromTheCap() {
+        // Four back-to-back races ending on Classic Late Dec (turn 48). The cap is waived on turn 48, so a chain of
+        // four landing there is allowed even with a cap of 3.
+        val st =
+            state(
+                currentTurn = 44,
+                races = (45..48).map { race("Classic G1 $it", it) },
+            ).copy(maxConsecutiveRaces = 3)
+        val schedule = MilpSolver.solve(st)
+        assertTrue(
+            (45..48).all { schedule.decisions[it] is Decision.RaceDecision },
+            "A race chain may run into the Late-December exempt turn (48) even when capped at 3",
+        )
+    }
+
+    @Test
+    fun calendarConstantsUseCorrectOneBasedTurns() {
+        assertEquals(setOf(24, 48, 72), ScoringFunctions.LATE_DEC_FREE_TURNS, "Late-Dec exemption must target the last turn of each year")
+        assertEquals(
+            setOf(37, 38, 39, 40, 61, 62, 63, 64),
+            SolverState.DEFAULT_SUMMER_BLOCKS,
+            "Summer blocks must be the Classic/Senior Jul-Aug turns; Junior has no summer camp",
+        )
+    }
+}

--- a/android/app/src/test/java/com/steve1316/uma_android_automation/bot/solver/ScoringFunctionsTest.kt
+++ b/android/app/src/test/java/com/steve1316/uma_android_automation/bot/solver/ScoringFunctionsTest.kt
@@ -118,18 +118,18 @@ class ScoringFunctionsTest {
 
     @Test
     fun consecutivePenaltyIsWaivedOnLateDecTurns() {
-        // Late-Dec turns (23, 47, 71) end the year and don't carry conditioning penalty.
-        assertEquals(0.0, ScoringFunctions.consecutiveRacePenalty(3, 23, w), 1e-9)
-        assertEquals(0.0, ScoringFunctions.consecutiveRacePenalty(5, 47, w), 1e-9)
-        assertEquals(0.0, ScoringFunctions.consecutiveRacePenalty(4, 71, w), 1e-9)
+        // Late-Dec turns (24, 48, 72) end the year and don't carry conditioning penalty.
+        assertEquals(0.0, ScoringFunctions.consecutiveRacePenalty(3, 24, w), 1e-9)
+        assertEquals(0.0, ScoringFunctions.consecutiveRacePenalty(5, 48, w), 1e-9)
+        assertEquals(0.0, ScoringFunctions.consecutiveRacePenalty(4, 72, w), 1e-9)
     }
 
     @Test
     fun summerBlockPenaltyAppliesOnlyInSummerTurns() {
         val st = state()
-        // Default summer blocks include 12, 13, 14 (Junior summer).
-        assertEquals(w.summerPenalty, ScoringFunctions.summerBlockPenalty(13, st), 1e-9)
-        assertEquals(0.0, ScoringFunctions.summerBlockPenalty(20, st), 1e-9)
+        // Summer camp is Classic/Senior only (37-40, 61-64); Junior year has no summer.
+        assertEquals(w.summerPenalty, ScoringFunctions.summerBlockPenalty(37, st), 1e-9)
+        assertEquals(0.0, ScoringFunctions.summerBlockPenalty(13, st), 1e-9)
     }
 
     @Test

--- a/src/context/BotStateContext.tsx
+++ b/src/context/BotStateContext.tsx
@@ -79,6 +79,7 @@ export interface Settings {
         smartRaceSolverForcedEpithets: string
         smartRaceSolverManualLocks: string
         smartRaceSolverMaxRaces: number
+        smartRaceSolverMaxConsecutiveRaces: number
         smartRaceSolverWeights: string
     }
 
@@ -283,6 +284,7 @@ export const defaultSettings: Settings = {
         smartRaceSolverForcedEpithets: "[]",
         smartRaceSolverManualLocks: "{}",
         smartRaceSolverMaxRaces: 0,
+        smartRaceSolverMaxConsecutiveRaces: 3,
         smartRaceSolverWeights: JSON.stringify({
             raceValue: 1.0,
             epithetValue: 1.0,

--- a/src/context/searchConfig.ts
+++ b/src/context/searchConfig.ts
@@ -508,6 +508,13 @@ const searchConfig: SearchOption[] = [
         parentId: "enable-smart-race-solver",
     },
     {
+        id: "smart-solver-max-consecutive-races",
+        title: "Maximum Consecutive Races",
+        description: "Caps how many races the solver schedules in back-to-back turns. Late-December turns are exempt so a chain may run into year-end. 0 = no limit.",
+        page: "SmartRaceSolverSettings",
+        parentId: "enable-smart-race-solver",
+    },
+    {
         id: "smart-solver-how-it-works",
         title: "How it works",
         description: "Smart Race Solver overview, loss handling, race-history scrape, and notes on epithets without matchers.",

--- a/src/context/searchConfig.ts
+++ b/src/context/searchConfig.ts
@@ -515,6 +515,20 @@ const searchConfig: SearchOption[] = [
         parentId: "enable-smart-race-solver",
     },
     {
+        id: "smart-solver-include-op",
+        title: "Include OP / Pre-OP Races",
+        description: "Lets the solver also consider OP and Pre-OP races, not just G1/G2/G3. Useful for weaker characters whose only eligible races are OP/Pre-OP.",
+        page: "SmartRaceSolverSettings",
+        parentId: "enable-smart-race-solver",
+    },
+    {
+        id: "smart-solver-allow-summer",
+        title: "Allow Racing During Summer",
+        description: "Lets the solver schedule races during the Classic/Senior summer training-camp turns, which are blocked by default.",
+        page: "SmartRaceSolverSettings",
+        parentId: "enable-smart-race-solver",
+    },
+    {
         id: "smart-solver-how-it-works",
         title: "How it works",
         description: "Smart Race Solver overview, loss handling, race-history scrape, and notes on epithets without matchers.",

--- a/src/lib/messageLog/buildSettingsBanner.ts
+++ b/src/lib/messageLog/buildSettingsBanner.ts
@@ -176,6 +176,7 @@ ${longTargetsString}${formatAdvancedScoringSection(settings.training)}
 🤖 Enable Smart Race Solver: ${settings.racing.enableSmartRaceSolver ? "✅" : "❌"}
 🚫 Disable Schedule Re-Plan Upon Race Loss: ${settings.racing.disableScheduleReplanOnRaceLoss ? "✅" : "❌"}
 🏁 Solver Max Extra Races: ${settings.racing.smartRaceSolverMaxRaces > 0 ? settings.racing.smartRaceSolverMaxRaces : "No limit"}
+⛓️ Solver Max Consecutive Races: ${settings.racing.smartRaceSolverMaxConsecutiveRaces > 0 ? settings.racing.smartRaceSolverMaxConsecutiveRaces : "No limit"}
 🎭 Solver Character Preset: ${settings.racing.smartRaceSolverCharacterPreset || "(none)"}
 🐎 Solver Aptitudes: Spr ${smartRaceSolverAptitudesObj.Sprint ?? "?"}, Mile ${smartRaceSolverAptitudesObj.Mile ?? "?"}, Med ${smartRaceSolverAptitudesObj.Medium ?? "?"}, Lng ${smartRaceSolverAptitudesObj.Long ?? "?"}, Trf ${smartRaceSolverAptitudesObj.Turf ?? "?"}, Drt ${smartRaceSolverAptitudesObj.Dirt ?? "?"}
 🎯 Solver Optimize Mode: ${smartRaceSolverOptimizeMode}

--- a/src/lib/solver/preview.ts
+++ b/src/lib/solver/preview.ts
@@ -49,6 +49,8 @@ export interface SolverConfigSnapshot {
     }
     /** Maximum number of optional races the solver may schedule. Mandatory races always run and do not count. 0 (or less) means no limit. */
     maxRaces: number
+    /** Maximum races allowed in back-to-back turns. Late-December turns are exempt. 0 (or less) means no limit. */
+    maxConsecutiveRaces: number
     /** Bundled races.json passed inline so the bridge does not depend on SettingsHelper persistence having reached SQLite by the time the preview fires. */
     racesDataJson?: string
     /** Bundled epithets.json passed inline for the same reason as `racesDataJson`. */

--- a/src/pages/SmartRaceSolverSettings/index.tsx
+++ b/src/pages/SmartRaceSolverSettings/index.tsx
@@ -1249,62 +1249,6 @@ const SmartRaceSolverSettings = () => {
                             </SearchableItem>
 
                             <SearchableItem
-                                id="disable-schedule-replan-on-race-loss"
-                                condition={enableSmartRaceSolver}
-                                parentId="enable-smart-race-solver"
-                                title="Disable Schedule Re-Plan Upon Race Loss"
-                                description="When a race is lost, keep the original schedule instead of re-planning the remaining turns. The loss is still recorded; epithets that depended on the lost race won't be re-routed."
-                            >
-                                <Row
-                                    title="Disable Schedule Re-Plan Upon Race Loss"
-                                    description="When a race is lost, keep the original schedule instead of re-planning the remaining turns. The loss is still recorded; epithets that depended on the lost race won't be re-routed."
-                                    right={<Switch checked={disableScheduleReplanOnRaceLoss} onCheckedChange={(checked) => updateRacingSetting("disableScheduleReplanOnRaceLoss", checked)} />}
-                                />
-                            </SearchableItem>
-
-                            {enableSmartRaceSolver && (
-                                <View style={[sectionsDisabledStyle, { paddingHorizontal: SPACING.md, paddingVertical: SPACING.sm }]}>
-                                    <CustomSlider
-                                        searchId="smart-solver-max-races"
-                                        searchCondition={enableSmartRaceSolver}
-                                        parentId="enable-smart-race-solver"
-                                        value={smartRaceSolverMaxRaces}
-                                        placeholder={defaultSettings.racing.smartRaceSolverMaxRaces}
-                                        onValueChange={(value) => updateRacingSetting("smartRaceSolverMaxRaces", value)}
-                                        onSlidingComplete={(value) => updateRacingSetting("smartRaceSolverMaxRaces", value)}
-                                        min={0}
-                                        max={40}
-                                        step={1}
-                                        label="Maximum Extra Races"
-                                        description="Caps how many optional races the solver schedules across the whole career. Mandatory career races always run and don't count toward this. 0 = no limit."
-                                        labelUnit=""
-                                        showValue={true}
-                                    />
-                                </View>
-                            )}
-
-                            {enableSmartRaceSolver && (
-                                <View style={[sectionsDisabledStyle, { paddingHorizontal: SPACING.md, paddingVertical: SPACING.sm }]}>
-                                    <CustomSlider
-                                        searchId="smart-solver-max-consecutive-races"
-                                        searchCondition={enableSmartRaceSolver}
-                                        parentId="enable-smart-race-solver"
-                                        value={smartRaceSolverMaxConsecutiveRaces}
-                                        placeholder={defaultSettings.racing.smartRaceSolverMaxConsecutiveRaces}
-                                        onValueChange={(value) => updateRacingSetting("smartRaceSolverMaxConsecutiveRaces", value)}
-                                        onSlidingComplete={(value) => updateRacingSetting("smartRaceSolverMaxConsecutiveRaces", value)}
-                                        min={0}
-                                        max={10}
-                                        step={1}
-                                        label="Maximum Consecutive Races"
-                                        description="Caps how many races the solver schedules in back-to-back turns. Late-December turns are exempt so a chain may run into year-end. 0 = no limit."
-                                        labelUnit=""
-                                        showValue={true}
-                                    />
-                                </View>
-                            )}
-
-                            <SearchableItem
                                 id="smart-solver-how-it-works"
                                 condition={enableSmartRaceSolver}
                                 parentId="enable-smart-race-solver"
@@ -1339,6 +1283,90 @@ const SmartRaceSolverSettings = () => {
                                 </View>
                             </SearchableItem>
                         </Section>
+
+                        {enableSmartRaceSolver && (
+                            <Section label="General" collapsible defaultOpen={true}>
+                                <SearchableItem
+                                    id="disable-schedule-replan-on-race-loss"
+                                    condition={enableSmartRaceSolver}
+                                    parentId="enable-smart-race-solver"
+                                    title="Disable Schedule Re-Plan Upon Race Loss"
+                                    description="When a race is lost, keep the original schedule instead of re-planning the remaining turns. The loss is still recorded; epithets that depended on the lost race won't be re-routed."
+                                >
+                                    <Row
+                                        title="Disable Schedule Re-Plan Upon Race Loss"
+                                        description="When a race is lost, keep the original schedule instead of re-planning the remaining turns. The loss is still recorded; epithets that depended on the lost race won't be re-routed."
+                                        right={<Switch checked={disableScheduleReplanOnRaceLoss} onCheckedChange={(checked) => updateRacingSetting("disableScheduleReplanOnRaceLoss", checked)} />}
+                                    />
+                                </SearchableItem>
+
+                                <View style={{ paddingHorizontal: SPACING.md, paddingVertical: SPACING.sm }}>
+                                    <CustomSlider
+                                        searchId="smart-solver-max-races"
+                                        searchCondition={enableSmartRaceSolver}
+                                        parentId="enable-smart-race-solver"
+                                        value={smartRaceSolverMaxRaces}
+                                        placeholder={defaultSettings.racing.smartRaceSolverMaxRaces}
+                                        onValueChange={(value) => updateRacingSetting("smartRaceSolverMaxRaces", value)}
+                                        onSlidingComplete={(value) => updateRacingSetting("smartRaceSolverMaxRaces", value)}
+                                        min={0}
+                                        max={40}
+                                        step={1}
+                                        label="Maximum Extra Races"
+                                        description="Caps how many optional races the solver schedules across the whole career. Mandatory career races always run and don't count toward this. 0 = no limit."
+                                        labelUnit=""
+                                        showValue={true}
+                                    />
+                                </View>
+
+                                <View style={{ paddingHorizontal: SPACING.md, paddingVertical: SPACING.sm }}>
+                                    <CustomSlider
+                                        searchId="smart-solver-max-consecutive-races"
+                                        searchCondition={enableSmartRaceSolver}
+                                        parentId="enable-smart-race-solver"
+                                        value={smartRaceSolverMaxConsecutiveRaces}
+                                        placeholder={defaultSettings.racing.smartRaceSolverMaxConsecutiveRaces}
+                                        onValueChange={(value) => updateRacingSetting("smartRaceSolverMaxConsecutiveRaces", value)}
+                                        onSlidingComplete={(value) => updateRacingSetting("smartRaceSolverMaxConsecutiveRaces", value)}
+                                        min={0}
+                                        max={10}
+                                        step={1}
+                                        label="Maximum Consecutive Races"
+                                        description="Caps how many races the solver schedules in back-to-back turns. Late-December turns are exempt so a chain may run into year-end. 0 = no limit."
+                                        labelUnit=""
+                                        showValue={true}
+                                    />
+                                </View>
+
+                                <SearchableItem
+                                    id="smart-solver-include-op"
+                                    condition={enableSmartRaceSolver}
+                                    parentId="enable-smart-race-solver"
+                                    title="Include OP / Pre-OP races"
+                                    description="By default the solver picks only G1/G2/G3 races. Enable this to also consider OP and Pre-OP races, useful for weaker characters whose only eligible races are OP/Pre-OP."
+                                >
+                                    <Row
+                                        title="Include OP / Pre-OP races"
+                                        description="By default the solver picks only G1/G2/G3 races. Enable this to also consider OP and Pre-OP races. Useful for weaker characters (e.g. Haru Urara) who can't qualify for many graded races; OP races contribute much less to stats but at least give the solver something to schedule."
+                                        right={<Switch checked={weights.includeOpAndPreOp} onCheckedChange={(checked) => updateWeight("includeOpAndPreOp", checked)} />}
+                                    />
+                                </SearchableItem>
+
+                                <SearchableItem
+                                    id="smart-solver-allow-summer"
+                                    condition={enableSmartRaceSolver}
+                                    parentId="enable-smart-race-solver"
+                                    title="Allow racing during Summer (Classic / Senior)"
+                                    description="By default the Summer training camp turns (Early Jul to Late Aug) in Classic and Senior years are blocked from racing. Enable this to let the solver schedule races in those turns."
+                                >
+                                    <Row
+                                        title="Allow racing during Summer (Classic / Senior)"
+                                        description="By default the Summer training camp turns (Early Jul → Late Aug) in Classic and Senior years are blocked from racing. Enable this to let the solver schedule races in those 4 turns each year - useful when a key epithet race lands in summer."
+                                        right={<Switch checked={weights.allowSummerRacing} onCheckedChange={(checked) => updateWeight("allowSummerRacing", checked)} />}
+                                    />
+                                </SearchableItem>
+                            </Section>
+                        )}
 
                         {enableSmartRaceSolver && showHeavySections && (
                             <>
@@ -1426,10 +1454,7 @@ const SmartRaceSolverSettings = () => {
                                             {renderAptitudeRow("Dirt", "Dirt")}
                                         </View>
                                     </SearchableItem>
-                                </Section>
 
-                                {/* Aptitude threshold */}
-                                <Section label="Aptitude Threshold">
                                     <SearchableItem
                                         id="smart-solver-aptitude-threshold"
                                         condition={enableSmartRaceSolver}
@@ -1438,6 +1463,7 @@ const SmartRaceSolverSettings = () => {
                                         description="Minimum aptitude (distance AND surface) required for a race to be eligible."
                                     >
                                         <View style={[sectionsDisabledStyle, { padding: SPACING.md }]}>
+                                            <Text style={{ ...TYPE.body, color: colors.text, fontWeight: "600", marginBottom: SPACING.xs }}>Aptitude Threshold</Text>
                                             <Text style={styles.description}>Minimum aptitude (distance AND surface) required for a race to be eligible.</Text>
                                             <View style={styles.aptButtons}>
                                                 {APTITUDE_RANKS.map((rank) => {
@@ -1453,29 +1479,6 @@ const SmartRaceSolverSettings = () => {
                                                         </Pressable>
                                                     )
                                                 })}
-                                            </View>
-
-                                            <Divider style={{ marginVertical: 16 }} />
-
-                                            <View style={{ flexDirection: "row", alignItems: "center", padding: SPACING.md, gap: SPACING.md }}>
-                                                <View style={{ flex: 1 }}>
-                                                    <Text style={[TYPE.body, { color: colors.text, fontWeight: "600" as const }]}>Include OP / Pre-OP races</Text>
-                                                    <Text style={[TYPE.caption, { color: colors.textMuted, marginTop: 2 }]}>
-                                                        By default the solver picks only G1/G2/G3 races. Enable this to also consider OP and Pre-OP races. Useful for weaker characters (e.g. Haru
-                                                        Urara) who can't qualify for many graded races; OP races contribute much less to stats but at least give the solver something to schedule.
-                                                    </Text>
-                                                </View>
-                                                <Switch checked={weights.includeOpAndPreOp} onCheckedChange={(checked) => updateWeight("includeOpAndPreOp", checked)} />
-                                            </View>
-                                            <View style={{ flexDirection: "row", alignItems: "center", padding: SPACING.md, gap: SPACING.md }}>
-                                                <View style={{ flex: 1 }}>
-                                                    <Text style={[TYPE.body, { color: colors.text, fontWeight: "600" as const }]}>Allow racing during Summer (Classic / Senior)</Text>
-                                                    <Text style={[TYPE.caption, { color: colors.textMuted, marginTop: 2 }]}>
-                                                        By default the Summer training camp turns (Early Jul → Late Aug) in Classic and Senior years are blocked from racing. Enable this to let the
-                                                        solver schedule races in those 4 turns each year - useful when a key epithet race lands in summer.
-                                                    </Text>
-                                                </View>
-                                                <Switch checked={weights.allowSummerRacing} onCheckedChange={(checked) => updateWeight("allowSummerRacing", checked)} />
                                             </View>
                                         </View>
                                     </SearchableItem>

--- a/src/pages/SmartRaceSolverSettings/index.tsx
+++ b/src/pages/SmartRaceSolverSettings/index.tsx
@@ -129,6 +129,7 @@ const SmartRaceSolverSettings = () => {
         smartRaceSolverForcedEpithets,
         smartRaceSolverManualLocks,
         smartRaceSolverMaxRaces,
+        smartRaceSolverMaxConsecutiveRaces,
         smartRaceSolverWeights,
     } = racingSettings
 
@@ -474,6 +475,7 @@ const SmartRaceSolverSettings = () => {
         manualLocks,
         weights,
         maxRaces: smartRaceSolverMaxRaces,
+        maxConsecutiveRaces: smartRaceSolverMaxConsecutiveRaces,
         // Only ship the bundled JSON the first time; Kotlin caches it after that.
         racesDataJson: bridgeDataPrimed ? undefined : RACES_DATA_JSON,
         epithetsDataJson: bridgeDataPrimed ? undefined : EPITHETS_DATA_JSON,
@@ -494,8 +496,9 @@ const SmartRaceSolverSettings = () => {
                 manualLocks,
                 weights,
                 maxRaces: smartRaceSolverMaxRaces,
+                maxConsecutiveRaces: smartRaceSolverMaxConsecutiveRaces,
             }),
-        [general?.scenario, smartRaceSolverCharacterPreset, aptitudes, targetEpithets, forcedEpithets, manualLocks, weights, smartRaceSolverMaxRaces]
+        [general?.scenario, smartRaceSolverCharacterPreset, aptitudes, targetEpithets, forcedEpithets, manualLocks, weights, smartRaceSolverMaxRaces, smartRaceSolverMaxConsecutiveRaces]
     )
 
     /**
@@ -1274,6 +1277,27 @@ const SmartRaceSolverSettings = () => {
                                         step={1}
                                         label="Maximum Extra Races"
                                         description="Caps how many optional races the solver schedules across the whole career. Mandatory career races always run and don't count toward this. 0 = no limit."
+                                        labelUnit=""
+                                        showValue={true}
+                                    />
+                                </View>
+                            )}
+
+                            {enableSmartRaceSolver && (
+                                <View style={[sectionsDisabledStyle, { paddingHorizontal: SPACING.md, paddingVertical: SPACING.sm }]}>
+                                    <CustomSlider
+                                        searchId="smart-solver-max-consecutive-races"
+                                        searchCondition={enableSmartRaceSolver}
+                                        parentId="enable-smart-race-solver"
+                                        value={smartRaceSolverMaxConsecutiveRaces}
+                                        placeholder={defaultSettings.racing.smartRaceSolverMaxConsecutiveRaces}
+                                        onValueChange={(value) => updateRacingSetting("smartRaceSolverMaxConsecutiveRaces", value)}
+                                        onSlidingComplete={(value) => updateRacingSetting("smartRaceSolverMaxConsecutiveRaces", value)}
+                                        min={0}
+                                        max={10}
+                                        step={1}
+                                        label="Maximum Consecutive Races"
+                                        description="Caps how many races the solver schedules in back-to-back turns. Late-December turns are exempt so a chain may run into year-end. 0 = no limit."
                                         labelUnit=""
                                         showValue={true}
                                     />


### PR DESCRIPTION
## Description
- This PR ports a configurable hard cap on consecutive races (default 3)to both the MILP and beam-search backends so the solver no longer chains 4-5 races in a row.
- It fixes the off-by-one `LATE_DEC_FREE_TURNS` and `DEFAULT_SUMMER_BLOCKS` calendar constants and removes the nonexistent Junior-year summer block.
- It adds a `Maximum Consecutive Races` slider and regroups the solver settings into new `General` and `Aptitudes` sections.
