### PR TITLE
Refactor and simplify the backend, frontend, and remote log viewer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,4 @@ docs/
 
 # Indexer-side embedder cache (downloaded MiniLM ONNX kept out of the APK).
 .cache/
+src/lib/training/scoring/__fixtures__/

--- a/android/app/src/main/assets/log_viewer.html
+++ b/android/app/src/main/assets/log_viewer.html
@@ -243,6 +243,8 @@
                 color: var(--accent-blue);
             }
 
+            /* ////////////////////////////////////////////////////////////////////////////////////////////////// */
+            /* ////////////////////////////////////////////////////////////////////////////////////////////////// */
             /* Modal Styles */
             .modal {
                 display: none;
@@ -1120,7 +1122,7 @@
                 z-index: 10000;
                 box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
                 max-width: 250px;
-                /* Cap height so a tall tooltip (many epithet rows) can never exceed the viewport. The 30px matches the 15px viewport padding used when positioning. */
+                /* Cap height so a tall tooltip never exceeds the viewport (30px = 2x the 15px positioning padding). */
                 max-height: calc(100vh - 30px);
                 overflow-y: auto;
             }
@@ -1257,16 +1259,10 @@
                 }
             }
 
-            /* Race History Calendar (Smart Race Solver). Sits as the rightmost flex child of
-               .dashboard, taking the empty space that .dashboard-info used to absorb via flex:1.
-               max-height matches the dashboard's natural row height so the calendar never
-               stretches the row; overflow scrolls internally. Visuals mirror the React Native
-               Smart Race Solver Settings page; keep palette and sizes in sync. */
-            /* Position-absolute body trick: the section is just the header in normal flow
-               (so it never grows the dashboard row beyond what aptitude / conditions /
-               dashboard-info already make it), then align-self: stretch expands the section
-               to the row's full height and the absolutely-positioned body fills the remaining
-               space below the header with internal scrolling. */
+            /* Race History Calendar (Smart Race Solver). Rightmost dashboard flex child. max-height matches the row so it
+               never stretches it and overflow scrolls internally. Mirrors the React Native SRS Settings page - keep palette and sizes in sync. */
+            /* Position-absolute body trick: the section is only the header in normal flow so it never grows the dashboard row,
+               then align-self: stretch expands it to full height and the absolute body fills the rest with internal scrolling. */
             .race-history-section {
                 position: relative;
                 padding: 8px 10px;
@@ -1279,12 +1275,9 @@
                 overflow: hidden;
             }
 
-            /* Hide the panel's content when the Smart Race Solver is disabled. Uses
-               `visibility: hidden` rather than `display: none` so the section keeps occupying its
-               flex slot - that way the other dashboard tiles (aptitudes, conditions, info) do not
-               shift across the row. Kotlin pushes the SRS_STATE message via LogStreamServer at run
-               start; the section keeps this class as its initial state so the empty grid never
-               flashes before the first message arrives. */
+            /* Hide the panel when the Smart Race Solver is disabled. Uses visibility: hidden, not display: none, so the section
+               keeps its flex slot and the other dashboard tiles do not shift. Kotlin pushes SRS_STATE via LogStreamServer at run
+               start. This class stays the initial state so the empty grid never flashes before the first message arrives. */
             .race-history-section.srs-disabled {
                 visibility: hidden;
             }
@@ -1680,9 +1673,9 @@
                     padding: 12px;
                 }
             }
-            /* ==============================================
-               Analytics Tab
-               ============================================== */
+            /* ////////////////////////////////////////////////////////////////////////////////////////////////// */
+            /* ////////////////////////////////////////////////////////////////////////////////////////////////// */
+            /* Analytics Tab */
             #analyticsView {
                 background: var(--bg-primary);
             }
@@ -1732,6 +1725,8 @@
                 to { opacity: 1; transform: none; }
             }
 
+            /* ////////////////////////////////////////////////////////////////////////////////////////////////// */
+            /* ////////////////////////////////////////////////////////////////////////////////////////////////// */
             /* Hero */
             .analytic-card.analytic-hero-card {
                 position: relative;
@@ -1794,6 +1789,8 @@
                 border-color: var(--log-error);
             }
 
+            /* ////////////////////////////////////////////////////////////////////////////////////////////////// */
+            /* ////////////////////////////////////////////////////////////////////////////////////////////////// */
             /* Sections + cards */
             .analytic-section { display: flex; flex-direction: column; gap: 14px; }
             .analytic-section-title {
@@ -2441,9 +2438,9 @@
         </footer>
 
         <script>
-            // ==============================================
+            // //////////////////////////////////////////////////////////////////////////////////////////////////
+            // //////////////////////////////////////////////////////////////////////////////////////////////////
             // Tooltip UI
-            // ==============================================
             const tooltip = document.createElement("div")
             tooltip.id = "tooltip"
             tooltip.className = "custom-tooltip"
@@ -2471,25 +2468,35 @@
             }
 
             /**
+             * Builds one breakdown row. A row with no value shows only its label.
+             * @param {{label: string, value?: string|number}} r Row to render.
+             * @returns {string} HTML string for a single tooltip row.
+             */
+            function tooltipRow(r) {
+                const value = r.value != null ? `<span class="tooltip-value">${r.value}</span>` : ""
+                return `<div class="tooltip-row"><span class="tooltip-label">${r.label}</span>${value}</div>`
+            }
+
+            /**
+             * Wraps breakdown rows in the tooltip's flex column.
+             * @param {Array<{label: string, value?: string|number}>} rows Rows to render.
+             * @returns {string} HTML string for the tooltip body.
+             */
+            function tooltipBreakdown(rows) {
+                return `<div style="display: flex; flex-direction: column; gap: 4px;">${rows.map(tooltipRow).join("")}</div>`
+            }
+
+            /**
              * Shows a specific tooltip for the training action counter.
              */
             function showTrainingTooltip(event) {
-                let content = '<div style="display: flex; flex-direction: column; gap: 4px;">'
                 const stats = ["Speed", "Stamina", "Power", "Guts", "Wit"]
-
-                stats.forEach(stat => {
-                    const count = trainingBreakdown[stat] || 0
+                const rows = stats.map((stat) => {
                     const level = trainingLevels[stat]
                     const levelText = level != null ? ` <span style="opacity: 0.7;">(Lvl ${level})</span>` : ""
-                    content += `
-                        <div class="tooltip-row">
-                            <span class="tooltip-label">${stat}</span>
-                            <span class="tooltip-value">${count}${levelText}</span>
-                        </div>`
+                    return { label: stat, value: `${trainingBreakdown[stat] || 0}${levelText}` }
                 })
-
-                content += "</div>"
-                showTooltip(event, "Training Breakdown", content)
+                showTooltip(event, "Training Breakdown", tooltipBreakdown(rows))
             }
 
             /**
@@ -2497,96 +2504,47 @@
              */
             function showSimpleTooltip(event, title) {
                 const count = event.currentTarget.querySelector(".stat-value").textContent
-                const content = `
-                    <div class="tooltip-row">
-                        <span class="tooltip-label">Total actions</span>
-                        <span class="tooltip-value">${count}</span>
-                    </div>`
-                showTooltip(event, title, content)
+                showTooltip(event, title, tooltipRow({ label: "Total actions", value: count }))
             }
 
             /**
              * Shows a specific tooltip for the race action counter.
              */
             function showRaceTooltip(event) {
-                let content = '<div style="display: flex; flex-direction: column; gap: 4px;">'
                 const grades = ["Finale", "G1", "G2", "G3", "OP", "Pre-OP", "Maiden", "Mandatory", "Standalone"]
-                
-                let found = false
-                grades.forEach(grade => {
+                const rows = []
+                grades.forEach((grade) => {
                     const count = raceBreakdown[grade] || 0
-                    if (count > 0) {
-                        found = true
-                        content += `
-                            <div class="tooltip-row">
-                                <span class="tooltip-label">${grade}</span>
-                                <span class="tooltip-value">${count}</span>
-                            </div>`
-                    }
+                    if (count > 0) rows.push({ label: grade, value: count })
                 })
-                
-                // Show "Other" if there are any unrecognized grades.
+
+                // Aggregate any unrecognized grades into a single "Other" row.
                 let otherCount = 0
                 for (const [grade, count] of Object.entries(raceBreakdown)) {
-                    if (!grades.includes(grade) && count > 0) {
-                        otherCount += count
-                    }
+                    if (!grades.includes(grade) && count > 0) otherCount += count
                 }
-                if (otherCount > 0) {
-                    found = true
-                    content += `
-                        <div class="tooltip-row">
-                            <span class="tooltip-label">Other</span>
-                            <span class="tooltip-value">${otherCount}</span>
-                        </div>`
-                }
-                
-                if (!found) {
-                    content += '<div class="tooltip-row"><span class="tooltip-label">No races yet</span></div>'
-                }
-                
-                content += "</div>"
-                showTooltip(event, "Race Grade Breakdown", content)
+                if (otherCount > 0) rows.push({ label: "Other", value: otherCount })
+
+                if (rows.length === 0) rows.push({ label: "No races yet" })
+                showTooltip(event, "Race Grade Breakdown", tooltipBreakdown(rows))
             }
 
             /**
              * Shows a specific tooltip for the mood recovery action counter.
              */
             function showMoodTooltip(event) {
-                let content = '<div style="display: flex; flex-direction: column; gap: 4px;">'
                 const types = ["Recreation", "Date", "Summer"]
-                
-                types.forEach(type => {
-                    const count = moodBreakdown[type] || 0
-                    content += `
-                        <div class="tooltip-row">
-                            <span class="tooltip-label">${type}</span>
-                            <span class="tooltip-value">${count}</span>
-                        </div>`
-                })
-                
-                content += "</div>"
-                showTooltip(event, "Mood Recovery Breakdown", content)
+                const rows = types.map((type) => ({ label: type, value: moodBreakdown[type] || 0 }))
+                showTooltip(event, "Mood Recovery Breakdown", tooltipBreakdown(rows))
             }
 
             /**
              * Shows a specific tooltip for the energy recovery action counter.
              */
             function showEnergyTooltip(event) {
-                let content = '<div style="display: flex; flex-direction: column; gap: 4px;">'
                 const types = ["Rest", "Date", "Summer"]
-                
-                types.forEach(type => {
-                    const count = energyBreakdown[type] || 0
-                    content += `
-                        <div class="tooltip-row">
-                            <span class="tooltip-label">${type}</span>
-                            <span class="tooltip-value">${count}</span>
-                        </div>`
-                })
-                
-                content += "</div>"
-                showTooltip(event, "Energy Recovery Breakdown", content)
+                const rows = types.map((type) => ({ label: type, value: energyBreakdown[type] || 0 }))
+                showTooltip(event, "Energy Recovery Breakdown", tooltipBreakdown(rows))
             }
 
             /**
@@ -2624,9 +2582,9 @@
                 }
             })
 
-            // ==============================================
+            // //////////////////////////////////////////////////////////////////////////////////////////////////
+            // //////////////////////////////////////////////////////////////////////////////////////////////////
             // State
-            // ==============================================
             let ws = null
             let autoScroll = true
             let messageCount = 0
@@ -2695,9 +2653,9 @@
                 }
             }
 
-            // ==============================================
+            // //////////////////////////////////////////////////////////////////////////////////////////////////
+            // //////////////////////////////////////////////////////////////////////////////////////////////////
             // WebSocket Connection
-            // ==============================================
 
             /**
              * Initializes the WebSocket connection and sets up event handlers.
@@ -2724,9 +2682,7 @@
                     reconnectAttempts = 0
                     footerInfo.textContent = "Connected to " + location.host
 
-                    // Clear the display on a fresh connection. This removes logs from
-                    // a previous run, and prevents duplicate logs from being appended
-                    // when the server resyncs the history buffer over this new connection.
+                    // Clear the display on a fresh connection so logs from a previous run do not duplicate when history resyncs.
                     clearDisplay()
                 }
 
@@ -2760,8 +2716,7 @@
                             console.error("Error parsing calendar snapshot:", e)
                         }
                     } else if (event.data.startsWith("SRS_STATE:")) {
-                        // Smart Race Solver enabled flag pushed by Racing.kt at run start. Toggles
-                        // the .srs-disabled class on the panel so it disappears when SRS is off.
+                        // Smart Race Solver enabled flag pushed by Racing.kt at run start. Toggles the .srs-disabled panel class.
                         setSmartRaceSolverEnabled(event.data.substring(10) === "true")
                     } else if (event.data.startsWith("ANALYTICS:")) {
                         // Run-analytics snapshot pushed by RunAnalytics at each turn boundary and at run end.
@@ -2839,9 +2794,9 @@
                 statusText.textContent = customText || status.charAt(0).toUpperCase() + status.slice(1)
             }
 
-            // ==============================================
+            // //////////////////////////////////////////////////////////////////////////////////////////////////
+            // //////////////////////////////////////////////////////////////////////////////////////////////////
             // Log Entry Creation
-            // ==============================================
 
             /**
              * Updates an existing log entry with a new timestamp and repetition count.
@@ -3098,9 +3053,9 @@
                 return div.innerHTML
             }
 
-            // ==============================================
+            // //////////////////////////////////////////////////////////////////////////////////////////////////
+            // //////////////////////////////////////////////////////////////////////////////////////////////////
             // Toolbar Actions
-            // ==============================================
 
             /**
              * Re-renders the entire log from allMessages, applying or removing condensation based on the current isCondensing flag. Used by
@@ -3326,9 +3281,9 @@
                 }
             }
 
-            // ==============================================
+            // //////////////////////////////////////////////////////////////////////////////////////////////////
+            // //////////////////////////////////////////////////////////////////////////////////////////////////
             // Race History Calendar (Smart Race Solver)
-            // ==============================================
             // Constants and helpers ported from src/lib/solver/constants.ts.
             // Keep these in sync with that file: GRADE_COLORS, MONTH_LABELS,
             // YEAR_LABELS, RACE_NAME_ABBREVIATIONS, turnDateLabel, shortenRaceName.
@@ -3603,9 +3558,7 @@
                 var yearOffset = (turn - 1) % 24
                 var yearName = turn <= 24 ? "Junior" : turn <= 48 ? "Classic" : "Senior"
                 var dateLabel = calTurnDateLabel(yearOffset)
-                // Use the same middle dot (U+00B7) the React Native Smart Race Solver
-                // popover uses as a visual separator. Kept as a literal character so the
-                // tooltip layout matches the original calendar exactly.
+                // Middle dot (U+00B7) separator matching the React Native Smart Race Solver popover.
                 var sep = " · "
                 var title = "T" + turn + sep + yearName + " " + dateLabel
 
@@ -3664,9 +3617,9 @@
                 showTooltip(event, title, content)
             }
 
-            // ==============================================
+            // //////////////////////////////////////////////////////////////////////////////////////////////////
+            // //////////////////////////////////////////////////////////////////////////////////////////////////
             // Font Size Adjustment
-            // ==============================================
 
             /**
              * Increments or decrements the font size.
@@ -3709,9 +3662,9 @@
                 updateFontSize(currentFontSize)
             }
 
-            // ==============================================
+            // //////////////////////////////////////////////////////////////////////////////////////////////////
+            // //////////////////////////////////////////////////////////////////////////////////////////////////
             // Search Input Handler
-            // ==============================================
 
             // Listen for input changes in the search field to filter logs in real-time.
             searchInput.addEventListener("input", function () {
@@ -3729,9 +3682,9 @@
                 searchInput.focus()
             })
 
-            // ==============================================
-            // Scroll Detection — Show/hide scroll-to-bottom
-            // ==============================================
+            // //////////////////////////////////////////////////////////////////////////////////////////////////
+            // //////////////////////////////////////////////////////////////////////////////////////////////////
+            // Scroll Detection - Show/hide scroll-to-bottom
 
             // Listen for font size change.
             fontSizeInput.addEventListener("input", function () {
@@ -3759,9 +3712,9 @@
                 }
             })
 
-            // ==============================================
+            // //////////////////////////////////////////////////////////////////////////////////////////////////
+            // //////////////////////////////////////////////////////////////////////////////////////////////////
             // Dashboard & UI Helpers
-            // ==============================================
 
             /**
              * Processes logs for special dashboard updates.
@@ -3860,40 +3813,8 @@
                 const trainee = parsed.trainee
                 if (!trainee) return
 
-                const category = trainee.category
-                const data = trainee.data
-
-                if (stateTarget) {
-                    if (category === "Name") {
-                        stateTarget.name = data.trim()
-                    } else if (category === "Mood") {
-                        stateTarget.mood = data.trim()
-                    } else if (category === "Positive Statuses") {
-                        stateTarget.positiveStatuses = data.split(", ").map((s) => s.trim())
-                    } else if (category === "Negative Statuses") {
-                        stateTarget.negativeStatuses = data.split(", ").map((s) => s.trim())
-                    } else if (category === "Energy") {
-                        stateTarget.energy = data.trim()
-                    } else if (category === "Fans") {
-                        stateTarget.fans = data.trim()
-                    } else if (category === "Skill Points") {
-                        stateTarget.skillPoints = data.trim()
-                    } else if (category === "Stats") {
-                        const stats = data.split(", ")
-                        stats.forEach((s) => {
-                            const [key, val] = s.split("=")
-                            stateTarget.stats[key] = val
-                        })
-                    } else {
-                        const apts = data.split(", ")
-                        apts.forEach((a) => {
-                            const [name, grade] = a.split("=")
-                            stateTarget.apts[name] = grade
-                        })
-                    }
-                } else {
-                    updateDashboard(category, data)
-                }
+                // updateDashboard already routes both the stateTarget and live-DOM paths for every category.
+                updateDashboard(trainee.category, trainee.data, stateTarget)
             }
 
             /**
@@ -4251,9 +4172,9 @@
                     })
             }
 
-            // ==============================================
+            // //////////////////////////////////////////////////////////////////////////////////////////////////
+            // //////////////////////////////////////////////////////////////////////////////////////////////////
             // Tab Switching & Image Logic
-            // ==============================================
 
             /**
              * Switches between different view tabs.
@@ -4407,9 +4328,9 @@
                 }
             })
 
-            // ==============================================
+            // //////////////////////////////////////////////////////////////////////////////////////////////////
+            // //////////////////////////////////////////////////////////////////////////////////////////////////
             // Log Files Tab
-            // ==============================================
 
             const LOG_FILE_PREVIEW_BYTE_LIMIT = 5 * 1024 * 1024
             // Cache the latest /logs/files response so the row click handlers can read each file's size
@@ -4827,6 +4748,21 @@
                 })
             }
 
+            /** Build a filled area-line dataset shared by the failure, fans, and skill-point charts. */
+            function analyticAreaLineDataset(opts) {
+                var ds = { label: opts.label, data: [], borderColor: opts.color, backgroundColor: analyticAreaGradient(opts.gradFrom, opts.gradTo), borderWidth: 2.5, tension: 0.3, fill: true }
+                if (opts.spanGaps) ds.spanGaps = true
+                Object.assign(ds, { pointRadius: 2.2, pointHoverRadius: 5, pointBorderColor: "rgba(255,255,255,0.9)", pointBorderWidth: 1, pointHitRadius: 12 })
+                return ds
+            }
+
+            /** Build the per-stat line datasets (stat growth / composition / cumulative gains), merged with chart-specific styling. */
+            function analyticStatLineDatasets(extra) {
+                return ANALYTIC_STAT_ORDER.map(function (s) {
+                    return Object.assign({ label: ANALYTIC_STAT_LABELS[s], data: [], borderColor: ANALYTIC_STAT_COLORS[s], backgroundColor: ANALYTIC_STAT_COLORS[s] }, extra)
+                })
+            }
+
             /** Create every analytics Chart instance once with empty data and themed options. Later updates reuse these via .update(). */
             function initAnalyticsCharts() {
                 if (typeof Chart === "undefined") {
@@ -4837,7 +4773,6 @@
                 analyticRegisterBarValueLabels()
                 analyticRegisterDoughnutCenter()
                 var textSec = analyticCssVar("--text-secondary") || "#8888a0"
-                var gridColor = "rgba(120, 120, 150, 0.12)"
                 Chart.defaults.color = textSec
                 Chart.defaults.font.family = analyticCssVar("--font-sans") || "Inter, sans-serif"
                 Chart.defaults.font.size = 11
@@ -4858,21 +4793,19 @@
                 // Never animate color properties, or a resize/hover tween throws "this._fn is not a function" and blanks the charts.
                 Chart.defaults.animations.colors = false
 
-                var linAxis = { grid: { color: gridColor }, ticks: { maxTicksLimit: 6 }, border: { display: false }, grace: "8%" }
-                var catAxis = { grid: { display: false }, ticks: { maxTicksLimit: 12 }, border: { display: false } }
                 var statColors = ANALYTIC_STAT_ORDER.map(function (s) { return ANALYTIC_STAT_COLORS[s] })
                 var statLabels = ANALYTIC_STAT_ORDER.map(function (s) { return ANALYTIC_STAT_LABELS[s] })
 
                 analyticsCharts.radar = new Chart(document.getElementById("analyticRadar"), {
                     type: "radar",
                     data: { labels: statLabels, datasets: [{ label: "Stats", data: [0, 0, 0, 0, 0], fill: true, backgroundColor: "rgba(108, 140, 255, 0.16)", borderColor: analyticCssVar("--accent-blue") || "#6c8cff", borderWidth: 2, pointBackgroundColor: statColors, pointBorderColor: analyticCssVar("--bg-primary") || "#0a0a0f", pointRadius: 4, pointHoverRadius: 6 }] },
-                    options: { plugins: { legend: { display: false } }, scales: { r: { angleLines: { color: gridColor }, grid: { color: gridColor }, pointLabels: { color: textSec, font: { size: 11, weight: "600" }, callback: function (label, i) { var s = ANALYTIC_STAT_ORDER[i]; var v = (window.__analyticStats && window.__analyticStats[s]) || 0; return ANALYTIC_STAT_LABELS[s] + " " + v } }, ticks: { display: false, backdropColor: "transparent" }, beginAtZero: true } } }
+                    options: { plugins: { legend: { display: false } }, scales: { r: { angleLines: { color: ANALYTIC_GRID_COLOR }, grid: { color: ANALYTIC_GRID_COLOR }, pointLabels: { color: textSec, font: { size: 11, weight: "600" }, callback: function (label, i) { var s = ANALYTIC_STAT_ORDER[i]; var v = (window.__analyticStats && window.__analyticStats[s]) || 0; return ANALYTIC_STAT_LABELS[s] + " " + v } }, ticks: { display: false, backdropColor: "transparent" }, beginAtZero: true } } }
                 })
 
                 analyticsCharts.statGrowth = new Chart(document.getElementById("analyticStatGrowth"), {
                     type: "line",
-                    data: { labels: [], datasets: ANALYTIC_STAT_ORDER.map(function (s) { return { label: ANALYTIC_STAT_LABELS[s], data: [], borderColor: ANALYTIC_STAT_COLORS[s], backgroundColor: ANALYTIC_STAT_COLORS[s], borderWidth: 2.5, tension: 0.3, pointRadius: 2.2, pointHoverRadius: 5, pointBorderColor: "rgba(255,255,255,0.9)", pointBorderWidth: 1, pointHitRadius: 12 } }) },
-                    options: { interaction: { mode: "index", intersect: false }, plugins: { legend: { position: "bottom" }, analyticCrosshair: true, tooltip: { callbacks: { title: analyticTooltipTurnTitle } } }, scales: { x: catAxis, y: linAxis } }
+                    data: { labels: [], datasets: analyticStatLineDatasets({ borderWidth: 2.5, tension: 0.3, pointRadius: 2.2, pointHoverRadius: 5, pointBorderColor: "rgba(255,255,255,0.9)", pointBorderWidth: 1, pointHitRadius: 12 }) },
+                    options: { interaction: { mode: "index", intersect: false }, plugins: { legend: { position: "bottom" }, analyticCrosshair: true, tooltip: { callbacks: { title: analyticTooltipTurnTitle } } }, scales: analyticTimeSeriesScales() }
                 })
 
                 analyticsCharts.trainingDist = new Chart(document.getElementById("analyticTrainingDist"), {
@@ -4884,13 +4817,13 @@
                 analyticsCharts.statGains = new Chart(document.getElementById("analyticStatGains"), {
                     type: "bar",
                     data: { labels: statLabels, datasets: [{ data: [0, 0, 0, 0, 0], backgroundColor: statColors, borderRadius: 6, borderSkipped: false }] },
-                    options: { plugins: { legend: { display: false }, analyticBarValueLabels: true }, scales: { x: catAxis, y: linAxis } }
+                    options: { plugins: { legend: { display: false }, analyticBarValueLabels: true }, scales: analyticTimeSeriesScales() }
                 })
 
                 analyticsCharts.failure = new Chart(document.getElementById("analyticFailure"), {
                     type: "line",
-                    data: { labels: [], datasets: [{ label: "Failure %", data: [], borderColor: analyticCssVar("--log-warn") || "#f59e0b", backgroundColor: analyticAreaGradient("rgba(245,158,11,0.40)", "rgba(245,158,11,0.02)"), borderWidth: 2.5, tension: 0.3, fill: true, spanGaps: true, pointRadius: 2.2, pointHoverRadius: 5, pointBorderColor: "rgba(255,255,255,0.9)", pointBorderWidth: 1, pointHitRadius: 12 }] },
-                    options: { interaction: { mode: "index", intersect: false }, plugins: { legend: { display: false }, analyticCrosshair: true, tooltip: { callbacks: { title: analyticTooltipTurnTitle } } }, scales: { x: catAxis, y: { grid: { color: gridColor }, border: { display: false }, suggestedMin: 0, suggestedMax: 100, ticks: { callback: function (v) { return v + "%" }, maxTicksLimit: 6 } } } }
+                    data: { labels: [], datasets: [analyticAreaLineDataset({ label: "Failure %", color: analyticCssVar("--log-warn") || "#f59e0b", gradFrom: "rgba(245,158,11,0.40)", gradTo: "rgba(245,158,11,0.02)", spanGaps: true })] },
+                    options: { interaction: { mode: "index", intersect: false }, plugins: { legend: { display: false }, analyticCrosshair: true, tooltip: { callbacks: { title: analyticTooltipTurnTitle } } }, scales: { x: analyticCatAxis(), y: { grid: { color: ANALYTIC_GRID_COLOR }, border: { display: false }, suggestedMin: 0, suggestedMax: 100, ticks: { callback: function (v) { return v + "%" }, maxTicksLimit: 6 } } } }
                 })
 
                 analyticsCharts.winRate = new Chart(document.getElementById("analyticWinRate"), {
@@ -4902,19 +4835,19 @@
                 analyticsCharts.racesByGrade = new Chart(document.getElementById("analyticRacesByGrade"), {
                     type: "bar",
                     data: { labels: [], datasets: [{ data: [], backgroundColor: [], borderRadius: 6, borderSkipped: false }] },
-                    options: { plugins: { legend: { display: false }, analyticBarValueLabels: true }, scales: { x: catAxis, y: { grid: { color: gridColor }, border: { display: false }, ticks: { precision: 0, maxTicksLimit: 5 } } } }
+                    options: { plugins: { legend: { display: false }, analyticBarValueLabels: true }, scales: { x: analyticCatAxis(), y: { grid: { color: ANALYTIC_GRID_COLOR }, border: { display: false }, ticks: { precision: 0, maxTicksLimit: 5 } } } }
                 })
 
                 analyticsCharts.fans = new Chart(document.getElementById("analyticFans"), {
                     type: "line",
-                    data: { labels: [], datasets: [{ label: "Fans", data: [], borderColor: analyticCssVar("--accent-purple") || "#9b6dff", backgroundColor: analyticAreaGradient("rgba(155,109,255,0.45)", "rgba(155,109,255,0.02)"), borderWidth: 2.5, tension: 0.3, fill: true, pointRadius: 2.2, pointHoverRadius: 5, pointBorderColor: "rgba(255,255,255,0.9)", pointBorderWidth: 1, pointHitRadius: 12 }] },
-                    options: { interaction: { mode: "index", intersect: false }, plugins: { legend: { display: false }, analyticCrosshair: true, tooltip: { callbacks: { title: analyticTooltipTurnTitle } } }, scales: { x: catAxis, y: { grid: { color: gridColor }, border: { display: false }, ticks: { callback: function (v) { return analyticAbbrevNum(v) }, maxTicksLimit: 6 } } } }
+                    data: { labels: [], datasets: [analyticAreaLineDataset({ label: "Fans", color: analyticCssVar("--accent-purple") || "#9b6dff", gradFrom: "rgba(155,109,255,0.45)", gradTo: "rgba(155,109,255,0.02)" })] },
+                    options: { interaction: { mode: "index", intersect: false }, plugins: { legend: { display: false }, analyticCrosshair: true, tooltip: { callbacks: { title: analyticTooltipTurnTitle } } }, scales: { x: analyticCatAxis(), y: { grid: { color: ANALYTIC_GRID_COLOR }, border: { display: false }, ticks: { callback: function (v) { return analyticAbbrevNum(v) }, maxTicksLimit: 6 } } } }
                 })
 
                 analyticsCharts.actionMix = new Chart(document.getElementById("analyticActionMix"), {
                     type: "bar",
                     data: { labels: [], datasets: ANALYTIC_ACTION_DEFS.map(function (d) { return { label: d.label, data: [], backgroundColor: analyticCssVar(d.cssVar) || d.fallback, borderRadius: 4, borderSkipped: false, stack: "actions" } }) },
-                    options: { interaction: { mode: "nearest", intersect: false }, plugins: { legend: { position: "bottom" } }, scales: { x: { stacked: true, grid: { display: false }, border: { display: false } }, y: { stacked: true, grid: { color: gridColor }, border: { display: false }, ticks: { precision: 0, maxTicksLimit: 6 } } } }
+                    options: { interaction: { mode: "nearest", intersect: false }, plugins: { legend: { position: "bottom" } }, scales: { x: { stacked: true, grid: { display: false }, border: { display: false } }, y: { stacked: true, grid: { color: ANALYTIC_GRID_COLOR }, border: { display: false }, ticks: { precision: 0, maxTicksLimit: 6 } } } }
                 })
 
                 analyticsCharts.energyMood = new Chart(document.getElementById("analyticEnergyMood"), {
@@ -4930,8 +4863,8 @@
                         interaction: { mode: "index", intersect: false },
                         plugins: { legend: { position: "bottom" }, analyticCrosshair: true, tooltip: { callbacks: { title: analyticTooltipTurnTitle, label: function (ctx) { return ctx.dataset.label === "Mood" ? "Mood: " + analyticTitleCase(ANALYTIC_MOOD_ORDER[ctx.raw] || "-") : "Energy: " + ctx.raw + "%" } } } },
                         scales: {
-                            x: catAxis,
-                            y: { position: "left", grid: { color: gridColor }, border: { display: false }, suggestedMin: 0, suggestedMax: 100 },
+                            x: analyticCatAxis(),
+                            y: { position: "left", grid: { color: ANALYTIC_GRID_COLOR }, border: { display: false }, suggestedMin: 0, suggestedMax: 100 },
                             y1: { position: "right", min: 0, max: 4, grid: { display: false }, border: { display: false }, ticks: { stepSize: 1, callback: function (v) { return analyticTitleCase(ANALYTIC_MOOD_ORDER[v] || "") } } }
                         }
                     }
@@ -4939,19 +4872,19 @@
 
                 analyticsCharts.statComp = new Chart(document.getElementById("analyticStatComp"), {
                     type: "line",
-                    data: { labels: [], datasets: ANALYTIC_STAT_ORDER.map(function (s) { return { label: ANALYTIC_STAT_LABELS[s], data: [], borderColor: ANALYTIC_STAT_COLORS[s], backgroundColor: ANALYTIC_STAT_COLORS[s], borderWidth: 0, tension: 0.3, fill: true, pointRadius: 0 } }) },
+                    data: { labels: [], datasets: analyticStatLineDatasets({ borderWidth: 0, tension: 0.3, fill: true, pointRadius: 0 }) },
                     options: { interaction: { mode: "index", intersect: false }, plugins: { legend: { position: "bottom" }, analyticCrosshair: true, tooltip: { callbacks: { title: analyticTooltipTurnTitle, label: function (ctx) { return ctx.dataset.label + ": " + ctx.raw + "%" } } } }, scales: { x: analyticCatAxis(), y: { stacked: true, min: 0, max: 100, grid: { color: ANALYTIC_GRID_COLOR }, border: { display: false }, ticks: { callback: function (v) { return v + "%" }, maxTicksLimit: 6 } } } }
                 })
 
                 analyticsCharts.skillPts = new Chart(document.getElementById("analyticSkillPts"), {
                     type: "line",
-                    data: { labels: [], datasets: [{ label: "Skill Pts", data: [], borderColor: analyticCssVar("--accent-blue") || "#6c8cff", backgroundColor: analyticAreaGradient("rgba(108,140,255,0.40)", "rgba(108,140,255,0.02)"), borderWidth: 2.5, tension: 0.3, fill: true, pointRadius: 2.2, pointHoverRadius: 5, pointBorderColor: "rgba(255,255,255,0.9)", pointBorderWidth: 1, pointHitRadius: 12 }] },
+                    data: { labels: [], datasets: [analyticAreaLineDataset({ label: "Skill Pts", color: analyticCssVar("--accent-blue") || "#6c8cff", gradFrom: "rgba(108,140,255,0.40)", gradTo: "rgba(108,140,255,0.02)" })] },
                     options: { interaction: { mode: "index", intersect: false }, plugins: { legend: { display: false }, analyticCrosshair: true, tooltip: { callbacks: { title: analyticTooltipTurnTitle } } }, scales: { x: analyticCatAxis(), y: Object.assign(analyticLinAxis(), { min: 0 }) } }
                 })
 
                 analyticsCharts.cumGains = new Chart(document.getElementById("analyticCumGains"), {
                     type: "line",
-                    data: { labels: [], datasets: ANALYTIC_STAT_ORDER.map(function (s) { return { label: ANALYTIC_STAT_LABELS[s], data: [], borderColor: ANALYTIC_STAT_COLORS[s], backgroundColor: ANALYTIC_STAT_COLORS[s], borderWidth: 0, tension: 0.3, fill: true, pointRadius: 0 } }) },
+                    data: { labels: [], datasets: analyticStatLineDatasets({ borderWidth: 0, tension: 0.3, fill: true, pointRadius: 0 }) },
                     options: { interaction: { mode: "index", intersect: false }, plugins: { legend: { position: "bottom" }, analyticCrosshair: true, tooltip: { callbacks: { title: analyticTooltipTurnTitle } } }, scales: { x: analyticCatAxis(), y: { stacked: true, grid: { color: ANALYTIC_GRID_COLOR }, border: { display: false }, ticks: { maxTicksLimit: 6 } } } }
                 })
 
@@ -5044,6 +4977,13 @@
                 var totals = snap.totals || {}
                 var perTurn = snap.perTurn || []
                 var turnLabels = perTurn.map(function (p) { return p.turn })
+                // Set a single-series line chart from per-turn data, reusing the shared turn labels.
+                var setSeries = function (key, mapper) {
+                    analyticUpdateChart(key, function (c) {
+                        c.data.labels = turnLabels
+                        c.data.datasets[0].data = perTurn.map(mapper)
+                    })
+                }
                 window.__analyticTurnDates = perTurn.map(function (p) { return p.date })
 
                 // Hero.
@@ -5091,10 +5031,7 @@
                 analyticUpdateChart("statGains", function (c) { c.data.datasets[0].data = ANALYTIC_STAT_ORDER.map(function (s) { return gByStat[s] || 0 }) })
 
                 // Failure chance over time.
-                analyticUpdateChart("failure", function (c) {
-                    c.data.labels = turnLabels
-                    c.data.datasets[0].data = perTurn.map(function (p) { return p.training && typeof p.training.failureChance === "number" ? p.training.failureChance : null })
-                })
+                setSeries("failure", function (p) { return p.training && typeof p.training.failureChance === "number" ? p.training.failureChance : null })
 
                 // Win-rate gauge.
                 analyticUpdateChart("winRate", function (c) {
@@ -5117,10 +5054,7 @@
                 })
 
                 // Fans over time.
-                analyticUpdateChart("fans", function (c) {
-                    c.data.labels = turnLabels
-                    c.data.datasets[0].data = perTurn.map(function (p) { return p.fans || 0 })
-                })
+                setSeries("fans", function (p) { return p.fans || 0 })
 
                 // Action mix by year (always show all three years). Mutate datasets in place so Chart.js reliably repaints.
                 analyticUpdateChart("actionMix", function (c) {
@@ -5142,10 +5076,7 @@
                 })
 
                 // Skill points over time.
-                analyticUpdateChart("skillPts", function (c) {
-                    c.data.labels = turnLabels
-                    c.data.datasets[0].data = perTurn.map(function (p) { return p.skillPoints || 0 })
-                })
+                setSeries("skillPts", function (p) { return p.skillPoints || 0 })
 
                 // Cumulative stat gains (running sum of per-turn training gains, per stat).
                 var running = { speed: 0, stamina: 0, power: 0, guts: 0, wit: 0 }
@@ -5414,7 +5345,7 @@
                 var titleEl = row ? row.querySelector("span") : null
                 var title = (titleEl ? titleEl.textContent : id).trim()
                 var name = (latestAnalyticsSnapshot && latestAnalyticsSnapshot.trainee && latestAnalyticsSnapshot.trainee.name) || "run"
-                // Mirror the saved log file naming, with a .csv extension: "<TraineeName>_<Chart-Title>_<yyyy-MM-dd HH_mm_ss>.csv" (trainee spaces -> underscores, chart spaces -> hyphens).
+                // Mirror the saved-log naming with a .csv extension: "<Trainee>_<Chart-Title>_<timestamp>.csv" (trainee spaces -> _, chart spaces -> -).
                 var who = name.replace(/ /g, "_")
                 var chartSlug = title.replace(/[^a-z0-9]+/gi, "-").replace(/^-+|-+$/g, "")
                 analyticDownloadCsv(who + "_" + chartSlug + "_" + analyticLogTimestamp() + ".csv", analyticChartCsvRows(chart, id))

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Campaign.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Campaign.kt
@@ -677,7 +677,7 @@ abstract class Campaign(game: Game) : Task(game) {
      * Determines whether to proceed with a consecutive race despite the warning.
      *
      * Called after [onConsecutiveRaceWarningDetected] and after force-race flags have been checked.
-     * This is only called when force-race flags are NOT active — if they are, the race proceeds unconditionally.
+     * This is only called when force-race flags are NOT active - if they are, the race proceeds unconditionally.
      *
      * @param args Additional arguments from dialog handling.
      * @return True to proceed with the race, false to abort and clear racing requirement flags.

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Racing.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Racing.kt
@@ -106,7 +106,7 @@ class Racing(private val game: Game, private val campaign: Campaign) {
     /** Optional custom agenda title that overrides the selected agenda name for OCR matching. */
     private val customAgendaTitle = SettingsHelper.getStringSetting("racing", "customAgendaTitle")
 
-    /** The effective agenda name used for OCR matching — custom title if provided, otherwise the selected agenda. */
+    /** The effective agenda name used for OCR matching - custom title if provided, otherwise the selected agenda. */
     private val effectiveAgendaName = if (customAgendaTitle.isNotBlank()) customAgendaTitle else selectedUserAgenda
 
     /** Whether to skip Summer training to do races from the in-game agenda. */
@@ -342,6 +342,69 @@ class Racing(private val game: Game, private val campaign: Campaign) {
     }
 
     /**
+     * Handles the dialog sequence that appears after tapping a Load List button (overwrite, scheduled-race, and closing dialogs).
+     * Polls until the agenda finishes loading or a 5-second timeout elapses.
+     */
+    private fun handleAgendaLoadDialogs() {
+        // Timeout after 5 seconds. Shouldn't ever take near that long.
+        val timeoutMs = 5000
+        val startTime: Long = System.currentTimeMillis()
+        while (System.currentTimeMillis() - startTime < timeoutMs) {
+            val result: DialogHandlerResult =
+                campaign.handleDialogs(
+                    args =
+                        mapOf(
+                            "bShouldDefer" to true,
+                            "bShouldWait" to true,
+                            "bShouldWaitForLoading" to true,
+                        ),
+                )
+
+            if (result is DialogHandlerResult.NoDialogDetected) {
+                continue
+            }
+
+            if (result !is DialogHandlerResult.Deferred) {
+                val name =
+                    when (result) {
+                        is DialogHandlerResult.Handled -> result.dialog.name
+                        is DialogHandlerResult.Unhandled -> result.dialog.name
+                        else -> "Unknown"
+                    }
+                throw IllegalStateException("loadUserRaceAgenda: Received non-deferred dialog result ($name). Expected deferred.")
+            }
+
+            when (result.dialog.name) {
+                "overwrite" -> {
+                    result.dialog.ok(game.imageUtils)
+                }
+
+                // Pops up when we try to load agenda with races that are in the past.
+                "scheduled_race" -> {
+                    result.dialog.close(game.imageUtils)
+                }
+
+                // We've closed all the extra dialogs after loading agenda so break from the loop.
+                "scheduled_races" -> {
+                    break
+                }
+
+                // We might detect the dialog too quick and find this one as it is in the process of closing. Ignore this and continue the loop.
+                "my_agendas" -> {}
+
+                // No dialog detected. This can happen if a dialog is closing. Not a problem, just continue with loop and timeout when the time comes.
+                null -> {}
+
+                // Fall back to the base dialog handler if we get a dialog that we weren't expecting.
+                else -> {
+                    MessageLog.e(TAG, "[ERROR] loadUserRaceAgenda:: Unknown dialog detected: ${result.dialog.name}. Falling back to base dialog handler.")
+                    campaign.handleDialogs()
+                }
+            }
+        }
+    }
+
+    /**
      * Loads the user's selected in-game race agenda.
      *
      * This function navigates through the agenda UI, finds the matching agenda, and loads it. If the agenda is not immediately visible, it will scroll the list to find it.
@@ -466,62 +529,7 @@ class Racing(private val game: Game, private val campaign: Campaign) {
                     // 3. The my_agendas dialog closes automatically and the scheduled_races dialog remains on screen.
                     game.gestureUtils.tap(buttonLocation.x, buttonLocation.y, ButtonRaceAgendaLoadList.template.path)
 
-                    // Timeout after 5 seconds. Shouldn't ever take near that long.
-                    val timeoutMs = 5000
-                    val startTime: Long = System.currentTimeMillis()
-                    while (System.currentTimeMillis() - startTime < timeoutMs) {
-                        val result: DialogHandlerResult =
-                            campaign.handleDialogs(
-                                args =
-                                    mapOf(
-                                        "bShouldDefer" to true,
-                                        "bShouldWait" to true,
-                                        "bShouldWaitForLoading" to true,
-                                    ),
-                            )
-
-                        if (result is DialogHandlerResult.NoDialogDetected) {
-                            continue
-                        }
-
-                        if (result !is DialogHandlerResult.Deferred) {
-                            val name =
-                                when (result) {
-                                    is DialogHandlerResult.Handled -> result.dialog.name
-                                    is DialogHandlerResult.Unhandled -> result.dialog.name
-                                    else -> "Unknown"
-                                }
-                            throw IllegalStateException("loadUserRaceAgenda: Received non-deferred dialog result ($name). Expected deferred.")
-                        }
-
-                        when (result.dialog.name) {
-                            "overwrite" -> {
-                                result.dialog.ok(game.imageUtils)
-                            }
-
-                            // Pops up when we try to load agenda with races that are in the past.
-                            "scheduled_race" -> {
-                                result.dialog.close(game.imageUtils)
-                            }
-
-                            // We've closed all the extra dialogs after loading agenda so break from the loop.
-                            "scheduled_races" -> {
-                                break
-                            }
-
-                            // We might detect the dialog too quick and find this one as it is in the process of closing. Ignore this and continue the loop.
-                            "my_agendas" -> {}
-
-                            // No dialog detected. This can happen if a dialog is closing. Not a problem, just continue with loop and timeout when the time comes.
-                            null -> {}
-
-                            // Fall back to the base dialog handler if we get a dialog that we weren't expecting.
-                            else -> {
-                                MessageLog.e(TAG, "[ERROR] loadUserRaceAgenda:: Unknown dialog detected: ${result.dialog.name}. Falling back to base dialog handler.")
-                                campaign.handleDialogs()
-                            }
-                        }
-                    }
+                    handleAgendaLoadDialogs()
 
                     foundAgenda = true
                     break
@@ -622,22 +630,6 @@ class Racing(private val game: Game, private val campaign: Campaign) {
         game.wait(2.0)
 
         return IconRaceListPredictionDoubleStar.findAll(game.imageUtils)
-    }
-
-    /**
-     * Checks if the racer's aptitudes match the race requirements (both terrain and distance must be B or greater).
-     *
-     * @param raceData The race data to check aptitudes against.
-     * @return True if both track surface and distance aptitudes are B or greater; false otherwise.
-     */
-    private fun checkRaceAptitudeMatch(raceData: RaceData): Boolean {
-        val trackSurfaceAptitude: Aptitude = campaign.trainee.checkTrackSurfaceAptitude(raceData.trackSurface)
-        val trackDistanceAptitude: Aptitude = campaign.trainee.checkTrackDistanceAptitude(raceData.trackDistance)
-
-        val trackSurfaceMatch: Boolean = trackSurfaceAptitude >= Aptitude.B
-        val trackDistanceMatch: Boolean = trackDistanceAptitude >= Aptitude.B
-
-        return trackSurfaceMatch && trackDistanceMatch
     }
 
     /**
@@ -1029,6 +1021,42 @@ class Racing(private val game: Game, private val campaign: Campaign) {
     }
 
     /**
+     * Whether the just-finished race is an eligible grade that can still be retried within the remaining budgets.
+     *
+     * @param sourceBitmap Optional pre-captured screenshot to match the retry button against.
+     * @return True when a grade-based retry should be attempted.
+     */
+    private fun canRetryGrade(sourceBitmap: Bitmap? = null): Boolean =
+        !disableRaceRetries &&
+            lastRaceGrade != null &&
+            retryEligibleGrades.contains(lastRaceGrade) &&
+            raceRetries > 0 &&
+            retriesThisRace < maxRetriesPerRace &&
+            ButtonTryAgainAlt.checkDisabled(game.imageUtils, sourceBitmap = sourceBitmap) == false
+
+    /**
+     * Whether the just-finished race was a one-time rival race that can still be retried within the remaining budgets.
+     *
+     * @param sourceBitmap Optional pre-captured screenshot to match the retry button against.
+     * @return True when a rival-race retry should be attempted (at most once per race).
+     */
+    private fun canRetryRival(sourceBitmap: Bitmap? = null): Boolean =
+        lastRaceIsRival && !bRetriedCurrentRace && canRetryGrade(sourceBitmap)
+
+    /**
+     * Taps the retry button and, on a successful tap, waits for the race to restart and consumes one retry from the budgets.
+     *
+     * @param sourceBitmap Optional pre-captured screenshot to match the retry button against.
+     */
+    private fun attemptRaceRetry(sourceBitmap: Bitmap? = null) {
+        if (ButtonTryAgainAlt.click(game.imageUtils, sourceBitmap = sourceBitmap)) {
+            game.wait(3.0)
+            retriesThisRace++
+            raceRetries--
+        }
+    }
+
+    /**
      * Executes the race with retry logic.
      *
      * @param isMandatory True if this is a mandatory race, which always retries until 1st place whenever possible.
@@ -1119,75 +1147,27 @@ class Racing(private val game: Game, private val campaign: Campaign) {
                     game.wait(1.0)
 
                     // After closing the popup, check if we can retry a specific race grade.
-                    if (!disableRaceRetries &&
-                        lastRaceGrade != null &&
-                        retryEligibleGrades.contains(lastRaceGrade) &&
-                        raceRetries > 0 &&
-                        retriesThisRace < maxRetriesPerRace &&
-                        ButtonTryAgainAlt.checkDisabled(game.imageUtils) == false
-                    ) {
+                    if (canRetryGrade()) {
                         MessageLog.i(TAG, "[RACE] $lastRaceGrade race detected and retry button is available. Retrying...")
-                        if (ButtonTryAgainAlt.click(game.imageUtils)) {
-                            game.wait(3.0)
-                            retriesThisRace++
-                            raceRetries--
-                        }
-                    } else if (!disableRaceRetries &&
-                        lastRaceIsRival &&
-                        lastRaceGrade != null &&
-                        retryEligibleGrades.contains(lastRaceGrade) &&
-                        !bRetriedCurrentRace &&
-                        raceRetries > 0 &&
-                        retriesThisRace < maxRetriesPerRace &&
-                        ButtonTryAgainAlt.checkDisabled(game.imageUtils) == false
-                    ) {
+                        attemptRaceRetry()
+                    } else if (canRetryRival()) {
                         MessageLog.i(TAG, "[RACE] Rival Race retry button is available. Retrying once...")
                         bRetriedCurrentRace = true
-                        if (ButtonTryAgainAlt.click(game.imageUtils)) {
-                            game.wait(3.0)
-                            retriesThisRace++
-                            raceRetries--
-                        }
+                        attemptRaceRetry()
                     } else {
                         MessageLog.i(TAG, "[RACE] No retries remaining or eligible race conditions not met.")
                     }
                 }
 
-                !disableRaceRetries &&
-                    lastRaceGrade != null &&
-                    retryEligibleGrades.contains(lastRaceGrade) &&
-                    raceRetries > 0 &&
-                    retriesThisRace < maxRetriesPerRace &&
-                    ButtonTryAgainAlt.checkDisabled(
-                        game.imageUtils,
-                        sourceBitmap = bitmap,
-                    ) == false -> {
+                canRetryGrade(bitmap) -> {
                     MessageLog.i(TAG, "[RACE] $lastRaceGrade race detected and retry button is available. Retrying...")
-                    if (ButtonTryAgainAlt.click(game.imageUtils, sourceBitmap = bitmap)) {
-                        game.wait(3.0)
-                        retriesThisRace++
-                        raceRetries--
-                    }
+                    attemptRaceRetry(bitmap)
                 }
 
-                !disableRaceRetries &&
-                    lastRaceIsRival &&
-                    lastRaceGrade != null &&
-                    retryEligibleGrades.contains(lastRaceGrade) &&
-                    !bRetriedCurrentRace &&
-                    raceRetries > 0 &&
-                    retriesThisRace < maxRetriesPerRace &&
-                    ButtonTryAgainAlt.checkDisabled(
-                        game.imageUtils,
-                        sourceBitmap = bitmap,
-                    ) == false -> {
+                canRetryRival(bitmap) -> {
                     MessageLog.i(TAG, "[RACE] Rival Race retry button is available. Retrying once...")
                     bRetriedCurrentRace = true
-                    if (ButtonTryAgainAlt.click(game.imageUtils, sourceBitmap = bitmap)) {
-                        game.wait(3.0)
-                        retriesThisRace++
-                        raceRetries--
-                    }
+                    attemptRaceRetry(bitmap)
                 }
 
                 // Mandatory races always retry until 1st place whenever possible.
@@ -1234,11 +1214,11 @@ class Racing(private val game: Game, private val campaign: Campaign) {
             return false
         }
 
-        // Use the Congratulations banner to confirm 1st place — only real wins should land
+        // Use the Congratulations banner to confirm 1st place - only real wins should land
         // in the solver's history. Losses drop the pending entry so the next plan sees the
         // unchanged history.
         val firstPlace = LabelCongratulations.check(game.imageUtils)
-        MessageLog.i(TAG, "[RACE] Race result detected — 1st place: $firstPlace.")
+        MessageLog.i(TAG, "[RACE] Race result detected - 1st place: $firstPlace.")
         SmartRaceSolverIntegration.commitPendingRace(won = firstPlace)
 
         // Max time limit for the while loop to attempt to finalize race results.
@@ -2086,7 +2066,7 @@ class Racing(private val game: Game, private val campaign: Campaign) {
      *
      * Detects on-screen double-star race predictions, matches them via [lookupRaceInDatabase],
      * and asks the solver to pick one. Returns false if the solver is disabled, no candidates
-     * match, or no schedule pick is found on screen — callers fall through to standard racing.
+     * match, or no schedule pick is found on screen - callers fall through to standard racing.
      *
      * @return True if a race was successfully selected and ready to run, false otherwise.
      */
@@ -2106,7 +2086,7 @@ class Racing(private val game: Game, private val campaign: Campaign) {
             SmartRaceSolverIntegration.peekRaceKeyForTurn(currentTurn = campaign.date.day, scenario = game.scenario)
 
         if (plannedKey != null) {
-            MessageLog.i(TAG, "[RACE] Smart Race Solver wants \"$plannedKey\" for turn ${campaign.date.day} — scanning until matched.")
+            MessageLog.i(TAG, "[RACE] Smart Race Solver wants \"$plannedKey\" for turn ${campaign.date.day} - scanning until matched.")
             val sourceBitmap = game.imageUtils.getSourceBitmap()
             for (location in doublePredictionLocations) {
                 val raceName = game.imageUtils.extractRaceName(location)

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Training.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Training.kt
@@ -2248,7 +2248,7 @@ open class Training(protected val game: Game, protected val campaign: Campaign) 
             analyzeTrainings()
             trainingSelected =
                 if (forceStat != null) {
-                    MessageLog.i(TAG, "[TRAINING] forceStat override active — selecting $forceStat without running recommendTraining.")
+                    MessageLog.i(TAG, "[TRAINING] forceStat override active - selecting $forceStat without running recommendTraining.")
                     forceStat
                 } else {
                     recommendTraining()

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/TrainingEvent.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/TrainingEvent.kt
@@ -396,6 +396,190 @@ class TrainingEvent(private val game: Game, private val campaign: Campaign) {
     // //////////////////////////////////////////////////////////////////////////////////////////////////
 
     /**
+     * Scores each option of a normal training event by weighting its reward lines (energy, mood, bond, hints, statuses, skills, and prioritized stats).
+     *
+     * @param eventRewards The OCR-read reward text for each event option.
+     * @param regex The letter-stripping regex used to normalize each reward line before parsing numbers.
+     * @return A mutable list of per-option selection weights; the highest-weighted index is the best choice.
+     */
+    private fun computeEventSelectionWeights(eventRewards: List<String>, regex: Regex): MutableList<Int> {
+        // Initialize the List for normal event processing.
+        val selectionWeight = List(eventRewards.size) { 0 }.toMutableList()
+
+        // Sum up the stat gains with additional weight applied to stats that are prioritized.
+        eventRewards.forEachIndexed { rewardIndex, reward ->
+            val formattedReward: List<String> = reward.split("\n")
+
+            formattedReward.forEach { line ->
+                val formattedLine: String =
+                    regex
+                        .replace(line, "")
+                        .replace("(", "")
+                        .replace(")", "")
+                        .trim()
+                        .lowercase()
+
+                // Skip empty strings and divider lines (lines that are all dashes or start with 5 dashes).
+                if (line.trim().isEmpty() || line.trim().length >= 5 && line.trim().substring(0, 5).all { it == '-' }) {
+                    return@forEach
+                }
+
+                var priorityStatCheck = false
+                if (line.lowercase().contains("can start dating")) {
+                    selectionWeight[rewardIndex] += 1000
+                } else if (line.lowercase().contains("event chain ended")) {
+                    selectionWeight[rewardIndex] += -300
+                } else if (line.lowercase().contains("(random)")) {
+                    selectionWeight[rewardIndex] += -10
+                } else if (line.lowercase().contains("randomly")) {
+                    selectionWeight[rewardIndex] += 50
+                } else if (line.lowercase().contains("energy")) {
+                    val finalEnergyValue =
+                        try {
+                            val energyValue =
+                                if (formattedLine.contains("/")) {
+                                    val splits = formattedLine.split("/")
+                                    var sum = 0
+                                    for (split in splits) {
+                                        sum +=
+                                            try {
+                                                split.trim().toInt()
+                                            } catch (_: NumberFormatException) {
+                                                20
+                                            }
+                                    }
+                                    sum
+                                } else {
+                                    formattedLine.toInt()
+                                }
+
+                            if (enablePrioritizeEnergyOptions) {
+                                energyValue * 100
+                            } else {
+                                val energyMultiplier =
+                                    when {
+                                        campaign.trainee.energy < 30 -> 4
+                                        campaign.trainee.energy < 50 -> 3
+                                        campaign.trainee.energy < 70 -> 2
+                                        campaign.trainee.energy >= 90 -> 0
+                                        else -> 1
+                                    }
+                                energyValue * energyMultiplier
+                            }
+                        } catch (_: NumberFormatException) {
+                            20
+                        }
+                    selectionWeight[rewardIndex] += finalEnergyValue
+                } else if (line.lowercase().contains("mood")) {
+                    val moodMultiplier =
+                        when (campaign.trainee.mood) {
+                            Mood.AWFUL -> 150
+                            Mood.BAD -> 120
+                            Mood.NORMAL -> 100
+                            Mood.GOOD -> 80
+                            Mood.GREAT -> 0
+                        }
+                    val moodWeight = if (formattedLine.contains("-")) -150 else moodMultiplier
+                    selectionWeight[rewardIndex] += moodWeight
+                } else if (line.lowercase().contains("bond")) {
+                    val bondWeight = if (formattedLine.contains("-")) -20 else 20
+                    selectionWeight[rewardIndex] += bondWeight
+                } else if (line.lowercase().contains("hint")) {
+                    selectionWeight[rewardIndex] += 25
+                } else if (PositiveStatus.names.any { status -> line.contains(status) }) {
+                    selectionWeight[rewardIndex] += 25
+                } else if (NegativeStatus.names.any { status -> line.contains(status) }) {
+                    selectionWeight[rewardIndex] += -25
+                } else if (line.lowercase().contains("skill")) {
+                    val finalSkillPoints =
+                        if (formattedLine.contains("/")) {
+                            val splits = formattedLine.split("/")
+                            var sum = 0
+                            for (split in splits) {
+                                sum +=
+                                    try {
+                                        split.trim().toInt()
+                                    } catch (_: NumberFormatException) {
+                                        10
+                                    }
+                            }
+                            sum
+                        } else {
+                            formattedLine.toInt()
+                        }
+                    selectionWeight[rewardIndex] += finalSkillPoints
+                } else {
+                    // Apply inflated weights to the prioritized stats based on their order.
+                    campaign.training.eventChoiceStatPriority.forEachIndexed { index, stat ->
+                        if (line.lowercase().contains(stat.name.lowercase())) {
+                            // Calculate weight bonus based on position (higher priority = higher bonus).
+                            val priorityBonus =
+                                when (index) {
+                                    0 -> 50
+                                    1 -> 40
+                                    2 -> 30
+                                    3 -> 20
+                                    else -> 10
+                                }
+
+                            val finalStatValue =
+                                try {
+                                    priorityStatCheck = true
+                                    if (formattedLine.contains("/")) {
+                                        val splits = formattedLine.split("/")
+                                        var sum = 0
+                                        for (split in splits) {
+                                            sum +=
+                                                try {
+                                                    split.trim().toInt()
+                                                } catch (_: NumberFormatException) {
+                                                    10
+                                                }
+                                        }
+                                        sum + priorityBonus
+                                    } else {
+                                        formattedLine.toInt() + priorityBonus
+                                    }
+                                } catch (_: NumberFormatException) {
+                                    priorityStatCheck = false
+                                    10
+                                }
+                            selectionWeight[rewardIndex] += finalStatValue
+                        }
+                    }
+
+                    // Apply normal weights to the rest of the stats.
+                    if (!priorityStatCheck) {
+                        val finalStatValue =
+                            try {
+                                if (formattedLine.contains("/")) {
+                                    val splits = formattedLine.split("/")
+                                    var sum = 0
+                                    for (split in splits) {
+                                        sum +=
+                                            try {
+                                                split.trim().toInt()
+                                            } catch (_: NumberFormatException) {
+                                                10
+                                            }
+                                    }
+                                    sum
+                                } else {
+                                    formattedLine.toInt()
+                                }
+                            } catch (_: NumberFormatException) {
+                                10
+                            }
+                        selectionWeight[rewardIndex] += finalStatValue
+                    }
+                }
+            }
+        }
+
+        return selectionWeight
+    }
+
+    /**
      * Handle the active Training Event. By default, it will select the first option.
      *
      * This method performs OCR to identify the event and its associated rewards. It then evaluates the options based on user preferences and character specific overrides to select the best possible
@@ -517,178 +701,7 @@ class TrainingEvent(private val game: Game, private val campaign: Campaign) {
                     MessageLog.v(TAG, "[TRAINING_EVENT] Scenario event override applied.")
                     printEventSummary(eventTitle, characterOrSupportName, eventRewards, null, optionSelected, confidence)
                 } else {
-                    // Initialize the List for normal event processing.
-                    val selectionWeight = List(eventRewards.size) { 0 }.toMutableList()
-
-                    // Sum up the stat gains with additional weight applied to stats that are prioritized.
-                    eventRewards.forEachIndexed { rewardIndex, reward ->
-                        val formattedReward: List<String> = reward.split("\n")
-
-                        formattedReward.forEach { line ->
-                            val formattedLine: String =
-                                regex
-                                    .replace(line, "")
-                                    .replace("(", "")
-                                    .replace(")", "")
-                                    .trim()
-                                    .lowercase()
-
-                            // Skip empty strings and divider lines (lines that are all dashes or start with 5 dashes).
-                            if (line.trim().isEmpty() || line.trim().length >= 5 && line.trim().substring(0, 5).all { it == '-' }) {
-                                return@forEach
-                            }
-
-                            var priorityStatCheck = false
-                            if (line.lowercase().contains("can start dating")) {
-                                selectionWeight[rewardIndex] += 1000
-                            } else if (line.lowercase().contains("event chain ended")) {
-                                selectionWeight[rewardIndex] += -300
-                            } else if (line.lowercase().contains("(random)")) {
-                                selectionWeight[rewardIndex] += -10
-                            } else if (line.lowercase().contains("randomly")) {
-                                selectionWeight[rewardIndex] += 50
-                            } else if (line.lowercase().contains("energy")) {
-                                val finalEnergyValue =
-                                    try {
-                                        val energyValue =
-                                            if (formattedLine.contains("/")) {
-                                                val splits = formattedLine.split("/")
-                                                var sum = 0
-                                                for (split in splits) {
-                                                    sum +=
-                                                        try {
-                                                            split.trim().toInt()
-                                                        } catch (_: NumberFormatException) {
-                                                            20
-                                                        }
-                                                }
-                                                sum
-                                            } else {
-                                                formattedLine.toInt()
-                                            }
-
-                                        if (enablePrioritizeEnergyOptions) {
-                                            energyValue * 100
-                                        } else {
-                                            val energyMultiplier =
-                                                when {
-                                                    campaign.trainee.energy < 30 -> 4
-                                                    campaign.trainee.energy < 50 -> 3
-                                                    campaign.trainee.energy < 70 -> 2
-                                                    campaign.trainee.energy >= 90 -> 0
-                                                    else -> 1
-                                                }
-                                            energyValue * energyMultiplier
-                                        }
-                                    } catch (_: NumberFormatException) {
-                                        20
-                                    }
-                                selectionWeight[rewardIndex] += finalEnergyValue
-                            } else if (line.lowercase().contains("mood")) {
-                                val moodMultiplier =
-                                    when (campaign.trainee.mood) {
-                                        Mood.AWFUL -> 150
-                                        Mood.BAD -> 120
-                                        Mood.NORMAL -> 100
-                                        Mood.GOOD -> 80
-                                        Mood.GREAT -> 0
-                                    }
-                                val moodWeight = if (formattedLine.contains("-")) -150 else moodMultiplier
-                                selectionWeight[rewardIndex] += moodWeight
-                            } else if (line.lowercase().contains("bond")) {
-                                val bondWeight = if (formattedLine.contains("-")) -20 else 20
-                                selectionWeight[rewardIndex] += bondWeight
-                            } else if (line.lowercase().contains("hint")) {
-                                selectionWeight[rewardIndex] += 25
-                            } else if (PositiveStatus.names.any { status -> line.contains(status) }) {
-                                selectionWeight[rewardIndex] += 25
-                            } else if (NegativeStatus.names.any { status -> line.contains(status) }) {
-                                selectionWeight[rewardIndex] += -25
-                            } else if (line.lowercase().contains("skill")) {
-                                val finalSkillPoints =
-                                    if (formattedLine.contains("/")) {
-                                        val splits = formattedLine.split("/")
-                                        var sum = 0
-                                        for (split in splits) {
-                                            sum +=
-                                                try {
-                                                    split.trim().toInt()
-                                                } catch (_: NumberFormatException) {
-                                                    10
-                                                }
-                                        }
-                                        sum
-                                    } else {
-                                        formattedLine.toInt()
-                                    }
-                                selectionWeight[rewardIndex] += finalSkillPoints
-                            } else {
-                                // Apply inflated weights to the prioritized stats based on their order.
-                                campaign.training.eventChoiceStatPriority.forEachIndexed { index, stat ->
-                                    if (line.lowercase().contains(stat.name.lowercase())) {
-                                        // Calculate weight bonus based on position (higher priority = higher bonus).
-                                        val priorityBonus =
-                                            when (index) {
-                                                0 -> 50
-                                                1 -> 40
-                                                2 -> 30
-                                                3 -> 20
-                                                else -> 10
-                                            }
-
-                                        val finalStatValue =
-                                            try {
-                                                priorityStatCheck = true
-                                                if (formattedLine.contains("/")) {
-                                                    val splits = formattedLine.split("/")
-                                                    var sum = 0
-                                                    for (split in splits) {
-                                                        sum +=
-                                                            try {
-                                                                split.trim().toInt()
-                                                            } catch (_: NumberFormatException) {
-                                                                10
-                                                            }
-                                                    }
-                                                    sum + priorityBonus
-                                                } else {
-                                                    formattedLine.toInt() + priorityBonus
-                                                }
-                                            } catch (_: NumberFormatException) {
-                                                priorityStatCheck = false
-                                                10
-                                            }
-                                        selectionWeight[rewardIndex] += finalStatValue
-                                    }
-                                }
-
-                                // Apply normal weights to the rest of the stats.
-                                if (!priorityStatCheck) {
-                                    val finalStatValue =
-                                        try {
-                                            if (formattedLine.contains("/")) {
-                                                val splits = formattedLine.split("/")
-                                                var sum = 0
-                                                for (split in splits) {
-                                                    sum +=
-                                                        try {
-                                                            split.trim().toInt()
-                                                        } catch (_: NumberFormatException) {
-                                                            10
-                                                        }
-                                                }
-                                                sum
-                                            } else {
-                                                formattedLine.toInt()
-                                            }
-                                        } catch (_: NumberFormatException) {
-                                            10
-                                        }
-                                    selectionWeight[rewardIndex] += finalStatValue
-                                }
-                            }
-                        }
-                    }
+                    val selectionWeight = computeEventSelectionWeights(eventRewards, regex)
 
                     // Select the best option that aligns with the stat prioritization made in the Training options.
                     val max: Int? = selectionWeight.maxOrNull()

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/Trackblazer.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/Trackblazer.kt
@@ -573,6 +573,42 @@ class Trackblazer(game: Game) : Campaign(game) {
         return false
     }
 
+    private data class RaceSuitability(val isSuitable: Boolean, val solverMatched: Boolean, val reasons: List<String>)
+
+    /**
+     * Evaluates whether a detected race passes the Trackblazer grade and consecutive-race filters.
+     * Solver-scheduled races bypass the filters since the solver already weighed those factors when picking the race.
+     *
+     * @param race The detected race to evaluate. Its isRival flag is set from rivalFound as a side effect.
+     * @param rivalFound Whether a rival was detected on this race row.
+     * @param solverPlannedKey The Smart Race Solver's planned race key for this turn, or null when the solver is off.
+     * @param consecutiveRaceCount How many races have been run consecutively, used for the >= 3 grade gate.
+     * @return The suitability verdict, whether the solver matched this race, and the reasons it was rejected.
+     */
+    private fun evaluateRaceSuitability(race: Racing.RaceData, rivalFound: Boolean, solverPlannedKey: String?, consecutiveRaceCount: Int): RaceSuitability {
+        val reasons = mutableListOf<String>()
+        race.isRival = rivalFound
+
+        // Solver-scheduled races bypass the grade and consecutive-race filters: the solver already weighed those factors when picking this race.
+        val solverMatched = solverPlannedKey != null && SmartRaceSolverIntegration.isRaceKeyMatch(race, solverPlannedKey)
+        val isTopGrade = race.grade in listOf(RaceGrade.G1, RaceGrade.G2, RaceGrade.G3)
+        val isSuitable =
+            when {
+                solverMatched -> true
+                date.year == DateYear.JUNIOR && !isTopGrade -> {
+                    reasons.add("Junior Year: Grade ${race.grade} is not G1, G2, or G3")
+                    false
+                }
+                date.year != DateYear.JUNIOR && consecutiveRaceCount >= 3 && !isTopGrade -> {
+                    reasons.add("Consecutive races >= 3: Grade ${race.grade} is not G1, G2, or G3")
+                    false
+                }
+                else -> true
+            }
+
+        return RaceSuitability(isSuitable, solverMatched, reasons)
+    }
+
     /**
      * Searches the race list for a suitable Trackblazer race based on double-star predictions and grade criteria.
      *
@@ -647,31 +683,7 @@ class Trackblazer(game: Game) : Campaign(game) {
                     val matches = racing.lookupRaceInDatabase(date.day, detectedName)
 
                     for (race in matches) {
-                        var isSuitable = false
-                        val reasons = mutableListOf<String>()
-                        race.isRival = rivalFound
-
-                        // Solver-scheduled races bypass the grade and consecutive-race filters: the solver already weighed those factors when picking this race.
-                        val solverMatched = solverPlannedKey != null && SmartRaceSolverIntegration.isRaceKeyMatch(race, solverPlannedKey)
-                        if (solverMatched) {
-                            isSuitable = true
-                        } else if (date.year == DateYear.JUNIOR) {
-                            if (listOf(RaceGrade.G1, RaceGrade.G2, RaceGrade.G3).contains(race.grade)) {
-                                isSuitable = true
-                            } else {
-                                reasons.add("Junior Year: Grade ${race.grade} is not G1, G2, or G3")
-                            }
-                        } else {
-                            if (consecutiveRaceCount >= 3) {
-                                if (listOf(RaceGrade.G1, RaceGrade.G2, RaceGrade.G3).contains(race.grade)) {
-                                    isSuitable = true
-                                } else {
-                                    reasons.add("Consecutive races >= 3: Grade ${race.grade} is not G1, G2, or G3")
-                                }
-                            } else {
-                                isSuitable = true
-                            }
-                        }
+                        val (isSuitable, solverMatched, reasons) = evaluateRaceSuitability(race, rivalFound, solverPlannedKey, consecutiveRaceCount)
 
                         if (isSuitable) {
                             val candidate = Candidate(screenPoint, race, detectedName, rivalFound)
@@ -714,31 +726,7 @@ class Trackblazer(game: Game) : Campaign(game) {
                 val matches = racing.lookupRaceInDatabase(date.day, detectedName)
 
                 for (race in matches) {
-                    var isSuitable = false
-                    val reasons = mutableListOf<String>()
-                    race.isRival = rivalFound
-
-                    // Solver-scheduled races bypass the grade and consecutive-race filters: the solver already weighed those factors when picking this race.
-                    val solverMatched = solverPlannedKey != null && SmartRaceSolverIntegration.isRaceKeyMatch(race, solverPlannedKey)
-                    if (solverMatched) {
-                        isSuitable = true
-                    } else if (date.year == DateYear.JUNIOR) {
-                        if (listOf(RaceGrade.G1, RaceGrade.G2, RaceGrade.G3).contains(race.grade)) {
-                            isSuitable = true
-                        } else {
-                            reasons.add("Junior Year: Grade ${race.grade} is not G1, G2, or G3")
-                        }
-                    } else {
-                        if (consecutiveRaceCount >= 3) {
-                            if (listOf(RaceGrade.G1, RaceGrade.G2, RaceGrade.G3).contains(race.grade)) {
-                                isSuitable = true
-                            } else {
-                                reasons.add("Consecutive races >= 3: Grade ${race.grade} is not G1, G2, or G3")
-                            }
-                        } else {
-                            isSuitable = true
-                        }
-                    }
+                    val (isSuitable, solverMatched) = evaluateRaceSuitability(race, rivalFound, solverPlannedKey, consecutiveRaceCount)
 
                     if (isSuitable) {
                         val candidate = Candidate(location, race, detectedName, rivalFound)
@@ -758,7 +746,7 @@ class Trackblazer(game: Game) : Campaign(game) {
             return null
         }
 
-        // If the Solver's planned race surfaced during the scan, short-circuit straight to it — its on-screen point is still current because the scrollList stopped on that entry.
+        // If the Solver's planned race surfaced during the scan, short-circuit straight to it - its on-screen point is still current because the scrollList stopped on that entry.
         if (solverMatchedCandidate != null) {
             val match = solverMatchedCandidate!!
             sb.appendLine("\nSelected Race: ${match.race.name} (${match.race.grade}) Rival: ${match.isRival} [Smart Race Solver pick]")
@@ -990,7 +978,7 @@ class Trackblazer(game: Game) : Campaign(game) {
             return true
         }
 
-        // Has mood items and energy is low — skip recovery, items will handle mood in useItems().
+        // Has mood items and energy is low - skip recovery, items will handle mood in useItems().
         return false
     }
 
@@ -1840,84 +1828,20 @@ class Trackblazer(game: Game) : Campaign(game) {
     }
 
     /**
-     * Handles the specialized training process for Trackblazer, including item usage.
+     * Attempts a Reset Whistle re-roll when no training was selected and the whistle window is open, re-analyzing and possibly force-picking afterward.
+     *
+     * @param initialSelection The training chosen by the initial analysis pass, or null if none was acceptable.
+     * @param hasCharm Whether a Good-Luck Charm is available this turn, passed through to the post-whistle re-analysis.
+     * @return The training selection after any re-roll - unchanged, newly picked, or null.
      */
-    private fun handleTrackblazerTraining() {
-        MessageLog.i(TAG, "[TRACKBLAZER] Starting specialized Training process.")
+    private fun maybeResetWhistleReroll(initialSelection: StatName?, hasCharm: Boolean): StatName? {
+        var trainingSelected = initialSelection
 
-        // Fast path: Already on the training screen from irregular training evaluation.
-        if (bIsIrregularTraining) {
-            MessageLog.i(TAG, "[TRACKBLAZER] Using existing irregular training analysis (already on Training screen).")
-            val trainingSelected: StatName? = training.recommendTraining(args = mapOf("isIrregularEvaluation" to true, "irregularTrainingMinStatGain" to minIrregularGain))
-            captureRunnerUpsSnapshot()
-            if (trainingSelected != null && training.lastSelectionSource != SelectionSource.ANALYSIS) {
-                MessageLog.i(TAG, "[TRACKBLAZER] On-screen evaluation used fallback (${training.lastSelectionSource}): $trainingSelected.")
-            }
-
-            // Still use training items (megaphones, ankle weights, charms, energy, stat items, etc.)
-            if (date.day >= 13) {
-                useItems(trainee, trainingSelected)
-            }
-
-            if (trainingSelected != null) {
-                val (pickFail, pickGains) = pickedStatDetails(trainingSelected)
-                decisionTracer.recordTrainingSelection(
-                    selected = trainingSelected,
-                    source = training.lastSelectionSource,
-                    reason = "Irregular Training fast-path (already on Training screen from pre-screen evaluation)",
-                    runnerUps = buildTrainingRunnerUps(trainingSelected),
-                    pickedFailureChance = pickFail,
-                    pickedStatGains = pickGains,
-                )
-                training.executeTraining(trainingSelected)
-            } else {
-                MessageLog.w(TAG, "[WARN] handleTrackblazerTraining:: Irregular training unexpectedly became null. Backing out.")
-                decisionTracer.recordTrainingSelection(
-                    selected = null,
-                    source = training.lastSelectionSource,
-                    reason = "Irregular Training fast-path lost its selection (recommendTraining returned null after pre-screen pick); backing out",
-                    runnerUps = buildTrainingRunnerUps(null),
-                )
-                ButtonBack.click(game.imageUtils)
-                game.wait(game.dialogWaitDelay)
-            }
-
-            bIsIrregularTraining = false
-            training.firstTrainingCheck = false
-            return
-        }
-
-        // Enter the Training screen.
-        if (!ButtonTraining.click(game.imageUtils)) {
-            MessageLog.e(TAG, "[ERROR] handleTrackblazerTraining:: Failed to enter Training screen.")
-            return
-        }
-        game.wait(0.5)
-
-        // Initial Training Analysis.
-        val hasCharm = date.day >= 13 && !bUsedCharmToday && (currentInventory["Good-Luck Charm"] ?: 0) > 0
-        training.analyzeTrainings(mapOf("ignoreFailureChance" to hasCharm, "minStatGainForCharm" to minCharmGain))
-        var trainingSelected: StatName? = training.recommendTraining()
-        captureRunnerUpsSnapshot()
-        if (trainingSelected != null && training.lastSelectionSource != SelectionSource.ANALYSIS) {
-            MessageLog.i(TAG, "[TRACKBLAZER] Initial training selection used fallback (${training.lastSelectionSource}): $trainingSelected.")
-        }
-
-        // Finally, perform a consolidated item usage pass after the training is finalized.
-        if (date.day >= 13) {
-            useItems(trainee, trainingSelected)
-        }
-
-        // Reset Whistle Check: Use if recommendations are poor.
-        // We define "poor" as no training being selected or certain other conditions.
-        // Block whistling during irregular training evaluations.
-
-        // Limit automated whistle usage to during summer or near end of senior (Turns 37-40, >60)
         if ((date.day in 37..40 || date.day > 60) && !bUsedWhistleToday && trainingSelected == null && !bIsIrregularTraining && !training.needsEnergyRecovery) {
             val hasWhistle = (currentInventory["Reset Whistle"] ?: 0) > 0
 
             // Whistle viability gate: when mood is below NORMAL, the mood multiplier structurally caps gains.
-            // Reshuffling trainings won't recover from that — so refuse to consume the Whistle if enough
+            // Reshuffling trainings won't recover from that - so refuse to consume the Whistle if enough
             // non-blacklisted trainings already show low main-stat gain. The required count scales with the
             // blacklist size: 0 blacklisted -> 3-of-5, 1 blacklisted -> 2-of-4, 2+ blacklisted -> 1 (clamped).
             val whistleGateBlocks =
@@ -2053,6 +1977,85 @@ class Trackblazer(game: Game) : Campaign(game) {
                 "Outside Whistle window (day=${date.day}, allowed: 37..40 or > 60)",
             )
         }
+
+        return trainingSelected
+    }
+
+    /**
+     * Handles the specialized training process for Trackblazer, including item usage.
+     */
+    private fun handleTrackblazerTraining() {
+        MessageLog.i(TAG, "[TRACKBLAZER] Starting specialized Training process.")
+
+        // Fast path: Already on the training screen from irregular training evaluation.
+        if (bIsIrregularTraining) {
+            MessageLog.i(TAG, "[TRACKBLAZER] Using existing irregular training analysis (already on Training screen).")
+            val trainingSelected: StatName? = training.recommendTraining(args = mapOf("isIrregularEvaluation" to true, "irregularTrainingMinStatGain" to minIrregularGain))
+            captureRunnerUpsSnapshot()
+            if (trainingSelected != null && training.lastSelectionSource != SelectionSource.ANALYSIS) {
+                MessageLog.i(TAG, "[TRACKBLAZER] On-screen evaluation used fallback (${training.lastSelectionSource}): $trainingSelected.")
+            }
+
+            // Still use training items (megaphones, ankle weights, charms, energy, stat items, etc.)
+            if (date.day >= 13) {
+                useItems(trainee, trainingSelected)
+            }
+
+            if (trainingSelected != null) {
+                val (pickFail, pickGains) = pickedStatDetails(trainingSelected)
+                decisionTracer.recordTrainingSelection(
+                    selected = trainingSelected,
+                    source = training.lastSelectionSource,
+                    reason = "Irregular Training fast-path (already on Training screen from pre-screen evaluation)",
+                    runnerUps = buildTrainingRunnerUps(trainingSelected),
+                    pickedFailureChance = pickFail,
+                    pickedStatGains = pickGains,
+                )
+                training.executeTraining(trainingSelected)
+            } else {
+                MessageLog.w(TAG, "[WARN] handleTrackblazerTraining:: Irregular training unexpectedly became null. Backing out.")
+                decisionTracer.recordTrainingSelection(
+                    selected = null,
+                    source = training.lastSelectionSource,
+                    reason = "Irregular Training fast-path lost its selection (recommendTraining returned null after pre-screen pick); backing out",
+                    runnerUps = buildTrainingRunnerUps(null),
+                )
+                ButtonBack.click(game.imageUtils)
+                game.wait(game.dialogWaitDelay)
+            }
+
+            bIsIrregularTraining = false
+            training.firstTrainingCheck = false
+            return
+        }
+
+        // Enter the Training screen.
+        if (!ButtonTraining.click(game.imageUtils)) {
+            MessageLog.e(TAG, "[ERROR] handleTrackblazerTraining:: Failed to enter Training screen.")
+            return
+        }
+        game.wait(0.5)
+
+        // Initial Training Analysis.
+        val hasCharm = date.day >= 13 && !bUsedCharmToday && (currentInventory["Good-Luck Charm"] ?: 0) > 0
+        training.analyzeTrainings(mapOf("ignoreFailureChance" to hasCharm, "minStatGainForCharm" to minCharmGain))
+        var trainingSelected: StatName? = training.recommendTraining()
+        captureRunnerUpsSnapshot()
+        if (trainingSelected != null && training.lastSelectionSource != SelectionSource.ANALYSIS) {
+            MessageLog.i(TAG, "[TRACKBLAZER] Initial training selection used fallback (${training.lastSelectionSource}): $trainingSelected.")
+        }
+
+        // Finally, perform a consolidated item usage pass after the training is finalized.
+        if (date.day >= 13) {
+            useItems(trainee, trainingSelected)
+        }
+
+        // Reset Whistle Check: Use if recommendations are poor.
+        // We define "poor" as no training being selected or certain other conditions.
+        // Block whistling during irregular training evaluations.
+
+        // Limit automated whistle usage to during summer or near end of senior (Turns 37-40, >60)
+        trainingSelected = maybeResetWhistleReroll(trainingSelected, hasCharm)
 
         // Final Training Execution.
         if (trainingSelected != null) {
@@ -2630,7 +2633,7 @@ class Trackblazer(game: Game) : Campaign(game) {
 
         // Determine if a Good-Luck Charm is being used this turn (either already queued or will be queued).
         // If so, skip energy items because the Charm sets failure to 0% regardless of energy, and the energy cost
-        // is subtracted after training — so using energy items would waste them.
+        // is subtracted after training - so using energy items would waste them.
         val charmBeingUsedThisTurn =
             bUsedCharmToday ||
                 (date.day >= 13 && failureChance >= 20 && (nextInventory["Good-Luck Charm"] ?: 0) > 0)

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/solver/EpithetTracker.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/solver/EpithetTracker.kt
@@ -60,6 +60,16 @@ object EpithetTracker {
         epithet.matchers.any { progress(it, state) > 0.0 }
 
     /**
+     * Counts how many distinct races in the run's history match the given candidate names.
+     *
+     * @param names The candidate race names to match against.
+     * @param state The solver state holding the race-win history.
+     * @return The number of distinct matched race names.
+     */
+    private fun winsMatchingCount(names: List<String>, state: SolverState): Int =
+        state.raceHistory.map { it.name }.toSet().intersect(names.toSet()).size
+
+    /**
      * Whole-matcher satisfaction check. Each [EpithetMatcher] subtype has its own predicate;
      * see [Epithet] for the semantics of each.
      *
@@ -83,10 +93,7 @@ object EpithetTracker {
                         (matcher.atClass == null || win.classYear.equals(matcher.atClass, ignoreCase = true))
                 } >= matcher.count
             }
-            is EpithetMatcher.WinAtLeast -> {
-                val pool = matcher.names.toSet()
-                state.raceHistory.map { it.name }.toSet().intersect(pool).size >= matcher.count
-            }
+            is EpithetMatcher.WinAtLeast -> winsMatchingCount(matcher.names, state) >= matcher.count
             is EpithetMatcher.WinCount ->
                 state.raceHistory.count { matchesFilter(it, matcher.filter, state) } >= matcher.count
             is EpithetMatcher.EpithetAnyOf ->
@@ -121,7 +128,7 @@ object EpithetTracker {
                 (have.toDouble() / matcher.count).coerceAtMost(1.0)
             }
             is EpithetMatcher.WinAtLeast -> {
-                val have = state.raceHistory.map { it.name }.toSet().intersect(matcher.names.toSet()).size
+                val have = winsMatchingCount(matcher.names, state)
                 (have.toDouble() / matcher.count).coerceAtMost(1.0)
             }
             is EpithetMatcher.WinCount -> {

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/solver/RaceHistory.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/solver/RaceHistory.kt
@@ -146,6 +146,29 @@ object RaceHistory {
     }
 
     /**
+     * Reads one crop region relative to an anchor point via OCR and trims the result.
+     *
+     * @param game Active Game instance for OCR.
+     * @param anchor The reference point the crop offsets are measured from.
+     * @param offsetX Horizontal offset of the crop from the anchor.
+     * @param offsetY Vertical offset of the crop from the anchor.
+     * @param w Crop width in reference pixels (scaled via relWidth).
+     * @param h Crop height in reference pixels (scaled via relHeight).
+     * @param debugName Identifier used for debug image dumps.
+     * @return The trimmed OCR text for the crop region.
+     */
+    private fun ocrFromAnchor(game: Game, anchor: Point, offsetX: Int, offsetY: Int, w: Int, h: Int, debugName: String): String =
+        game.imageUtils
+            .performOCRFromReference(
+                referencePoint = anchor,
+                offsetX = offsetX,
+                offsetY = offsetY,
+                width = game.imageUtils.relWidth(w),
+                height = game.imageUtils.relHeight(h),
+                debugName = debugName,
+            ).trim()
+
+    /**
      * Parse a single race history row by anchoring on its visible LabelStrategy chip and OCR-ing the crop regions relative to it.
      *
      * @param game Active Game instance for OCR and image search.
@@ -162,38 +185,11 @@ object RaceHistory {
         val anchorY: Int = entry.bbox.y + anchorInEntry.y.toInt()
         val anchor = Point(anchorX.toDouble(), anchorY.toDouble())
 
-        val nameFormatted =
-            game.imageUtils
-                .performOCRFromReference(
-                    referencePoint = anchor,
-                    offsetX = FORMATTED_NAME_OFFSET_X,
-                    offsetY = FORMATTED_NAME_OFFSET_Y,
-                    width = game.imageUtils.relWidth(FORMATTED_NAME_W),
-                    height = game.imageUtils.relHeight(FORMATTED_NAME_H),
-                    debugName = "race_history_formatted_$anchorY",
-                ).trim()
+        val nameFormatted = ocrFromAnchor(game, anchor, FORMATTED_NAME_OFFSET_X, FORMATTED_NAME_OFFSET_Y, FORMATTED_NAME_W, FORMATTED_NAME_H, "race_history_formatted_$anchorY")
 
-        val dateString =
-            game.imageUtils
-                .performOCRFromReference(
-                    referencePoint = anchor,
-                    offsetX = DATE_OFFSET_X,
-                    offsetY = DATE_OFFSET_Y,
-                    width = game.imageUtils.relWidth(DATE_W),
-                    height = game.imageUtils.relHeight(DATE_H),
-                    debugName = "race_history_date_$anchorY",
-                ).trim()
+        val dateString = ocrFromAnchor(game, anchor, DATE_OFFSET_X, DATE_OFFSET_Y, DATE_W, DATE_H, "race_history_date_$anchorY")
 
-        val strategy =
-            game.imageUtils
-                .performOCRFromReference(
-                    referencePoint = anchor,
-                    offsetX = STRATEGY_OFFSET_X,
-                    offsetY = STRATEGY_OFFSET_Y,
-                    width = game.imageUtils.relWidth(STRATEGY_W),
-                    height = game.imageUtils.relHeight(STRATEGY_H),
-                    debugName = "race_history_strategy_$anchorY",
-                ).trim()
+        val strategy = ocrFromAnchor(game, anchor, STRATEGY_OFFSET_X, STRATEGY_OFFSET_Y, STRATEGY_W, STRATEGY_H, "race_history_strategy_$anchorY")
 
         val firstPlaceRegion =
             intArrayOf(

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/solver/SmartRaceSolverIntegration.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/solver/SmartRaceSolverIntegration.kt
@@ -35,6 +35,11 @@ object SmartRaceSolverIntegration {
      *  turn and the existing Preview-based seed runs instead. */
     private const val PRE_DEBUT_TURN_THRESHOLD: TurnNumber = 13
 
+    /** Calendar turn used for the synthetic Junior Make Debut display row. The viewer's date-label scheme renders this turn as "Late Jun",
+     *  matching the in-game date the Make Debut race actually occurs on. The cell sits inside the pre-debut block; the renderer suppresses
+     *  the pre-debut style when a synthetic result is attached. */
+    private const val MAKE_DEBUT_DISPLAY_TURN: TurnNumber = 12
+
     /** Wins for the current run - both confirmed in-game finishes and Preview-assumed wins
      *  added on a mid-run restart. Cleared by [reset]. Guarded by its own monitor since the
      *  bot and UI threads can read/write here concurrently. */
@@ -153,11 +158,6 @@ object SmartRaceSolverIntegration {
     // //////////////////////////////////////////////////////////////////////////////////////////////////
     // //////////////////////////////////////////////////////////////////////////////////////////////////
     // Junior Make Debut display-only entry
-
-    /** Calendar turn used for the synthetic Junior Make Debut display row. The viewer's date-label scheme renders this turn as "Late Jun",
-     *  matching the in-game date the Make Debut race actually occurs on. The cell sits inside the pre-debut block; the renderer suppresses
-     *  the pre-debut style when a synthetic result is attached. */
-    private const val MAKE_DEBUT_DISPLAY_TURN: TurnNumber = 12
 
     /**
      * Emits a single MessageLog line announcing the synthetic Junior Make Debut entry shown in the Remote Log Viewer calendar. Idempotent
@@ -300,7 +300,7 @@ object SmartRaceSolverIntegration {
      * @param historyAfter Snapshot of [raceHistory] after [recordRaceWon] added this win.
      */
     private fun logEpithetProgressAfterWin(raceName: String, turnNumber: TurnNumber, historyBefore: List<RaceWin>, historyAfter: List<RaceWin>) {
-        val epithets = epithetsForActiveContext(cachedEpithets ?: loadEpithets() ?: return, currentRunScenario)
+        val epithets = epithetsForActiveContext(cachedEpithets ?: loadEpithets() ?: return, currentRunScenario, SettingsHelper.getStringSetting("racing", "smartRaceSolverCharacterPreset"))
         val racesByTurn = cachedRaces ?: loadAllRaces() ?: return
         val race = racesByTurn[turnNumber]?.firstOrNull { it.name == raceName }
         val candidates = epithets.filter { epi -> epi.matchers.any { matcherReferencesRace(it, raceName, race) } }
@@ -672,7 +672,7 @@ object SmartRaceSolverIntegration {
             characterPreset = characterPreset,
             aptitudes = aptitudes,
             racesByTurn = applied.racesByTurn,
-            epithets = epithetsForActiveContext(epithets, scenario),
+            epithets = epithetsForActiveContext(epithets, scenario, characterPreset ?: ""),
             raceHistory = raceHistorySnapshot,
             forcedEpithets = readStringSet("smartRaceSolverForcedEpithets"),
             targetEpithets = readStringSet("smartRaceSolverTargetEpithets"),
@@ -695,10 +695,10 @@ object SmartRaceSolverIntegration {
      * @param epithets Full epithet list parsed from epithets.json.
      * @param scenario Active scenario name (e.g. "Trackblazer", "URA Finale", "Unity Cup"). Blank
      *   disables the scenario gate so test contexts and the preview history seed keep working.
+     * @param preset Active character preset. Blank disables the character gate.
      * @return Subset of [epithets] usable for the active scenario / preset.
      */
-    private fun epithetsForActiveContext(epithets: List<Epithet>, scenario: String): List<Epithet> {
-        val preset = SettingsHelper.getStringSetting("racing", "smartRaceSolverCharacterPreset")
+    private fun epithetsForActiveContext(epithets: List<Epithet>, scenario: String, preset: String): List<Epithet> {
         return epithets.filter {
             val scenarioRestrictions = EpithetFilters.scenariosFor(it)
             val scenarioOk =
@@ -899,10 +899,7 @@ object SmartRaceSolverIntegration {
     private fun readStringSet(key: String): Set<String> {
         val json = SettingsHelper.getStringSetting("racing", key)
         if (json.isEmpty()) return emptySet()
-        return runCatching {
-            val arr = JSONArray(json)
-            (0 until arr.length()).mapTo(mutableSetOf()) { arr.getString(it) }
-        }.getOrElse { emptySet() }
+        return runCatching { jsonStringList(JSONArray(json)).toSet() }.getOrElse { emptySet() }
     }
 
     /**
@@ -1027,9 +1024,7 @@ object SmartRaceSolverIntegration {
     internal fun parseEpithets(json: String): List<Epithet> {
         val obj = JSONObject(json)
         val out = ArrayList<Epithet>(obj.length())
-        val keys = obj.keys()
-        while (keys.hasNext()) {
-            val name = keys.next()
+        for (name in obj.keys()) {
             val e = obj.getJSONObject(name)
             out.add(
                 Epithet(
@@ -1052,13 +1047,7 @@ object SmartRaceSolverIntegration {
      */
     private fun parseMatchers(arr: JSONArray?): List<EpithetMatcher> {
         if (arr == null) return emptyList()
-        val out = ArrayList<EpithetMatcher>(arr.length())
-        for (i in 0 until arr.length()) {
-            val m = arr.getJSONObject(i)
-            val matcher = parseMatcher(m) ?: continue
-            out.add(matcher)
-        }
-        return out
+        return (0 until arr.length()).mapNotNull { parseMatcher(arr.getJSONObject(it)) }
     }
 
     /**
@@ -1152,9 +1141,7 @@ object SmartRaceSolverIntegration {
     private fun parsePresets(json: String): Map<String, Aptitudes> {
         val obj = JSONObject(json)
         val out = HashMap<String, Aptitudes>(obj.length())
-        val keys = obj.keys()
-        while (keys.hasNext()) {
-            val name = keys.next()
+        for (name in obj.keys()) {
             val p = obj.getJSONObject(name)
             val dist = p.optJSONObject("distanceAptitudes")
             val surf = p.optJSONObject("surfaceAptitudes")
@@ -1249,9 +1236,7 @@ object SmartRaceSolverIntegration {
     internal fun parseRacesData(json: String): Map<TurnNumber, List<RaceCandidate>> {
         val obj = JSONObject(json)
         val out = HashMap<TurnNumber, MutableList<RaceCandidate>>()
-        val keys = obj.keys()
-        while (keys.hasNext()) {
-            val key = keys.next()
+        for (key in obj.keys()) {
             val r = obj.getJSONObject(key)
             val turn = r.optInt("turnNumber", -1)
             if (turn <= 0) continue
@@ -1295,9 +1280,7 @@ object SmartRaceSolverIntegration {
     ): Map<TurnNumber, Decision> {
         if (obj == null) return emptyMap()
         val out = HashMap<TurnNumber, Decision>()
-        val keys = obj.keys()
-        while (keys.hasNext()) {
-            val turnStr = keys.next()
+        for (turnStr in obj.keys()) {
             val turn = turnStr.toIntOrNull() ?: continue
             val value = obj.optString(turnStr, "")
             if (value.isEmpty()) continue

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/components/Button.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/components/Button.kt
@@ -10,339 +10,104 @@
 
 package com.steve1316.uma_android_automation.components
 
-object ButtonAgenda : ButtonInterface {
-    override val template = Template("components/button/agenda", region = Region.bottomHalf)
-}
-
-object ButtonAutoSelect : ButtonInterface {
-    override val template = Template("components/button/auto_select")
-}
-
-object ButtonBack : ButtonInterface {
-    override val template = Template("components/button/back", region = Region.bottomHalf)
-}
-
-object ButtonBackGreen : ButtonInterface {
-    override val template = Template("components/button/back_green", region = Region.bottomHalf)
-}
-
-object ButtonBeginShowdown : ButtonInterface {
-    override val template = Template("components/button/begin_showdown")
-}
-
-object ButtonBorrowSupportCard : ButtonInterface {
-    override val template = Template("components/button/borrow_support_card")
-}
-
-object ButtonBurger : ButtonInterface {
-    override val template = Template("components/button/burger", region = Region.bottomHalf)
-}
-
-object ButtonCancel : ButtonInterface {
-    override val template = Template("components/button/cancel", region = Region.bottomHalf)
-}
-
-object ButtonCareer : ButtonInterface {
-    override val template = Template("components/button/career")
-}
-
-object ButtonChangeRunningStyle : ButtonInterface {
-    override val template = Template("components/button/change")
-}
-
-object ButtonClose : ButtonInterface {
-    override val template = Template("components/button/close", region = Region.bottomHalf)
-}
-
-object ButtonCollectAll : ButtonInterface {
-    override val template = Template("components/button/collect_all", region = Region.bottomHalf)
-}
-
-object ButtonConfirm : ButtonInterface {
-    override val template = Template("components/button/confirm", region = Region.bottomHalf)
-}
-
-object ButtonConfirmExclamation : ButtonInterface {
-    override val template = Template("components/button/confirm_exclamation", region = Region.bottomHalf)
-}
-
-object ButtonDailyRaces : ButtonInterface {
-    override val template = Template("components/button/daily_races")
-}
-
-object ButtonDailyRacesDisabled : ButtonInterface {
-    override val template = Template("components/button/daily_races_disabled")
-}
-
-object ButtonDailyRacesJupiterCup : ButtonInterface {
-    override val template = Template("components/button/daily_races_jupiter_cup_logo")
-}
-
-object ButtonDailyRacesMoonlightSho : ButtonInterface {
-    override val template = Template("components/button/daily_races_moonlight_sho_logo")
-}
-
-object ButtonEditTeam : ButtonInterface {
-    override val template = Template("components/button/edit_team")
-}
-
-object ButtonFollow : ButtonInterface {
-    override val template = Template("components/button/follow")
-}
-
-object ButtonFinish : ButtonInterface {
-    override val template = Template("components/button/finish")
-}
-
-object ButtonGiveUp : ButtonInterface {
-    override val template = Template("components/button/give_up")
-}
-
-object ButtonToHome : ButtonInterface {
-    override val template = Template("components/button/to_home")
-}
-
-object ButtonHomeSpecialMissions : ButtonInterface {
-    override val template = Template("components/button/home_special_missions")
-}
-
-object ButtonHomePresents : ButtonInterface {
-    override val template = Template("components/button/home_presents")
-}
-
-object ButtonSpecialMissionsTabDaily : ButtonInterface {
-    override val template = Template("components/button/special_missions_tab_daily")
-}
-
-object ButtonSpecialMissionsTabMain : ButtonInterface {
-    override val template = Template("components/button/special_missions_tab_main")
-}
-
-object ButtonSpecialMissionsTabTitles : ButtonInterface {
-    override val template = Template("components/button/special_missions_tab_titles")
-}
-
-object ButtonSpecialMissionsTabSpecial : ButtonInterface {
-    override val template = Template("components/button/special_missions_tab_special")
-}
-
-object ButtonLater : ButtonInterface {
-    override val template = Template("components/button/later")
-}
-
-object ButtonLegendRace : ButtonInterface {
-    override val template = Template("components/button/legend_race")
-}
-
-object ButtonLegendRaceDisabled : ButtonInterface {
-    override val template = Template("components/button/legend_race_disabled")
-}
-
-object ButtonRaceHardInactive : ButtonInterface {
-    override val template = Template("components/button/race_hard_inactive")
-}
-
-object ButtonRaceHardActive : ButtonInterface {
-    override val template = Template("components/button/race_hard_active")
-}
-
-object ButtonLegendRaceHomeSpecialMissions : ButtonInterface {
-    override val template = Template("components/button/legend_race_special_missions")
-}
-
-object ButtonLog : ButtonInterface {
-    override val template = Template("components/button/log", region = Region.bottomHalf)
-}
-
-object ButtonNext : ButtonInterface {
-    override val template = Template("components/button/next", region = Region.bottomHalf)
-}
-
-object ButtonNextWithImage : ButtonInterface {
-    override val template = Template("components/button/next_with_image", region = Region.bottomHalf)
-}
-
-object ButtonNextRaceEnd : ButtonInterface {
-    override val template = Template("components/button/next_race_end", region = Region.bottomHalf)
-}
-
-object ButtonNo : ButtonInterface {
-    override val template = Template("components/button/no", region = Region.bottomHalf)
-}
-
-object ButtonOk : ButtonInterface {
-    override val template = Template("components/button/ok", region = Region.bottomHalf)
-}
-
-object ButtonOptions : ButtonInterface {
-    override val template = Template("components/button/options", region = Region.bottomHalf)
-}
-
-object ButtonLearn : ButtonInterface {
-    override val template = Template("components/button/learn")
-}
-
-object ButtonReset : ButtonInterface {
-    override val template = Template("components/button/reset", region = Region.bottomHalf)
-}
-
-object ButtonRace : ButtonInterface {
-    override val template = Template("components/button/race", region = Region.bottomHalf)
-}
-
-object ButtonRaceDayRace : ButtonInterface {
-    override val template = Template("components/button/race_day_race", region = Region.bottomHalf)
-}
-
-object ButtonRaceAgain : ButtonInterface {
-    override val template = Template("components/button/race_again", region = Region.bottomHalf)
-}
-
-object ButtonRaceDetails : ButtonInterface {
-    override val template = Template("components/button/race_details", region = Region.bottomHalf)
-}
-
-object ButtonRaceEvents : ButtonInterface {
-    override val template = Template("components/button/race_events")
-}
-
-object ButtonRaceExclamation : ButtonInterface {
-    override val template = Template("components/button/race_exclamation", region = Region.bottomHalf)
-}
-
-object ButtonRaceExclamationShiftedUp : ButtonInterface {
-    override val template = Template("components/button/race_exclamation_shifted_up", region = Region.middle)
-}
-
-object ButtonRaceManual : ButtonInterface {
-    override val template = Template("components/button/race_manual", region = Region.bottomHalf)
-}
-
-object ButtonRaceRecommendationsCenterStage : ButtonInterface {
-    override val template = Template("components/button/race_recommendations_center_stage")
-}
-
-object ButtonRaceRecommendationsPathToFame : ButtonInterface {
-    override val template = Template("components/button/race_recommendations_path_to_fame")
-}
-
-object ButtonRaceRecommendationsForgeYourOwnPath : ButtonInterface {
-    override val template = Template("components/button/race_recommendations_forge_your_own_path")
-}
-
-object ButtonRaceResults : ButtonInterface {
-    override val template = Template("components/button/race_results")
-}
-
-object ButtonRestore : ButtonInterface {
-    override val template = Template("components/button/restore")
-}
-
-object ButtonRetry : ButtonInterface {
-    override val template = Template("components/button/retry")
-}
-
-object ButtonResume : ButtonInterface {
-    override val template = Template("components/button/resume")
-}
-
-object ButtonSave : ButtonInterface {
-    override val template = Template("components/button/save", region = Region.bottomHalf)
-}
-
-object ButtonSaveSchedule : ButtonInterface {
-    override val template = Template("components/button/save_schedule", region = Region.bottomHalf)
-}
-
-object ButtonSaveAndExit : ButtonInterface {
-    override val template = Template("components/button/save_and_exit", region = Region.bottomHalf)
-}
-
-object ButtonSeeResults : ButtonInterface {
-    override val template = Template("components/button/see_results", region = Region.bottomHalf)
-}
-
-object ButtonSelectOpponent : ButtonInterface {
-    override val template = Template("components/button/select_opponent", region = Region.bottomHalf)
-}
-
-object ButtonSelectLegacy : ButtonInterface {
-    override val template = Template("components/button/select_legacy")
-}
-
-object ButtonShop : ButtonInterface {
-    override val template = Template("components/button/shop")
-}
-
-object ButtonSkip : ButtonInterface {
-    override val template = Template("components/button/skip", region = Region.bottomHalf)
-}
-
-object ButtonSkills : ButtonInterface {
-    override val template = Template("components/button/skills", region = Region.bottomHalf)
-}
-
-object ButtonStartCareer : ButtonInterface {
-    override val template = Template("components/button/start_career", region = Region.bottomHalf)
-}
-
-object ButtonStartCareerOffset : ButtonInterface {
-    override val template = Template("components/button/start_career_offset", region = Region.bottomHalf)
-}
-
-object ButtonTeamRace : ButtonInterface {
-    override val template = Template("components/button/team_race")
-}
-
-object ButtonTeamTrials : ButtonInterface {
-    override val template = Template("components/button/team_trials")
-}
-
-object ButtonTitleScreen : ButtonInterface {
-    override val template = Template("components/button/title_screen")
-}
-
-object ButtonTryAgain : ButtonInterface {
-    override val template = Template("components/button/try_again", region = Region.bottomHalf)
-}
-
-object ButtonTryAgainAlt : ButtonInterface {
-    override val template = Template("components/button/try_again_alt", region = Region.bottomHalf)
-}
-
-object ButtonViewResults : ButtonInterface {
-    override val template = Template("components/button/view_results", region = Region.bottomHalf)
-}
-
-object ButtonWatchConcert : ButtonInterface {
-    override val template = Template("components/button/watch_concert", region = Region.bottomHalf)
-}
-
-object ButtonRaceStrategyFront : ButtonInterface {
-    override val template = Template("components/button/strategy_front_select", region = Region.middle)
-}
-
-object ButtonRaceStrategyPace : ButtonInterface {
-    override val template = Template("components/button/strategy_pace_select", region = Region.middle)
-}
-
-object ButtonRaceStrategyLate : ButtonInterface {
-    override val template = Template("components/button/strategy_late_select", region = Region.middle)
-}
-
-object ButtonRaceStrategyEnd : ButtonInterface {
-    override val template = Template("components/button/strategy_end_select", region = Region.middle)
-}
+/**
+ * Builds a clickable button component backed by the `components/button/[name]` template.
+ *
+ * @param name Leaf filename under `components/button/` identifying the template image.
+ * @param region Screen region to constrain matching to. Defaults to the whole screen.
+ * @return A [ButtonInterface] wrapping the resolved template.
+ */
+private fun button(name: String, region: IntArray = intArrayOf(0, 0, 0, 0)): ButtonInterface =
+    object : ButtonInterface {
+        override val template = Template("components/button/$name", region = region)
+    }
+
+val ButtonAgenda = button("agenda", Region.bottomHalf)
+val ButtonAutoSelect = button("auto_select")
+val ButtonBack = button("back", Region.bottomHalf)
+val ButtonBackGreen = button("back_green", Region.bottomHalf)
+val ButtonBeginShowdown = button("begin_showdown")
+val ButtonBorrowSupportCard = button("borrow_support_card")
+val ButtonBurger = button("burger", Region.bottomHalf)
+val ButtonCancel = button("cancel", Region.bottomHalf)
+val ButtonCareer = button("career")
+val ButtonChangeRunningStyle = button("change")
+val ButtonClose = button("close", Region.bottomHalf)
+val ButtonCollectAll = button("collect_all", Region.bottomHalf)
+val ButtonConfirm = button("confirm", Region.bottomHalf)
+val ButtonConfirmExclamation = button("confirm_exclamation", Region.bottomHalf)
+val ButtonDailyRaces = button("daily_races")
+val ButtonDailyRacesDisabled = button("daily_races_disabled")
+val ButtonDailyRacesJupiterCup = button("daily_races_jupiter_cup_logo")
+val ButtonDailyRacesMoonlightSho = button("daily_races_moonlight_sho_logo")
+val ButtonEditTeam = button("edit_team")
+val ButtonFollow = button("follow")
+val ButtonFinish = button("finish")
+val ButtonGiveUp = button("give_up")
+val ButtonToHome = button("to_home")
+val ButtonHomeSpecialMissions = button("home_special_missions")
+val ButtonHomePresents = button("home_presents")
+val ButtonSpecialMissionsTabDaily = button("special_missions_tab_daily")
+val ButtonSpecialMissionsTabMain = button("special_missions_tab_main")
+val ButtonSpecialMissionsTabTitles = button("special_missions_tab_titles")
+val ButtonSpecialMissionsTabSpecial = button("special_missions_tab_special")
+val ButtonLater = button("later")
+val ButtonLegendRace = button("legend_race")
+val ButtonLegendRaceDisabled = button("legend_race_disabled")
+val ButtonRaceHardInactive = button("race_hard_inactive")
+val ButtonRaceHardActive = button("race_hard_active")
+val ButtonLegendRaceHomeSpecialMissions = button("legend_race_special_missions")
+val ButtonLog = button("log", Region.bottomHalf)
+val ButtonNext = button("next", Region.bottomHalf)
+val ButtonNextWithImage = button("next_with_image", Region.bottomHalf)
+val ButtonNextRaceEnd = button("next_race_end", Region.bottomHalf)
+val ButtonNo = button("no", Region.bottomHalf)
+val ButtonOk = button("ok", Region.bottomHalf)
+val ButtonOptions = button("options", Region.bottomHalf)
+val ButtonLearn = button("learn")
+val ButtonReset = button("reset", Region.bottomHalf)
+val ButtonRace = button("race", Region.bottomHalf)
+val ButtonRaceDayRace = button("race_day_race", Region.bottomHalf)
+val ButtonRaceAgain = button("race_again", Region.bottomHalf)
+val ButtonRaceDetails = button("race_details", Region.bottomHalf)
+val ButtonRaceEvents = button("race_events")
+val ButtonRaceExclamation = button("race_exclamation", Region.bottomHalf)
+val ButtonRaceExclamationShiftedUp = button("race_exclamation_shifted_up", Region.middle)
+val ButtonRaceManual = button("race_manual", Region.bottomHalf)
+val ButtonRaceRecommendationsCenterStage = button("race_recommendations_center_stage")
+val ButtonRaceRecommendationsPathToFame = button("race_recommendations_path_to_fame")
+val ButtonRaceRecommendationsForgeYourOwnPath = button("race_recommendations_forge_your_own_path")
+val ButtonRaceResults = button("race_results")
+val ButtonRestore = button("restore")
+val ButtonRetry = button("retry")
+val ButtonResume = button("resume")
+val ButtonSave = button("save", Region.bottomHalf)
+val ButtonSaveSchedule = button("save_schedule", Region.bottomHalf)
+val ButtonSaveAndExit = button("save_and_exit", Region.bottomHalf)
+val ButtonSeeResults = button("see_results", Region.bottomHalf)
+val ButtonSelectOpponent = button("select_opponent", Region.bottomHalf)
+val ButtonSelectLegacy = button("select_legacy")
+val ButtonShop = button("shop")
+val ButtonSkip = button("skip", Region.bottomHalf)
+val ButtonSkills = button("skills", Region.bottomHalf)
+val ButtonStartCareer = button("start_career", Region.bottomHalf)
+val ButtonStartCareerOffset = button("start_career_offset", Region.bottomHalf)
+val ButtonTeamRace = button("team_race")
+val ButtonTeamTrials = button("team_trials")
+val ButtonTitleScreen = button("title_screen")
+val ButtonTryAgain = button("try_again", Region.bottomHalf)
+val ButtonTryAgainAlt = button("try_again_alt", Region.bottomHalf)
+val ButtonViewResults = button("view_results", Region.bottomHalf)
+val ButtonWatchConcert = button("watch_concert", Region.bottomHalf)
+val ButtonRaceStrategyFront = button("strategy_front_select", Region.middle)
+val ButtonRaceStrategyPace = button("strategy_pace_select", Region.middle)
+val ButtonRaceStrategyLate = button("strategy_late_select", Region.middle)
+val ButtonRaceStrategyEnd = button("strategy_end_select", Region.middle)
 
 // More complex buttons
 
-object ButtonMenuBarHomeSelected : ButtonInterface {
-    override val template = Template("components/button/menu_bar_home_selected")
-}
-
-object ButtonMenuBarHomeUnselected : ButtonInterface {
-    override val template = Template("components/button/menu_bar_home_unselected")
-}
+val ButtonMenuBarHomeSelected = button("menu_bar_home_selected")
+val ButtonMenuBarHomeUnselected = button("menu_bar_home_unselected")
 
 object ButtonMenuBarHome : MultiStateButtonInterface {
     override val templates: List<Template> =
@@ -352,13 +117,8 @@ object ButtonMenuBarHome : MultiStateButtonInterface {
         )
 }
 
-object ButtonMenuBarRaceSelected : ButtonInterface {
-    override val template = Template("components/button/menu_bar_race_selected")
-}
-
-object ButtonMenuBarRaceUnselected : ButtonInterface {
-    override val template = Template("components/button/menu_bar_race_unselected")
-}
+val ButtonMenuBarRaceSelected = button("menu_bar_race_selected")
+val ButtonMenuBarRaceUnselected = button("menu_bar_race_unselected")
 
 object ButtonMenuBarRace : MultiStateButtonInterface {
     override val templates: List<Template> =
@@ -368,166 +128,44 @@ object ButtonMenuBarRace : MultiStateButtonInterface {
         )
 }
 
-object ButtonCompleteCareer : ButtonInterface {
-    override val template = Template("components/button/complete_career", region = Region.bottomHalf)
-}
-
-object ButtonCareerEndSkills : ButtonInterface {
-    override val template = Template("components/button/career_end_skills")
-}
-
-object ButtonClawMachine : ButtonInterface {
-    override val template = Template("components/button/claw_machine", region = Region.bottomHalf)
-}
-
-object ButtonClawMachineOk : ButtonInterface {
-    override val template = Template("components/button/claw_machine_ok", region = Region.bottomHalf)
-}
-
-object ButtonInheritance : ButtonInterface {
-    override val template = Template("components/button/inheritance", region = Region.bottomHalf)
-}
-
-object ButtonPredictions : ButtonInterface {
-    override val template = Template("components/button/predictions", region = Region.bottomHalf)
-}
-
-object ButtonRunners : ButtonInterface {
-    override val template = Template("components/button/runners", region = Region.middle)
-}
-
-object ButtonUnityCupRace : ButtonInterface {
-    override val template = Template("components/button/unitycup_race", region = Region.bottomHalf)
-}
-
-object ButtonUnityCupRaceFinal : ButtonInterface {
-    override val template = Template("components/button/unitycup_race_final", region = Region.bottomHalf)
-}
-
-object ButtonUnityCupSeeAllRaceResults : ButtonInterface {
-    override val template = Template("components/button/unitycup_see_all_race_results", region = Region.bottomHalf)
-}
-
-object ButtonUnityCupTeam : ButtonInterface {
-    override val template = Template("components/button/unitycup_team", region = Region.bottomHalf)
-}
-
-object ButtonUnityCupWatchMainRace : ButtonInterface {
-    override val template = Template("components/button/unitycup_watch_main_race", region = Region.bottomHalf)
-}
-
-object ButtonRest : ButtonInterface {
-    override val template = Template("components/button/rest", region = Region.bottomHalf)
-}
-
-object ButtonRestAndRecreation : ButtonInterface {
-    override val template = Template("components/button/rest_and_recreation", region = Region.bottomHalf)
-}
-
-object ButtonInfirmary : ButtonInterface {
-    override val template = Template("components/button/infirmary", region = Region.bottomHalf)
-}
-
-object ButtonRecreation : ButtonInterface {
-    override val template = Template("components/button/recreation", region = Region.bottomHalf)
-}
-
-object ButtonEndCareer : ButtonInterface {
-    override val template = Template("components/button/end_career", region = Region.bottomHalf)
-}
-
-object ButtonRaceListFullStats : ButtonInterface {
-    override val template = Template("components/button/race_list_full_stats", region = Region.middle)
-}
-
-object ButtonSkillListFullStats : ButtonInterface {
-    override val template = Template("components/button/skill_list_full_stats", region = Region.topHalf)
-}
-
-object ButtonHomeFullStats : ButtonInterface {
-    override val template = Template("components/button/home_full_stats", region = Region.middle)
-}
-
-object ButtonTrainingSpeed : ButtonInterface {
-    override val template = Template("components/button/training_speed", region = Region.bottomHalf)
-}
-
-object ButtonTrainingStamina : ButtonInterface {
-    override val template = Template("components/button/training_stamina", region = Region.bottomHalf)
-}
-
-object ButtonTrainingPower : ButtonInterface {
-    override val template = Template("components/button/training_power", region = Region.bottomHalf)
-}
-
-object ButtonTrainingGuts : ButtonInterface {
-    override val template = Template("components/button/training_guts", region = Region.bottomHalf)
-}
-
-object ButtonTrainingWit : ButtonInterface {
-    override val template = Template("components/button/training_wit", region = Region.bottomHalf)
-}
-
-object ButtonTraining : ButtonInterface {
-    override val template = Template("components/button/training", region = Region.bottomHalf)
-}
-
-object ButtonRaces : ButtonInterface {
-    override val template = Template("components/button/races", region = Region.bottomHalf)
-}
-
-object ButtonHomeFansInfo : ButtonInterface {
-    override val template = Template("components/button/home_fans_info", region = Region.leftHalf)
-}
-
-object ButtonSkillUp : ButtonInterface {
-    override val template = Template("components/button/skill_up", region = Region.rightHalf)
-}
-
-object ButtonSkillDown : ButtonInterface {
-    override val template = Template("components/button/skill_down", region = Region.rightHalf)
-}
-
-object ButtonOverwrite : ButtonInterface {
-    override val template = Template("components/button/overwrite", region = Region.bottomHalf)
-}
-
-object ButtonMyAgendas : ButtonInterface {
-    override val template = Template("components/button/my_agendas", region = Region.bottomHalf)
-}
-
-object ButtonRaceAgendaLoadList : ButtonInterface {
-    override val template = Template("components/button/race_agenda_load_list", region = Region.rightHalf)
-}
-
-object ButtonDetails : ButtonInterface {
-    override val template = Template("components/button/details", region = Region.middle)
-}
-
-object ButtonShopTrackblazer : ButtonInterface {
-    override val template = Template("components/button/shop_trackblazer", region = Region.bottomHalf)
-}
-
-object ButtonTrainingItems : ButtonInterface {
-    override val template = Template("components/button/training_items")
-}
-
-object ButtonExchange : ButtonInterface {
-    override val template = Template("components/button/exchange", region = Region.bottomHalf)
-}
-
-object ButtonConfirmUse : ButtonInterface {
-    override val template = Template("components/button/confirm_use", region = Region.bottomHalf)
-}
-
-object ButtonUseTrainingItems : ButtonInterface {
-    override val template = Template("components/button/use_training_items", region = Region.bottomHalf)
-}
-
-object ButtonConditions : ButtonInterface {
-    override val template = Template("components/button/conditions", region = Region.middle)
-}
-
-object ButtonEventProgressChevron : ButtonInterface {
-    override val template = Template("components/button/event_progress_chevron")
-}
+val ButtonCompleteCareer = button("complete_career", Region.bottomHalf)
+val ButtonCareerEndSkills = button("career_end_skills")
+val ButtonClawMachine = button("claw_machine", Region.bottomHalf)
+val ButtonClawMachineOk = button("claw_machine_ok", Region.bottomHalf)
+val ButtonInheritance = button("inheritance", Region.bottomHalf)
+val ButtonPredictions = button("predictions", Region.bottomHalf)
+val ButtonRunners = button("runners", Region.middle)
+val ButtonUnityCupRace = button("unitycup_race", Region.bottomHalf)
+val ButtonUnityCupRaceFinal = button("unitycup_race_final", Region.bottomHalf)
+val ButtonUnityCupSeeAllRaceResults = button("unitycup_see_all_race_results", Region.bottomHalf)
+val ButtonUnityCupTeam = button("unitycup_team", Region.bottomHalf)
+val ButtonUnityCupWatchMainRace = button("unitycup_watch_main_race", Region.bottomHalf)
+val ButtonRest = button("rest", Region.bottomHalf)
+val ButtonRestAndRecreation = button("rest_and_recreation", Region.bottomHalf)
+val ButtonInfirmary = button("infirmary", Region.bottomHalf)
+val ButtonRecreation = button("recreation", Region.bottomHalf)
+val ButtonEndCareer = button("end_career", Region.bottomHalf)
+val ButtonRaceListFullStats = button("race_list_full_stats", Region.middle)
+val ButtonSkillListFullStats = button("skill_list_full_stats", Region.topHalf)
+val ButtonHomeFullStats = button("home_full_stats", Region.middle)
+val ButtonTrainingSpeed = button("training_speed", Region.bottomHalf)
+val ButtonTrainingStamina = button("training_stamina", Region.bottomHalf)
+val ButtonTrainingPower = button("training_power", Region.bottomHalf)
+val ButtonTrainingGuts = button("training_guts", Region.bottomHalf)
+val ButtonTrainingWit = button("training_wit", Region.bottomHalf)
+val ButtonTraining = button("training", Region.bottomHalf)
+val ButtonRaces = button("races", Region.bottomHalf)
+val ButtonHomeFansInfo = button("home_fans_info", Region.leftHalf)
+val ButtonSkillUp = button("skill_up", Region.rightHalf)
+val ButtonSkillDown = button("skill_down", Region.rightHalf)
+val ButtonOverwrite = button("overwrite", Region.bottomHalf)
+val ButtonMyAgendas = button("my_agendas", Region.bottomHalf)
+val ButtonRaceAgendaLoadList = button("race_agenda_load_list", Region.rightHalf)
+val ButtonDetails = button("details", Region.middle)
+val ButtonShopTrackblazer = button("shop_trackblazer", Region.bottomHalf)
+val ButtonTrainingItems = button("training_items")
+val ButtonExchange = button("exchange", Region.bottomHalf)
+val ButtonConfirmUse = button("confirm_use", Region.bottomHalf)
+val ButtonUseTrainingItems = button("use_training_items", Region.bottomHalf)
+val ButtonConditions = button("conditions", Region.middle)
+val ButtonEventProgressChevron = button("event_progress_chevron")

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/components/Dialog.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/components/Dialog.kt
@@ -57,6 +57,60 @@ import com.steve1316.uma_android_automation.types.BoundingBox
 import com.steve1316.uma_android_automation.utils.CustomImageUtils
 import org.opencv.core.Point
 
+/** Define the key components and functions for interacting with Dialogs. */
+interface DialogInterface {
+    /** A unique name used to identify this dialog. */
+    val name: String
+
+    /** The on-screen title of the dialog. Multiple dialogs may have the same title. */
+    val title: String
+
+    /** List of all the button components within the dialog. If there is a button used to close the dialog, then it MUST be the first entry in this list. */
+    val buttons: List<BaseComponentInterface>
+
+    /** The button used primarily to close the dialog. If not specified, the first button in the buttons list will be used. */
+    val closeButton: BaseComponentInterface?
+
+    /** The button typically used to accept the dialog. If there is only one button in the dialog, then this may be set to that button. */
+    val okButton: BaseComponentInterface?
+
+    /**
+     * Close the dialog by clicking the close button.
+     *
+     * If no close button is specified, then the first button in the [buttons] list is treated as the close button and is clicked.
+     *
+     * @param imageUtils A reference to a CustomImageUtils instance.
+     * @param tries The number of attempts when searching for the button.
+     * @return True if the close button was found and clicked.
+     */
+    fun close(imageUtils: CustomImageUtils, tries: Int = 1): Boolean {
+        if (closeButton == null) {
+            return buttons.getOrNull(0)?.click(imageUtils = imageUtils, tries = tries) ?: false
+        }
+        return closeButton?.click(imageUtils = imageUtils, tries = tries) ?: false
+    }
+
+    /**
+     * Close the dialog by clicking the OK button.
+     *
+     * If no OK button is defined for this dialog, then the [close] function is called instead.
+     *
+     * @param imageUtils A reference to a CustomImageUtils instance.
+     * @param tries The number of attempts when searching for the button.
+     * @return True if the OK button was found and clicked.
+     */
+    fun ok(imageUtils: CustomImageUtils, tries: Int = 1): Boolean {
+        if (okButton == null) {
+            return if (buttons.size == 1) {
+                close(imageUtils = imageUtils, tries = tries)
+            } else {
+                false
+            }
+        }
+        return okButton?.click(imageUtils = imageUtils, tries = tries) ?: false
+    }
+}
+
 /** Utility class for detecting and handling dialogs in the game. */
 object DialogUtils {
     private val TAG: String = "[${MainActivity.loggerTag}]DialogUtils"
@@ -244,60 +298,6 @@ object DialogUtils {
     }
 }
 
-/** Define the key components and functions for interacting with Dialogs. */
-interface DialogInterface {
-    /** A unique name used to identify this dialog. */
-    val name: String
-
-    /** The on-screen title of the dialog. Multiple dialogs may have the same title. */
-    val title: String
-
-    /** List of all the button components within the dialog. If there is a button used to close the dialog, then it MUST be the first entry in this list. */
-    val buttons: List<BaseComponentInterface>
-
-    /** The button used primarily to close the dialog. If not specified, the first button in the buttons list will be used. */
-    val closeButton: BaseComponentInterface?
-
-    /** The button typically used to accept the dialog. If there is only one button in the dialog, then this may be set to that button. */
-    val okButton: BaseComponentInterface?
-
-    /**
-     * Close the dialog by clicking the close button.
-     *
-     * If no close button is specified, then the first button in the [buttons] list is treated as the close button and is clicked.
-     *
-     * @param imageUtils A reference to a CustomImageUtils instance.
-     * @param tries The number of attempts when searching for the button.
-     * @return True if the close button was found and clicked.
-     */
-    fun close(imageUtils: CustomImageUtils, tries: Int = 1): Boolean {
-        if (closeButton == null) {
-            return buttons.getOrNull(0)?.click(imageUtils = imageUtils, tries = tries) ?: false
-        }
-        return closeButton?.click(imageUtils = imageUtils, tries = tries) ?: false
-    }
-
-    /**
-     * Close the dialog by clicking the OK button.
-     *
-     * If no OK button is defined for this dialog, then the [close] function is called instead.
-     *
-     * @param imageUtils A reference to a CustomImageUtils instance.
-     * @param tries The number of attempts when searching for the button.
-     * @return True if the OK button was found and clicked.
-     */
-    fun ok(imageUtils: CustomImageUtils, tries: Int = 1): Boolean {
-        if (okButton == null) {
-            return if (buttons.size == 1) {
-                close(imageUtils = imageUtils, tries = tries)
-            } else {
-                false
-            }
-        }
-        return okButton?.click(imageUtils = imageUtils, tries = tries) ?: false
-    }
-}
-
 /** Store the list of all dialog objects and a mapping of them for easy access. */
 object DialogObjects {
     /** List of all [DialogInterface] objects. */
@@ -410,136 +410,70 @@ object DialogObjects {
 // //////////////////////////////////////////////////////////////////////////////////////////////////
 // Dialog Objects
 
+/**
+ * Builds a [DialogInterface] from its identifying [name], on-screen [title], and component buttons.
+ *
+ * @param name Unique identifier for this dialog.
+ * @param title On-screen title text used to recognize the dialog.
+ * @param buttons All button components within the dialog. If a close button is used, it must be the first entry.
+ * @param closeButton Button used to close the dialog, or null to fall back to the first entry in [buttons].
+ * @param okButton Button typically used to accept the dialog, or null if there is none.
+ * @return A [DialogInterface] exposing the supplied metadata.
+ */
+private fun dialog(
+    name: String,
+    title: String,
+    buttons: List<BaseComponentInterface> = emptyList(),
+    closeButton: BaseComponentInterface? = null,
+    okButton: BaseComponentInterface? = null,
+): DialogInterface =
+    object : DialogInterface {
+        override val name: String = name
+        override val title: String = title
+        override val buttons: List<BaseComponentInterface> = buttons
+        override val closeButton: BaseComponentInterface? = closeButton
+        override val okButton: BaseComponentInterface? = okButton
+    }
+
+// Dialogs are declared below with the dialog() factory. The few that override close()/ok() to
+// choose among several buttons at runtime remain full object declarations instead.
+
 /** Title Screen.
  *
  * This dialog also has an "Account Link" button, but we never want to allow the bot to click that, so we won't add it.
  */
-object DialogAccountLink : DialogInterface {
-    override val name: String = "account_link"
-    override val title: String = "Account Link"
-    override val closeButton = null
-    override val okButton = null
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonLater,
-        )
-}
+val DialogAccountLink = dialog("account_link", "Account Link", buttons = listOf(ButtonLater))
 
 /** Anywhere (ALWAYS THROW ERROR).
  *
  * This dialog has two different OK buttons: ButtonEnter and ButtonOk.
  * However since we never want to handle those buttons, we won't even add them in here.
  */
-object DialogAgeConfirmation : DialogInterface {
-    override val name: String = "age_confirmation"
-    override val title: String = "Age Confirmation"
-    override val closeButton = null
-    override val okButton = null
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonCancel,
-        )
-}
+val DialogAgeConfirmation = dialog("age_confirmation", "Age Confirmation", buttons = listOf(ButtonCancel))
 
 /** Career */
-object DialogAgendaDetails : DialogInterface {
-    override val name: String = "agenda_details"
-    override val title: String = "Agenda Details"
-    override val closeButton = null
-    override val okButton = null
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonClose,
-        )
-}
+val DialogAgendaDetails = dialog("agenda_details", "Agenda Details", buttons = listOf(ButtonClose))
 
 /** Career (Unity Cup) */
-object DialogAutoFill : DialogInterface {
-    override val name: String = "auto_fill"
-    override val title: String = "Auto-Fill"
-    override val closeButton = null
-    override val okButton: BaseComponentInterface = ButtonEditTeam
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonClose,
-            ButtonEditTeam,
-        )
-}
+val DialogAutoFill = dialog("auto_fill", "Auto-Fill", buttons = listOf(ButtonClose, ButtonEditTeam), okButton = ButtonEditTeam)
 
 /** Career Selection */
-object DialogAutoSelect : DialogInterface {
-    override val name: String = "auto_select"
-    override val title: String = "Auto-Select"
-    override val closeButton = null
-    override val okButton: BaseComponentInterface = ButtonOk
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonCancel,
-            ButtonOk,
-            Checkbox,
-        )
-}
+val DialogAutoSelect = dialog("auto_select", "Auto-Select", buttons = listOf(ButtonCancel, ButtonOk, Checkbox), okButton = ButtonOk)
 
 /** Career (event only) */
-object DialogAllRewardsEarned : DialogInterface {
-    override val name: String = "all_rewards_earned"
-    override val title: String = "ALL REWARDS EARNED!"
-    override val closeButton = null
-    override val okButton = null
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonClose,
-        )
-}
+val DialogAllRewardsEarned = dialog("all_rewards_earned", "ALL REWARDS EARNED!", buttons = listOf(ButtonClose))
 
 /** Career -> Career Profile dialog. */
-object DialogBonusUmamusumeDetails : DialogInterface {
-    override val name: String = "bonus_umamusume_details"
-    override val title: String = "Bonus Umamusume Details"
-    override val closeButton = null
-    override val okButton = null
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonClose,
-        )
-}
+val DialogBonusUmamusumeDetails = dialog("bonus_umamusume_details", "Bonus Umamusume Details", buttons = listOf(ButtonClose))
 
 /** Career Selection */
-object DialogBorrowCard : DialogInterface {
-    override val name: String = "borrow_card"
-    override val title: String = "Borrow Card"
-    override val closeButton = null
-    override val okButton = null
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonClose,
-        )
-}
+val DialogBorrowCard = dialog("borrow_card", "Borrow Card", buttons = listOf(ButtonClose))
 
 /** Career Selection */
-object DialogBorrowCardConfirmation : DialogInterface {
-    override val name: String = "borrow_card_confirmation"
-    override val title: String = "Confirmation"
-    override val closeButton = null
-    override val okButton: BaseComponentInterface = ButtonOk
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonClose,
-            ButtonOk,
-        )
-}
+val DialogBorrowCardConfirmation = dialog("borrow_card_confirmation", "Confirmation", buttons = listOf(ButtonClose, ButtonOk), okButton = ButtonOk)
 
 /** Career */
-object DialogCareer : DialogInterface {
-    override val name: String = "career"
-    override val title: String = "Career"
-    override val closeButton = null
-    override val okButton = null
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonClose,
-        )
-}
+val DialogCareer = dialog("career", "Career", buttons = listOf(ButtonClose))
 
 /** Career */
 object DialogCareerComplete : DialogInterface {
@@ -567,94 +501,25 @@ object DialogCareerComplete : DialogInterface {
 }
 
 /** Career (training event effects). */
-object DialogChoices : DialogInterface {
-    override val name: String = "choices"
-    override val title: String = "Choices"
-    override val closeButton = null
-    override val okButton = null
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonClose,
-        )
-}
+val DialogChoices = dialog("choices", "Choices", buttons = listOf(ButtonClose))
 
 /** Career */
-object DialogChooseRecreationPartner : DialogInterface {
-    override val name: String = "choose_recreation_partner"
-    override val title: String = "Choose Recreation Partner"
-    override val closeButton: BaseComponentInterface = ButtonCancel
-    override val okButton = null
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonCancel,
-        )
-}
+val DialogChooseRecreationPartner = dialog("choose_recreation_partner", "Choose Recreation Partner", buttons = listOf(ButtonCancel), closeButton = ButtonCancel)
 
 /** Career (yes this is different from above...). */
-object DialogCompleteCareer : DialogInterface {
-    override val name: String = "complete_career"
-    override val title: String = "Complete Career"
-    override val closeButton = null
-    override val okButton: BaseComponentInterface = ButtonFinish
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonCancel,
-            ButtonFinish,
-        )
-}
+val DialogCompleteCareer = dialog("complete_career", "Complete Career", buttons = listOf(ButtonCancel, ButtonFinish), okButton = ButtonFinish)
 
 /** Career */
-object DialogConcertSkipConfirmation : DialogInterface {
-    override val name: String = "concert_skip_confirmation"
-    override val title: String = "Confirmation"
-    override val closeButton = null
-    override val okButton: BaseComponentInterface = ButtonOk
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonCancel,
-            ButtonOk,
-            Checkbox,
-        )
-}
+val DialogConcertSkipConfirmation = dialog("concert_skip_confirmation", "Confirmation", buttons = listOf(ButtonCancel, ButtonOk, Checkbox), okButton = ButtonOk)
 
 /** Career Selection */
-object DialogConfirmAutoSelect : DialogInterface {
-    override val name: String = "confirm_auto_select"
-    override val title: String = "Confirm Auto-Select"
-    override val closeButton = null
-    override val okButton: BaseComponentInterface = ButtonOk
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonCancel,
-            ButtonOk,
-            Checkbox,
-        )
-}
+val DialogConfirmAutoSelect = dialog("confirm_auto_select", "Confirm Auto-Select", buttons = listOf(ButtonCancel, ButtonOk, Checkbox), okButton = ButtonOk)
 
 /** Main Screen */
-object DialogConfirmExchange : DialogInterface {
-    override val name: String = "confirm_exchange"
-    override val title: String = "Confirm Exchange"
-    override val closeButton = null
-    override val okButton = null
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonClose,
-        )
-}
+val DialogConfirmExchange = dialog("confirm_exchange", "Confirm Exchange", buttons = listOf(ButtonClose))
 
 /** Career (Trackblazer) */
-object DialogConfirmUse : DialogInterface {
-    override val name: String = "confirm_use"
-    override val title: String = "Confirm Use"
-    override val closeButton = null
-    override val okButton: BaseComponentInterface = ButtonUseTrainingItems
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonCancel,
-            ButtonUseTrainingItems,
-        )
-}
+val DialogConfirmUse = dialog("confirm_use", "Confirm Use", buttons = listOf(ButtonCancel, ButtonUseTrainingItems), okButton = ButtonUseTrainingItems)
 
 /** Anywhere */
 object DialogConnectionError : DialogInterface {
@@ -681,474 +546,118 @@ object DialogConnectionError : DialogInterface {
 }
 
 /** Career */
-object DialogConsecutiveRaceWarning : DialogInterface {
-    override val name: String = "consecutive_race_warning"
-    override val title: String = "Warning"
-    override val closeButton = null
-    override val okButton = ButtonOk
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonCancel,
-            ButtonOk,
-        )
-}
+val DialogConsecutiveRaceWarning = dialog("consecutive_race_warning", "Warning", buttons = listOf(ButtonCancel, ButtonOk), okButton = ButtonOk)
 
 /** Main Screen */
-object DialogContinueCareer : DialogInterface {
-    override val name: String = "continue_career"
-    override val title: String = "Continue Career"
-    override val closeButton = null
-    override val okButton = ButtonResume
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonCancel,
-            ButtonResume,
-        )
-}
+val DialogContinueCareer = dialog("continue_career", "Continue Career", buttons = listOf(ButtonCancel, ButtonResume), okButton = ButtonResume)
 
 /** Team Trials */
-object DialogConfirmRestoreRP : DialogInterface {
-    override val name: String = "confirm_restore_rp"
-    override val title: String = "Confirm"
-    override val closeButton = null
-    override val okButton: BaseComponentInterface = ButtonRestore
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonNo,
-            ButtonRestore,
-        )
-}
+val DialogConfirmRestoreRP = dialog("confirm_restore_rp", "Confirm", buttons = listOf(ButtonNo, ButtonRestore), okButton = ButtonRestore)
 
 /** Team Trials, Special Events, Daily Races. */
-object DialogDailySale : DialogInterface {
-    override val name: String = "daily_sale"
-    override val title: String = "Daily Sale"
-    override val closeButton = null
-    override val okButton: BaseComponentInterface = ButtonShop
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonCancel,
-            ButtonShop,
-        )
-}
+val DialogDailySale = dialog("daily_sale", "Daily Sale", buttons = listOf(ButtonCancel, ButtonShop), okButton = ButtonShop)
 
 /** Anywhere */
-object DialogDateChanged : DialogInterface {
-    override val name: String = "date_changed"
-    override val title: String = "Date Changed"
-    override val closeButton = null
-    override val okButton = null
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonOk,
-        )
-}
+val DialogDateChanged = dialog("date_changed", "Date Changed", buttons = listOf(ButtonOk))
 
 /** Anywhere */
-object DialogDisplaySettings : DialogInterface {
-    override val name: String = "display_settings"
-    override val title: String = "Display Settings"
-    override val closeButton = null
-    override val okButton: BaseComponentInterface = ButtonOk
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonCancel,
-            ButtonOk,
-        )
-}
+val DialogDisplaySettings = dialog("display_settings", "Display Settings", buttons = listOf(ButtonCancel, ButtonOk), okButton = ButtonOk)
 
 /** Title Screen (only?) */
-object DialogDownloadError : DialogInterface {
-    override val name: String = "download_error"
-    override val title: String = "Download Error"
-    override val closeButton = null
-    override val okButton: BaseComponentInterface = ButtonRetry
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonTitleScreen,
-            ButtonRetry,
-        )
-}
+val DialogDownloadError = dialog("download_error", "Download Error", buttons = listOf(ButtonTitleScreen, ButtonRetry), okButton = ButtonRetry)
 
 /** Career End */
-object DialogEpithet : DialogInterface {
-    override val name: String = "epithet"
-    override val title: String = "Epithet"
-    override val closeButton = null
-    override val okButton = null
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonConfirmExclamation,
-            Checkbox,
-        )
-}
+val DialogEpithet = dialog("epithet", "Epithet", buttons = listOf(ButtonConfirmExclamation, Checkbox))
 
 // This is the dialog opened from the Epithets button in DialogMenu.
 
 /** Career DialogMenu -> Epithets button. */
-object DialogEpithets : DialogInterface {
-    override val name: String = "epithets"
-    override val title: String = "Epithets"
-    override val closeButton = null
-    override val okButton = null
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonClose,
-        )
-}
+val DialogEpithets = dialog("epithets", "Epithets", buttons = listOf(ButtonClose))
 
 /** Career (Trackblazer) */
-object DialogExchangeComplete : DialogInterface {
-    override val name: String = "exchange_complete"
-    override val title: String = "Exchange Complete"
-    override val closeButton: BaseComponentInterface = ButtonClose
-    override val okButton: BaseComponentInterface = ButtonConfirmUse
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonClose,
-            ButtonConfirmUse,
-        )
-}
+val DialogExchangeComplete = dialog("exchange_complete", "Exchange Complete", buttons = listOf(ButtonClose, ButtonConfirmUse), closeButton = ButtonClose, okButton = ButtonConfirmUse)
 
 /** Main Screen */
-object DialogExternalLink : DialogInterface {
-    override val name: String = "external_link"
-    override val title: String = "External Link"
-    override val closeButton = null
-    override val okButton: BaseComponentInterface = ButtonOk
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonCancel,
-            ButtonOk,
-        )
-}
+val DialogExternalLink = dialog("external_link", "External Link", buttons = listOf(ButtonCancel, ButtonOk), okButton = ButtonOk)
 
 /** Career DialogGoals */
-object DialogFans : DialogInterface {
-    override val name: String = "fans"
-    override val title: String = "Fans"
-    override val closeButton = null
-    override val okButton = null
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonClose,
-        )
-}
+val DialogFans = dialog("fans", "Fans", buttons = listOf(ButtonClose))
 
 /** Career */
-object DialogFeaturedCards : DialogInterface {
-    override val name: String = "featured_cards"
-    override val title: String = "Featured Cards"
-    override val closeButton = null
-    override val okButton = null
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonClose,
-        )
-}
+val DialogFeaturedCards = dialog("featured_cards", "Featured Cards", buttons = listOf(ButtonClose))
 
 /** Career Selection */
-object DialogFinalConfirmation : DialogInterface {
-    override val name: String = "final_confirmation"
-    override val title: String = "Final Confirmation"
-    override val closeButton = null
-    override val okButton: BaseComponentInterface = ButtonStartCareer
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonCancel,
-            ButtonStartCareer,
-        )
-}
+val DialogFinalConfirmation = dialog("final_confirmation", "Final Confirmation", buttons = listOf(ButtonCancel, ButtonStartCareer), okButton = ButtonStartCareer)
 
 /** Career */
-object DialogFollowTrainer : DialogInterface {
-    override val name: String = "follow_trainer"
-    override val title: String = "Follow Trainer"
-    override val closeButton = null
-    override val okButton: BaseComponentInterface = ButtonFollow
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonCancel,
-            ButtonFollow,
-        )
-}
+val DialogFollowTrainer = dialog("follow_trainer", "Follow Trainer", buttons = listOf(ButtonCancel, ButtonFollow), okButton = ButtonFollow)
 
 /** Career */
-object DialogGiveUp : DialogInterface {
-    override val name: String = "give_up"
-    override val title: String = "Give Up"
-    override val closeButton = null
-    override val okButton: BaseComponentInterface = ButtonGiveUp
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonCancel,
-            ButtonGiveUp,
-        )
-}
+val DialogGiveUp = dialog("give_up", "Give Up", buttons = listOf(ButtonCancel, ButtonGiveUp), okButton = ButtonGiveUp)
 
 /** Career */
-object DialogGoalNotReached : DialogInterface {
-    override val name: String = "goal_not_reached"
-    override val title: String = "Goal Not Reached"
-    override val closeButton = null
-    override val okButton: BaseComponentInterface = ButtonRace
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonCancel,
-            ButtonRace,
-        )
-}
+val DialogGoalNotReached = dialog("goal_not_reached", "Goal Not Reached", buttons = listOf(ButtonCancel, ButtonRace), okButton = ButtonRace)
 
 /** Career */
-object DialogGoals : DialogInterface {
-    override val name: String = "goals"
-    override val title: String = "Goals"
-    override val closeButton = null
-    override val okButton = null
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonClose,
-        )
-}
+val DialogGoals = dialog("goals", "Goals", buttons = listOf(ButtonClose))
 
 /** Anywhere (from options dialog). */
-object DialogHelpAndGlossary : DialogInterface {
-    override val name: String = "help_and_glossary"
-    override val title: String = "Help & Glossary"
-    override val closeButton = null
-    override val okButton = null
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonClose,
-        )
-}
+val DialogHelpAndGlossary = dialog("help_and_glossary", "Help & Glossary", buttons = listOf(ButtonClose))
 
 /** Career */
-object DialogInfirmary : DialogInterface {
-    override val name: String = "infirmary"
-    override val title: String = "Infirmary"
-    override val closeButton = null
-    override val okButton: BaseComponentInterface = ButtonOk
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonCancel,
-            ButtonOk,
-            Checkbox,
-        )
-}
+val DialogInfirmary = dialog("infirmary", "Infirmary", buttons = listOf(ButtonCancel, ButtonOk, Checkbox), okButton = ButtonOk)
 
 /** Career */
-object DialogInsufficientFans : DialogInterface {
-    override val name: String = "insufficient_fans"
-    override val title: String = "Insufficient Fans"
-    override val closeButton = null
-    override val okButton: BaseComponentInterface = ButtonRace
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonCancel,
-            ButtonRace,
-        )
-}
+val DialogInsufficientFans = dialog("insufficient_fans", "Insufficient Fans", buttons = listOf(ButtonCancel, ButtonRace), okButton = ButtonRace)
 
 /** Career (Trackblazer) */
-object DialogInsufficientGoalRaceResultPts : DialogInterface {
-    override val name: String = "insufficient_goal_race_result_pts"
-    override val title: String = "Insufficient Goal Race Result Pts"
-    override val closeButton: BaseComponentInterface = ButtonCancel
-    override val okButton: BaseComponentInterface = ButtonRace
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonCancel,
-            ButtonRace,
-        )
-}
+val DialogInsufficientGoalRaceResultPts =
+    dialog("insufficient_goal_race_result_pts", "Insufficient Goal Race Result Pts", buttons = listOf(ButtonCancel, ButtonRace), closeButton = ButtonCancel, okButton = ButtonRace)
 
 /** Team Trials, Special Events, Daily Races. */
-object DialogItemsSelected : DialogInterface {
-    override val name: String = "items_selected"
-    override val title: String = "Items Selected"
-    override val closeButton = null
-    override val okButton: BaseComponentInterface = ButtonRaceExclamationShiftedUp
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonCancel,
-            ButtonRaceExclamationShiftedUp,
-        )
-}
+val DialogItemsSelected = dialog("items_selected", "Items Selected", buttons = listOf(ButtonCancel, ButtonRaceExclamationShiftedUp), okButton = ButtonRaceExclamationShiftedUp)
 
 /** Career */
-object DialogLog : DialogInterface {
-    override val name: String = "log"
-    override val title: String = "Log"
-    override val closeButton = null
-    override val okButton = null
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonClose,
-        )
-}
+val DialogLog = dialog("log", "Log", buttons = listOf(ButtonClose))
 
 /** Career */
-object DialogMenu : DialogInterface {
-    override val name: String = "menu"
-    override val title: String = "Menu"
-    override val closeButton = null
-    override val okButton = null
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonClose,
-            ButtonOptions,
-            ButtonSaveAndExit,
-            ButtonGiveUp,
-        )
-}
+val DialogMenu = dialog("menu", "Menu", buttons = listOf(ButtonClose, ButtonOptions, ButtonSaveAndExit, ButtonGiveUp))
 
 /** Career */
-object DialogMoodEffect : DialogInterface {
-    override val name: String = "mood_effect"
-    override val title: String = "Mood Effect"
-    override val closeButton = null
-    override val okButton = null
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonClose,
-        )
-}
+val DialogMoodEffect = dialog("mood_effect", "Mood Effect", buttons = listOf(ButtonClose))
 
 /** Career */
-object DialogMyAgendas : DialogInterface {
-    override val name: String = "my_agendas"
-    override val title: String = "My Agendas"
-    override val closeButton = null
-    override val okButton = null
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonClose,
-        )
-}
+val DialogMyAgendas = dialog("my_agendas", "My Agendas", buttons = listOf(ButtonClose))
 
 /** Career */
-object DialogNoRetries : DialogInterface {
-    override val name: String = "no_retries"
-    override val title: String = "No Retries"
-    override val closeButton = null
-    override val okButton = null
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonEndCareer,
-        )
-}
+val DialogNoRetries = dialog("no_retries", "No Retries", buttons = listOf(ButtonEndCareer))
 
 /** Main Screen */
-object DialogNotices : DialogInterface {
-    override val name: String = "notices"
-    override val title: String = "Notices"
-    override val closeButton = null
-    override val okButton = null
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonClose,
-        )
-}
+val DialogNotices = dialog("notices", "Notices", buttons = listOf(ButtonClose))
 
 /** Shop (only when clicking inactive daily sales button). */
-object DialogOpenSoon : DialogInterface {
-    override val name: String = "open_soon"
-    override val title: String = "Open Soon!"
-    override val closeButton = null
-    override val okButton = null
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonClose,
-        )
-}
+val DialogOpenSoon = dialog("open_soon", "Open Soon!", buttons = listOf(ButtonClose))
 
 /** Card details */
-object DialogCareerEventDetails : DialogInterface {
-    override val name: String = "career_event_details"
-    override val title: String = "Career Event Details"
-    override val closeButton = null
-    override val okButton = null
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonClose,
-        )
-}
+val DialogCareerEventDetails = dialog("career_event_details", "Career Event Details", buttons = listOf(ButtonClose))
 
 /** Career */
-object DialogCareerProfile : DialogInterface {
-    override val name: String = "career_profile"
-    override val title: String = "Career Profile"
-    override val closeButton = null
-    override val okButton = null
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonClose,
-        )
-}
+val DialogCareerProfile = dialog("career_profile", "Career Profile", buttons = listOf(ButtonClose))
 
 /** Anywhere */
-object DialogOptions : DialogInterface {
-    override val name: String = "options"
-    override val title: String = "Options"
-    override val closeButton = null
-    override val okButton: BaseComponentInterface = ButtonSave
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonCancel,
-            ButtonSave,
-        )
-}
+val DialogOptions = dialog("options", "Options", buttons = listOf(ButtonCancel, ButtonSave), okButton = ButtonSave)
 
 /** Career -> Agenda */
-object DialogOverwrite : DialogInterface {
-    override val name: String = "overwrite"
-    override val title: String = "Overwrite"
-    override val closeButton = null
-    override val okButton: ComponentInterface = ButtonOverwrite
-    override val buttons: List<ComponentInterface> =
-        listOf(
-            ButtonCancel,
-            ButtonOverwrite,
-        )
-}
+val DialogOverwrite = dialog("overwrite", "Overwrite", okButton = ButtonOverwrite)
 
 /** Career -> Career Profile dialog. */
-object DialogPerks : DialogInterface {
-    override val name: String = "perks"
-    override val title: String = "Perks"
-    override val closeButton = null
-    override val okButton = null
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonClose,
-        )
-}
+val DialogPerks = dialog("perks", "Perks", buttons = listOf(ButtonClose))
 
 /** Career -> DialogTryAgain */
-object DialogPlacing : DialogInterface {
-    override val name: String = "placing"
-    override val title: String = "Placing"
-    override val closeButton = null
-    override val okButton = null
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonClose,
-        )
-}
+val DialogPlacing = dialog("placing", "Placing", buttons = listOf(ButtonClose))
 
 /** Main Screen (I think?). */
-object DialogPresents : DialogInterface {
-    override val name: String = "presents"
-    override val title: String = "Presents"
-    override val closeButton = null
-    override val okButton: BaseComponentInterface = ButtonCollectAll
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonClose,
-            ButtonCollectAll,
-        )
-}
+val DialogPresents = dialog("presents", "Presents", buttons = listOf(ButtonClose, ButtonCollectAll), okButton = ButtonCollectAll)
 
 /**
  * Career.
@@ -1158,41 +667,13 @@ object DialogPresents : DialogInterface {
  * The other, less scary option is it will have a ButtonOk button which will attempt to buy a clock using carats. Again, we don't want to even give the bot a chance to do this, so we just won't even
  * add that button in here.
  */
-object DialogPurchaseAlarmClock : DialogInterface {
-    override val name: String = "purchase_alarm_clock"
-    override val title: String = "Purchase Alarm Clock"
-    override val closeButton = null
-    override val okButton = null
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonCancel,
-        )
-}
+val DialogPurchaseAlarmClock = dialog("purchase_alarm_clock", "Purchase Alarm Clock", buttons = listOf(ButtonCancel))
 
 /** Anywhere (ALWAYS THROW ERROR). */
-object DialogPurchaseCarats : DialogInterface {
-    override val name: String = "purchase_carats"
-    override val title: String = "Purchase Carats"
-    override val closeButton = null
-    override val okButton = null
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonClose,
-        )
-}
+val DialogPurchaseCarats = dialog("purchase_carats", "Purchase Carats", buttons = listOf(ButtonClose))
 
 /** Daily Races */
-object DialogPurchaseDailyRaceTicket : DialogInterface {
-    override val name: String = "purchase_daily_race_ticket"
-    override val title: String = "Purchase Daily Race Ticket"
-    override val closeButton = null
-    override val okButton: BaseComponentInterface = ButtonOk
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonCancel,
-            ButtonOk,
-        )
-}
+val DialogPurchaseDailyRaceTicket = dialog("purchase_daily_race_ticket", "Purchase Daily Race Ticket", buttons = listOf(ButtonCancel, ButtonOk), okButton = ButtonOk)
 
 /** Daily Races, Special Events, and Career. */
 object DialogRaceDetails : DialogInterface {
@@ -1225,478 +706,123 @@ object DialogRaceDetails : DialogInterface {
 }
 
 /** Career */
-object DialogRacePlayback : DialogInterface {
-    override val name: String = "race_playback"
-    override val title: String = "Race Playback"
-    override val closeButton = null
-    override val okButton: BaseComponentInterface = ButtonOk
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonCancel,
-            ButtonOk,
-            Checkbox,
-            RadioLandscape,
-            RadioPortrait,
-        )
-}
+val DialogRacePlayback = dialog("race_playback", "Race Playback", buttons = listOf(ButtonCancel, ButtonOk, Checkbox, RadioLandscape, RadioPortrait), okButton = ButtonOk)
 
 /** Career */
-object DialogRaceRecommendations : DialogInterface {
-    override val name: String = "race_recommendations"
-    override val title: String = "Race Recommendations"
-    override val closeButton = null
-    override val okButton: BaseComponentInterface = ButtonConfirm
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonConfirm,
-            ButtonRaceRecommendationsCenterStage,
-            ButtonRaceRecommendationsPathToFame,
-            ButtonRaceRecommendationsForgeYourOwnPath,
-            Checkbox,
-        )
-}
+val DialogRaceRecommendations =
+    dialog(
+        "race_recommendations",
+        "Race Recommendations",
+        buttons = listOf(ButtonConfirm, ButtonRaceRecommendationsCenterStage, ButtonRaceRecommendationsPathToFame, ButtonRaceRecommendationsForgeYourOwnPath, Checkbox),
+        okButton = ButtonConfirm,
+    )
 
 /** Career */
-object DialogRecreation : DialogInterface {
-    override val name: String = "recreation"
-    override val title: String = "Recreation"
-    override val closeButton = null
-    override val okButton: BaseComponentInterface = ButtonOk
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonCancel,
-            ButtonOk,
-            Checkbox,
-        )
-}
+val DialogRecreation = dialog("recreation", "Recreation", buttons = listOf(ButtonCancel, ButtonOk, Checkbox), okButton = ButtonOk)
 
 /** Anywhere */
-object DialogRegistrationComplete : DialogInterface {
-    override val name: String = "registration_complete"
-    override val title: String = "Registration Complete"
-    override val closeButton = null
-    override val okButton = null
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonClose,
-        )
-}
+val DialogRegistrationComplete = dialog("registration_complete", "Registration Complete", buttons = listOf(ButtonClose))
 
 /** Transfer Requests */
-object DialogRequestFulfilled : DialogInterface {
-    override val name: String = "request_fulfilled"
-    override val title: String = "REQUEST FULFILLED"
-    override val closeButton = null
-    override val okButton = null
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonClose,
-        )
-}
+val DialogRequestFulfilled = dialog("request_fulfilled", "REQUEST FULFILLED", buttons = listOf(ButtonClose))
 
 /** Career */
-object DialogRest : DialogInterface {
-    override val name: String = "rest"
-    override val title: String = "Rest"
-    override val closeButton = null
-    override val okButton: BaseComponentInterface = ButtonOk
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonCancel,
-            ButtonOk,
-            Checkbox,
-        )
-}
+val DialogRest = dialog("rest", "Rest", buttons = listOf(ButtonCancel, ButtonOk, Checkbox), okButton = ButtonOk)
 
 /** Career */
-object DialogRestAndRecreation : DialogInterface {
-    // This one doesn't have a checkbox to not ask again for some reason.
-    override val name: String = "rest_and_recreation"
-    override val title: String = "Rest & Recreation"
-    override val closeButton = null
-    override val okButton: BaseComponentInterface = ButtonOk
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonCancel,
-            ButtonOk,
-        )
-}
+val DialogRestAndRecreation = dialog("rest_and_recreation", "Rest & Recreation", buttons = listOf(ButtonCancel, ButtonOk), okButton = ButtonOk)
 
 /** Main Screen, Special Events. */
-object DialogRewardsCollected : DialogInterface {
-    override val name: String = "rewards_collected"
-    override val title: String = "Rewards Collected"
-    override val closeButton = null
-    override val okButton = null
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonClose,
-        )
-}
+val DialogRewardsCollected = dialog("rewards_collected", "Rewards Collected", buttons = listOf(ButtonClose))
 
 /** Career -> Race screens. */
-object DialogRunners : DialogInterface {
-    override val name: String = "runners"
-    override val title: String = "Runners"
-    override val closeButton = null
-    override val okButton = null
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonClose,
-        )
-}
+val DialogRunners = dialog("runners", "Runners", buttons = listOf(ButtonClose))
 
 /** Career -> Agenda */
-object DialogScheduleRace : DialogInterface {
-    override val name: String = "schedule_race"
-    override val title: String = "Schedule Race"
-    override val closeButton = null
-    override val okButton = null
-    override val buttons: List<ComponentInterface> =
-        listOf(
-            ButtonClose,
-        )
-}
+val DialogScheduleRace = dialog("schedule_race", "Schedule Race")
 
 /** Career -> Agenda */
-object DialogScheduleCancellation : DialogInterface {
-    override val name: String = "schedule_cancellation"
-    override val title: String = "Schedule Cancellation"
-    override val closeButton = null
-    override val okButton = null
-    override val buttons: List<ComponentInterface> =
-        listOf(
-            ButtonClose,
-        )
-}
+val DialogScheduleCancellation = dialog("schedule_cancellation", "Schedule Cancellation")
 
 /** Career */
-object DialogScheduledRaceAvailable : DialogInterface {
-    override val name: String = "scheduled_race_available"
-    override val title: String = "Scheduled Race Available"
-    override val closeButton = null
-    override val okButton: BaseComponentInterface = ButtonRace
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonClose,
-            ButtonRace,
-        )
-}
+val DialogScheduledRaceAvailable = dialog("scheduled_race_available", "Scheduled Race Available", buttons = listOf(ButtonClose, ButtonRace), okButton = ButtonRace)
 
 /** Career */
-object DialogScheduledRaces : DialogInterface {
-    override val name: String = "scheduled_races"
-    override val title: String = "Scheduled Races"
-    override val closeButton = null
-    override val okButton = null
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonClose,
-        )
-}
+val DialogScheduledRaces = dialog("scheduled_races", "Scheduled Races", buttons = listOf(ButtonClose))
 
 /** Career */
-object DialogScheduleSettings : DialogInterface {
-    override val name: String = "schedule_settings"
-    override val title: String = "Schedule Settings"
-    override val closeButton = null
-    override val okButton: BaseComponentInterface = ButtonSaveSchedule
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonCancel,
-            ButtonSaveSchedule,
-        )
-}
+val DialogScheduleSettings = dialog("schedule_settings", "Schedule Settings", buttons = listOf(ButtonCancel, ButtonSaveSchedule), okButton = ButtonSaveSchedule)
 
 /** Anywhere */
-object DialogSessionError : DialogInterface {
-    override val name: String = "session_error"
-    override val title: String = "Session Error"
-    override val closeButton = null
-    override val okButton = null
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonTitleScreen,
-        )
-}
+val DialogSessionError = dialog("session_error", "Session Error", buttons = listOf(ButtonTitleScreen))
 
 /** Career (Trackblazer) */
-object DialogShop : DialogInterface {
-    override val name: String = "shop"
-    override val title: String = "Shop"
-    override val closeButton = null
-    override val okButton: BaseComponentInterface = ButtonShop
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonClose,
-            ButtonShop,
-        )
-}
+val DialogShop = dialog("shop", "Shop", buttons = listOf(ButtonClose, ButtonShop), okButton = ButtonShop)
 
 /** Anywhere */
-object DialogSkillDetails : DialogInterface {
-    override val name: String = "skill_details"
-    override val title: String = "Skill Details"
-    override val closeButton = null
-    override val okButton = null
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonClose,
-        )
-}
+val DialogSkillDetails = dialog("skill_details", "Skill Details", buttons = listOf(ButtonClose))
 
 /** Career */
-object DialogSkillListConfirmation : DialogInterface {
-    override val name: String = "skill_list_confirmation"
-    override val title: String = "Confirmation"
-    override val closeButton = null
-    override val okButton: BaseComponentInterface = ButtonLearn
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonCancel,
-            ButtonLearn,
-        )
-}
+val DialogSkillListConfirmation = dialog("skill_list_confirmation", "Confirmation", buttons = listOf(ButtonCancel, ButtonLearn), okButton = ButtonLearn)
 
 /** Career */
-object DialogSkillListConfirmExit : DialogInterface {
-    override val name: String = "skill_list_confirm_exit"
-    override val title: String = "Confirm"
-    override val closeButton = null
-    override val okButton: BaseComponentInterface = ButtonOk
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonCancel,
-            ButtonOk,
-        )
-}
+val DialogSkillListConfirmExit = dialog("skill_list_confirm_exit", "Confirm", buttons = listOf(ButtonCancel, ButtonOk), okButton = ButtonOk)
 
 /** Career */
-object DialogSkillsLearned : DialogInterface {
-    override val name: String = "skills_learned"
-    override val title: String = "Skills Learned"
-    override val closeButton = null
-    override val okButton = null
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonClose,
-        )
-}
+val DialogSkillsLearned = dialog("skills_learned", "Skills Learned", buttons = listOf(ButtonClose))
 
 /** Career */
-object DialogSongAcquired : DialogInterface {
-    override val name: String = "song_acquired"
-    override val title: String = "Song Acquired"
-    override val closeButton = null
-    override val okButton = null
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonClose,
-        )
-}
+val DialogSongAcquired = dialog("song_acquired", "Song Acquired", buttons = listOf(ButtonClose))
 
 /** Career (legacy uma details). */
-object DialogSparkDetails : DialogInterface {
-    override val name: String = "spark_details"
-    override val title: String = "Spark Details"
-    override val closeButton = null
-    override val okButton = null
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonClose,
-        )
-}
+val DialogSparkDetails = dialog("spark_details", "Spark Details", buttons = listOf(ButtonClose))
 
 /** Career -> Career Profile dialog. */
-object DialogSparks : DialogInterface {
-    override val name: String = "sparks"
-    override val title: String = "Sparks"
-    override val closeButton = null
-    override val okButton = null
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonClose,
-        )
-}
+val DialogSparks = dialog("sparks", "Sparks", buttons = listOf(ButtonClose))
 
 /** Main Screen, Special Events. */
-object DialogSpecialMissions : DialogInterface {
-    override val name: String = "special_missions"
-    override val title: String = "Special Missions"
-    override val closeButton = null
-    override val okButton: BaseComponentInterface = ButtonCollectAll
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonOk,
-            ButtonCollectAll,
-        )
-}
+val DialogSpecialMissions = dialog("special_missions", "Special Missions", buttons = listOf(ButtonOk, ButtonCollectAll), okButton = ButtonCollectAll)
 
 /** Race Screen */
-object DialogStrategy : DialogInterface {
-    override val name: String = "strategy"
-    override val title: String = "Strategy"
-    override val closeButton = null
-    override val okButton: BaseComponentInterface = ButtonConfirm
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonCancel,
-            ButtonConfirm,
-            ButtonRaceStrategyFront,
-            ButtonRaceStrategyPace,
-            ButtonRaceStrategyLate,
-            ButtonRaceStrategyEnd,
-        )
-}
+val DialogStrategy =
+    dialog(
+        "strategy",
+        "Strategy",
+        buttons = listOf(ButtonCancel, ButtonConfirm, ButtonRaceStrategyFront, ButtonRaceStrategyPace, ButtonRaceStrategyLate, ButtonRaceStrategyEnd),
+        okButton = ButtonConfirm,
+    )
 
 /** Main Screen, end of career. */
-object DialogStoryUnlocked : DialogInterface {
-    override val name: String = "story_unlocked"
-    override val title: String = "Story Unlocked"
-    override val closeButton = null
-    override val okButton = null
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonToHome,
-        )
-}
+val DialogStoryUnlocked = dialog("story_unlocked", "Story Unlocked", buttons = listOf(ButtonToHome))
 
 /** Career (Unity Cup) */
-object DialogTeamInfo : DialogInterface {
-    override val name: String = "team_info"
-    override val title: String = "Team Info"
-    override val closeButton = null
-    override val okButton: BaseComponentInterface = ButtonEditTeam
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonClose,
-            ButtonEditTeam,
-        )
-}
+val DialogTeamInfo = dialog("team_info", "Team Info", buttons = listOf(ButtonClose, ButtonEditTeam), okButton = ButtonEditTeam)
 
 /** Career */
-object DialogTrophyWon : DialogInterface {
-    override val name: String = "trophy_won"
-    override val title: String = "TROPHY WON!"
-    override val closeButton = null
-    override val okButton = null
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonClose,
-        )
-}
+val DialogTrophyWon = dialog("trophy_won", "TROPHY WON!", buttons = listOf(ButtonClose))
 
 /** Career */
-object DialogTryAgain : DialogInterface {
-    override val name: String = "try_again"
-    override val title: String = "Try Again"
-    override val closeButton = null
-    override val okButton: BaseComponentInterface = ButtonTryAgain
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonCancel,
-            ButtonTryAgain,
-        )
-}
+val DialogTryAgain = dialog("try_again", "Try Again", buttons = listOf(ButtonCancel, ButtonTryAgain), okButton = ButtonTryAgain)
 
 /** Career */
-object DialogUmamusumeClass : DialogInterface {
-    override val name: String = "umamusume_class"
-    override val title: String = "Umamusume Class"
-    override val closeButton = null
-    override val okButton = null
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonClose,
-        )
-}
+val DialogUmamusumeClass = dialog("umamusume_class", "Umamusume Class", buttons = listOf(ButtonClose))
 
 /** Career */
-object DialogUmamusumeDetails : DialogInterface {
-    override val name: String = "umamusume_details"
-    override val title: String = "Umamusume Details"
-    override val closeButton = null
-    override val okButton = null
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonClose,
-        )
-}
+val DialogUmamusumeDetails = dialog("umamusume_details", "Umamusume Details", buttons = listOf(ButtonClose))
 
 /** Career (Unity Cup) */
-object DialogUnityCupAvailable : DialogInterface {
-    override val name: String = "unity_cup_available"
-    override val title: String = "Unity Cup Available"
-    override val closeButton = null
-    override val okButton = null
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonClose,
-        )
-}
+val DialogUnityCupAvailable = dialog("unity_cup_available", "Unity Cup Available", buttons = listOf(ButtonClose))
 
 /** Career (Unity Cup) */
-object DialogUnityCupConfirmation : DialogInterface {
-    override val name: String = "unity_cup_confirmation"
-    override val title: String = "Confirmation"
-    override val closeButton = null
-    override val okButton: BaseComponentInterface = ButtonBeginShowdown
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonCancel,
-            ButtonBeginShowdown,
-        )
-}
+val DialogUnityCupConfirmation = dialog("unity_cup_confirmation", "Confirmation", buttons = listOf(ButtonCancel, ButtonBeginShowdown), okButton = ButtonBeginShowdown)
 
 /** Race Screen */
-object DialogUnlockRequirements : DialogInterface {
-    override val name: String = "unlock_requirements"
-    override val title: String = "Unlock Requirements"
-    override val closeButton = null
-    override val okButton = null
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonClose,
-        )
-}
+val DialogUnlockRequirements = dialog("unlock_requirements", "Unlock Requirements", buttons = listOf(ButtonClose))
 
-object DialogUnmetRequirements : DialogInterface {
-    override val name: String = "unmet_requirements"
-    override val title: String = "Unmet Requirements"
-    override val closeButton = null
-    override val okButton: BaseComponentInterface = ButtonRace
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonCancel,
-            ButtonRace,
-        )
-}
+val DialogUnmetRequirements = dialog("unmet_requirements", "Unmet Requirements", buttons = listOf(ButtonCancel, ButtonRace), okButton = ButtonRace)
 
 /** Main Screen, end of career. */
-object DialogViewStory : DialogInterface {
-    override val name: String = "view_story"
-    override val title: String = "View Story"
-    override val closeButton = null
-    override val okButton: BaseComponentInterface = ButtonOk
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonCancel,
-            ButtonOk,
-            RadioLandscape,
-            RadioPortrait,
-            RadioVoiceOff,
-        )
-}
+val DialogViewStory = dialog("view_story", "View Story", buttons = listOf(ButtonCancel, ButtonOk, RadioLandscape, RadioPortrait, RadioVoiceOff), okButton = ButtonOk)
 
 /** Trackblazer */
-object DialogTrainingItems : DialogInterface {
-    override val name: String = "training_items"
-    override val title: String = "Training Items"
-    override val closeButton: BaseComponentInterface = ButtonClose
-    override val okButton: BaseComponentInterface = ButtonConfirmUse
-    override val buttons: List<BaseComponentInterface> =
-        listOf(
-            ButtonClose,
-            ButtonConfirmUse,
-        )
-}
+val DialogTrainingItems = dialog("training_items", "Training Items", buttons = listOf(ButtonClose, ButtonConfirmUse), closeButton = ButtonClose, okButton = ButtonConfirmUse)

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/components/Icon.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/components/Icon.kt
@@ -6,222 +6,71 @@
 
 package com.steve1316.uma_android_automation.components
 
-object IconMoodGreat : ComponentInterface {
-    override val template = Template("components/icon/mood_great", region = Region.topHalf)
-}
+/**
+ * Builds an icon component backed by the `components/icon/[name]` template.
+ *
+ * @param name Leaf filename under `components/icon/` identifying the template image.
+ * @param region Screen region to constrain matching to. Defaults to the whole screen.
+ * @param confidence Match-confidence override for this template. Defaults to 0.0 (use the global default).
+ * @return A [ComponentInterface] wrapping the resolved template.
+ */
+private fun icon(name: String, region: IntArray = intArrayOf(0, 0, 0, 0), confidence: Double = 0.0): ComponentInterface =
+    object : ComponentInterface {
+        override val template = Template("components/icon/$name", region = region, confidence = confidence)
+    }
 
-object IconMoodGood : ComponentInterface {
-    override val template = Template("components/icon/mood_good", region = Region.topHalf)
-}
-
-object IconMoodNormal : ComponentInterface {
-    override val template = Template("components/icon/mood_normal", region = Region.topHalf)
-}
-
-object IconMoodBad : ComponentInterface {
-    override val template = Template("components/icon/mood_bad", region = Region.topHalf)
-}
-
-object IconMoodAwful : ComponentInterface {
-    override val template = Template("components/icon/mood_awful", region = Region.topHalf)
-}
-
-object IconTrainingHeaderSpeed : ComponentInterface {
-    override val template = Template("components/icon/training_header_speed", region = Region.topHalf)
-}
-
-object IconTrainingHeaderStamina : ComponentInterface {
-    override val template = Template("components/icon/training_header_stamina", region = Region.topHalf)
-}
-
-object IconTrainingHeaderPower : ComponentInterface {
-    override val template = Template("components/icon/training_header_power", region = Region.topHalf)
-}
-
-object IconTrainingHeaderGuts : ComponentInterface {
-    override val template = Template("components/icon/training_header_guts", region = Region.topHalf)
-}
-
-object IconTrainingHeaderWit : ComponentInterface {
-    override val template = Template("components/icon/training_header_wit", region = Region.topHalf)
-}
-
-object IconHorseshoe : ComponentInterface {
-    override val template = Template("components/icon/horseshoe")
-}
-
-object IconDoubleCircle : ComponentInterface {
-    override val template = Template("components/icon/double_circle")
-}
-
-object IconUnityCupRaceEndLogo : ComponentInterface {
-    override val template = Template("components/icon/unity_cup_race_end_logo", region = Region.topHalf)
-}
-
-object IconTazuna : ComponentInterface {
-    override val template = Template("components/icon/tazuna", region = Region.topHalf)
-}
-
-object IconRaceDayRibbon : ComponentInterface {
-    override val template = Template("components/icon/race_day_ribbon", region = Region.bottomHalf)
-}
-
-object IconRaceHistory1st : ComponentInterface {
-    override val template = Template("components/icon/race_history_1st")
-}
-
-object IconGoalRibbon : ComponentInterface {
-    override val template = Template("components/icon/goal_ribbon", region = Region.leftHalf)
-}
-
-object IconRaceListPredictionDoubleStar : ComponentInterface {
-    override val template = Template("components/icon/race_list_prediction_double_star", region = Region.rightHalf)
-}
-
-object IconRaceListSelectionBracketBottomRight : ComponentInterface {
-    override val template = Template("components/icon/race_list_selection_bracket_bottom_right", region = Region.rightHalf)
-}
-
-object IconRaceListMaidenPill : ComponentInterface {
-    override val template = Template("components/icon/race_list_maiden_pill", region = Region.bottomHalf)
-}
-
-object IconScrollListTopLeft : ComponentInterface {
-    override val template = Template("components/icon/scroll_list_top_left", region = Region.leftHalf)
-}
-
-object IconScrollListBottomRight : ComponentInterface {
-    override val template = Template("components/icon/scroll_list_bottom_right", region = Region.rightHalf)
-}
-
-object IconObtainedPill : ComponentInterface {
-    override val template = Template("components/icon/obtained_pill", region = Region.rightHalf)
-}
-
-object IconSkillTitleDoubleCircle : ComponentInterface {
-    override val template = Template("components/icon/skill_title_double_circle")
-}
-
-object IconSkillTitleCircle : ComponentInterface {
-    override val template = Template("components/icon/skill_title_circle")
-}
-
-object IconSkillTitleX : ComponentInterface {
-    override val template = Template("components/icon/skill_title_x")
-}
-
-object IconRaceListTopLeft : ComponentInterface {
-    override val template = Template("components/icon/race_list_top_left", region = Region.leftHalf)
-}
-
-object IconRaceListBottomRight : ComponentInterface {
-    override val template = Template("components/icon/race_list_bottom_right", region = Region.rightHalf)
-}
-
-object IconOneFreePerDayTooltip : ComponentInterface {
-    override val template = Template("components/icon/one_free_per_day_tooltip", region = Region.middle)
-}
-
-object IconEnergyBarLeftPart : ComponentInterface {
-    override val template = Template("components/icon/energy_bar_left_part", region = Region.topHalf)
-}
-
-object IconEnergyBarRightPart0 : ComponentInterface {
-    override val template = Template("components/icon/energy_bar_right_part_0", region = Region.topHalf)
-}
-
-object IconEnergyBarRightPart1 : ComponentInterface {
-    override val template = Template("components/icon/energy_bar_right_part_1", region = Region.topHalf)
-}
-
-object IconRaceNotEnoughFans : ComponentInterface {
-    override val template = Template("components/icon/race_not_enough_fans", region = Region.middle)
-}
-
-object IconStatBlockSpeed : ComponentInterface {
-    override val template = Template("components/icon/stat_block_speed")
-}
-
-object IconStatBlockStamina : ComponentInterface {
-    override val template = Template("components/icon/stat_block_stamina")
-}
-
-object IconStatBlockPower : ComponentInterface {
-    override val template = Template("components/icon/stat_block_power")
-}
-
-object IconStatBlockGuts : ComponentInterface {
-    override val template = Template("components/icon/stat_block_guts")
-}
-
-object IconStatBlockWit : ComponentInterface {
-    override val template = Template("components/icon/stat_block_wit")
-}
-
-object IconStatBlockTrainer : ComponentInterface {
-    override val template = Template("components/icon/stat_block_trainer")
-}
-
-object IconStatBlockGroup : ComponentInterface {
-    override val template = Template("components/icon/stat_block_group")
-}
-
-object IconStatSupportEtsukoOtonashi : ComponentInterface {
-    override val template = Template("components/icon/stat_support_etsuko_otonashi")
-}
-
-object IconStatSupportRikoKashimoto : ComponentInterface {
-    override val template = Template("components/icon/stat_support_riko_kashimoto")
-}
-
-object IconStatSupportYayoiAkikawa : ComponentInterface {
-    override val template = Template("components/icon/stat_support_yayoi_akikawa")
-}
-
-object IconStatSkillHint : ComponentInterface {
-    override val template = Template("components/icon/stat_skill_hint", confidence = 0.9)
-}
-
-object IconRecreationDate : ComponentInterface {
-    override val template = Template("components/icon/recreation_date", region = Region.bottomHalf)
-}
-
-object IconRecreationDateOpen : ComponentInterface {
-    override val template = Template("components/icon/recreation_date_open", region = Region.middle)
-}
-
-object IconTrainingEventHorseshoe : ComponentInterface {
-    override val template = Template("components/icon/training_event_horseshoe", region = Region.leftHalf)
-}
-
-object IconEventTitleSpacer : ComponentInterface {
-    override val template = Template("components/icon/event_title_spacer")
-}
-
-object IconUnityCupSpiritExplosion : ComponentInterface {
-    override val template = Template("components/icon/unitycup_spirit_explosion", region = Region.topRightThird)
-}
-
-object IconUnityCupSpiritTraining : ComponentInterface {
-    override val template = Template("components/icon/unitycup_spirit_training", region = Region.topRightThird)
-}
-
-object IconUnityCupTutorialHeader : ComponentInterface {
-    override val template = Template("components/icon/unitycup_tutorial_header", region = Region.topHalf)
-}
-
-object IconInfirmaryEventHeader : ComponentInterface {
-    override val template = Template("components/icon/infirmary_event_header", region = Region.topHalf)
-}
-
-object IconRaceAgendaEmpty : ComponentInterface {
-    override val template = Template("components/icon/race_agenda_empty", region = Region.topHalf)
-}
-
-object IconDialogScrollListTopLeft : ComponentInterface {
-    override val template = Template("components/icon/dialog_scroll_list_top_left", region = Region.leftHalf)
-}
-
-object IconDialogScrollListBottomRight : ComponentInterface {
-    override val template = Template("components/icon/dialog_scroll_list_bottom_right", region = Region.rightHalf)
-}
+val IconMoodGreat = icon("mood_great", Region.topHalf)
+val IconMoodGood = icon("mood_good", Region.topHalf)
+val IconMoodNormal = icon("mood_normal", Region.topHalf)
+val IconMoodBad = icon("mood_bad", Region.topHalf)
+val IconMoodAwful = icon("mood_awful", Region.topHalf)
+val IconTrainingHeaderSpeed = icon("training_header_speed", Region.topHalf)
+val IconTrainingHeaderStamina = icon("training_header_stamina", Region.topHalf)
+val IconTrainingHeaderPower = icon("training_header_power", Region.topHalf)
+val IconTrainingHeaderGuts = icon("training_header_guts", Region.topHalf)
+val IconTrainingHeaderWit = icon("training_header_wit", Region.topHalf)
+val IconHorseshoe = icon("horseshoe")
+val IconDoubleCircle = icon("double_circle")
+val IconUnityCupRaceEndLogo = icon("unity_cup_race_end_logo", Region.topHalf)
+val IconTazuna = icon("tazuna", Region.topHalf)
+val IconRaceDayRibbon = icon("race_day_ribbon", Region.bottomHalf)
+val IconRaceHistory1st = icon("race_history_1st")
+val IconGoalRibbon = icon("goal_ribbon", Region.leftHalf)
+val IconRaceListPredictionDoubleStar = icon("race_list_prediction_double_star", Region.rightHalf)
+val IconRaceListSelectionBracketBottomRight = icon("race_list_selection_bracket_bottom_right", Region.rightHalf)
+val IconRaceListMaidenPill = icon("race_list_maiden_pill", Region.bottomHalf)
+val IconScrollListTopLeft = icon("scroll_list_top_left", Region.leftHalf)
+val IconScrollListBottomRight = icon("scroll_list_bottom_right", Region.rightHalf)
+val IconObtainedPill = icon("obtained_pill", Region.rightHalf)
+val IconSkillTitleDoubleCircle = icon("skill_title_double_circle")
+val IconSkillTitleCircle = icon("skill_title_circle")
+val IconSkillTitleX = icon("skill_title_x")
+val IconRaceListTopLeft = icon("race_list_top_left", Region.leftHalf)
+val IconRaceListBottomRight = icon("race_list_bottom_right", Region.rightHalf)
+val IconOneFreePerDayTooltip = icon("one_free_per_day_tooltip", Region.middle)
+val IconEnergyBarLeftPart = icon("energy_bar_left_part", Region.topHalf)
+val IconEnergyBarRightPart0 = icon("energy_bar_right_part_0", Region.topHalf)
+val IconEnergyBarRightPart1 = icon("energy_bar_right_part_1", Region.topHalf)
+val IconRaceNotEnoughFans = icon("race_not_enough_fans", Region.middle)
+val IconStatBlockSpeed = icon("stat_block_speed")
+val IconStatBlockStamina = icon("stat_block_stamina")
+val IconStatBlockPower = icon("stat_block_power")
+val IconStatBlockGuts = icon("stat_block_guts")
+val IconStatBlockWit = icon("stat_block_wit")
+val IconStatBlockTrainer = icon("stat_block_trainer")
+val IconStatBlockGroup = icon("stat_block_group")
+val IconStatSupportEtsukoOtonashi = icon("stat_support_etsuko_otonashi")
+val IconStatSupportRikoKashimoto = icon("stat_support_riko_kashimoto")
+val IconStatSupportYayoiAkikawa = icon("stat_support_yayoi_akikawa")
+val IconStatSkillHint = icon("stat_skill_hint", confidence = 0.9)
+val IconRecreationDate = icon("recreation_date", Region.bottomHalf)
+val IconRecreationDateOpen = icon("recreation_date_open", Region.middle)
+val IconTrainingEventHorseshoe = icon("training_event_horseshoe", Region.leftHalf)
+val IconEventTitleSpacer = icon("event_title_spacer")
+val IconUnityCupSpiritExplosion = icon("unitycup_spirit_explosion", Region.topRightThird)
+val IconUnityCupSpiritTraining = icon("unitycup_spirit_training", Region.topRightThird)
+val IconUnityCupTutorialHeader = icon("unitycup_tutorial_header", Region.topHalf)
+val IconInfirmaryEventHeader = icon("infirmary_event_header", Region.topHalf)
+val IconRaceAgendaEmpty = icon("race_agenda_empty", Region.topHalf)
+val IconDialogScrollListTopLeft = icon("dialog_scroll_list_top_left", Region.leftHalf)
+val IconDialogScrollListBottomRight = icon("dialog_scroll_list_bottom_right", Region.rightHalf)

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/components/Label.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/components/Label.kt
@@ -6,174 +6,58 @@
 
 package com.steve1316.uma_android_automation.components
 
-object LabelCongratulations : ComponentInterface {
-    override val template = Template("components/label/congratulations", region = Region.topHalf)
-}
+/**
+ * Builds a non-clickable label component backed by the `components/label/[name]` template.
+ *
+ * @param name Leaf filename under `components/label/` identifying the template image.
+ * @param region Screen region to constrain matching to. Defaults to the whole screen.
+ * @return A [ComponentInterface] wrapping the resolved template.
+ */
+private fun label(name: String, region: IntArray = intArrayOf(0, 0, 0, 0)): ComponentInterface =
+    object : ComponentInterface {
+        override val template = Template("components/label/$name", region = region)
+    }
 
-object LabelStatDistance : ComponentInterface {
-    override val template = Template("components/label/stat_distance", region = Region.topHalf)
-}
-
-object LabelStatTrackSurface : ComponentInterface {
-    override val template = Template("components/label/stat_track_surface", region = Region.topHalf)
-}
-
-object LabelStatStyle : ComponentInterface {
-    override val template = Template("components/label/stat_style", region = Region.topHalf)
-}
-
-object LabelUmamusumeClassFans : ComponentInterface {
-    override val template = Template("components/label/umamusume_class_fans", region = Region.middle)
-}
-
-object LabelStatTableHeaderSkillPoints : ComponentInterface {
-    override val template = Template("components/label/stat_table_header_skill_points", region = Region.bottomHalf)
-}
-
-object LabelTrainingFailureChance : ComponentInterface {
-    override val template = Template("components/label/training_failure_chance", region = Region.bottomHalf)
-}
-
-object LabelWinToBecomeRank : ComponentInterface {
-    override val template = Template("components/label/win_to_become_rank")
-}
-
-object LabelUnityCupOpponentSelectionLaurel : ComponentInterface {
-    override val template = Template("components/label/unitycup_opponent_selection_laurel", region = Region.leftHalf)
-}
-
-object LabelEnergy : ComponentInterface {
-    override val template = Template("components/label/energy")
-}
-
-object LabelEnergyBarLeftPart : ComponentInterface {
-    override val template = Template("components/label/energy_bar_left_part")
-}
-
-object LabelEnergyBarRightPart : ComponentInterface {
-    override val template = Template("components/label/energy_bar_right_part_0")
-}
-
-object LabelEnergyBarExtendedRightPart : ComponentInterface {
-    override val template = Template("components/label/energy_bar_right_part_1")
-}
-
-object LabelSkillListScreenSkillPoints : ComponentInterface {
-    override val template = Template("components/label/skill_list_screen_skill_points", region = Region.topHalf)
-}
-
-object LabelScheduledRace : ComponentInterface {
-    override val template = Template("components/label/scheduled_race", region = Region.bottomHalf)
-}
-
-object LabelStrategy : ComponentInterface {
-    override val template = Template("components/label/strategy")
-}
-
-object LabelTrainingCannotPerform : ComponentInterface {
-    override val template = Template("components/label/training_cannot_perform", region = Region.middle)
-}
-
-object LabelTrophyWonDialogTitle : ComponentInterface {
-    override val template = Template("components/label/trophy_won")
-}
-
-object LabelConnecting : ComponentInterface {
-    override val template = Template("components/label/connecting", region = Region.topHalf)
-}
-
-object LabelNowLoading : ComponentInterface {
-    override val template = Template("components/label/now_loading", region = Region.bottomHalf)
-}
-
-object LabelOrdinaryCuties : ComponentInterface {
-    override val template = Template("components/label/ordinary_cuties", region = Region.middle)
-}
-
-object LabelStatMaxed : ComponentInterface {
-    override val template = Template("components/label/stat_maxed")
-}
-
-object LabelStatAptitudeA : ComponentInterface {
-    override val template = Template("components/label/stat_aptitude_A")
-}
-
-object LabelStatAptitudeB : ComponentInterface {
-    override val template = Template("components/label/stat_aptitude_B")
-}
-
-object LabelStatAptitudeC : ComponentInterface {
-    override val template = Template("components/label/stat_aptitude_C")
-}
-
-object LabelStatAptitudeD : ComponentInterface {
-    override val template = Template("components/label/stat_aptitude_D")
-}
-
-object LabelStatAptitudeE : ComponentInterface {
-    override val template = Template("components/label/stat_aptitude_E")
-}
-
-object LabelStatAptitudeF : ComponentInterface {
-    override val template = Template("components/label/stat_aptitude_F")
-}
-
-object LabelStatAptitudeG : ComponentInterface {
-    override val template = Template("components/label/stat_aptitude_G")
-}
-
-object LabelStatAptitudeS : ComponentInterface {
-    override val template = Template("components/label/stat_aptitude_S")
-}
-
-object LabelRecreationDateComplete : ComponentInterface {
-    override val template = Template("components/label/recreation_date_complete", region = Region.middle)
-}
-
-object LabelRaceSelectionFans : ComponentInterface {
-    override val template = Template("components/label/race_selection_fans", region = Region.bottomHalf)
-}
-
-object LabelRaceCriteriaFans : ComponentInterface {
-    override val template = Template("components/label/race_criteria_fans", region = Region.topHalf)
-}
-
-object LabelRaceCriteriaG3OrAbove : ComponentInterface {
-    override val template = Template("components/label/race_criteria_g3_or_above", region = Region.topHalf)
-}
-
-object LabelRaceCriteriaMaiden : ComponentInterface {
-    override val template = Template("components/label/race_criteria_maiden", region = Region.topHalf)
-}
-
-object LabelRaceCriteriaPreOpOrAbove : ComponentInterface {
-    override val template = Template("components/label/race_criteria_pre_op_or_above", region = Region.topHalf)
-}
-
-object LabelRaceCriteriaTrophies : ComponentInterface {
-    override val template = Template("components/label/race_criteria_trophies", region = Region.topHalf)
-}
-
-object LabelThereAreNoRacesToCompeteIn : ComponentInterface {
-    override val template = Template("components/label/there_are_no_races_to_compete_in", region = Region.middle)
-}
-
-object LabelEventProgress : ComponentInterface {
-    override val template = Template("components/label/event_progress", region = Region.middle)
-}
-
-object LabelRecreationUmamusume : ComponentInterface {
-    override val template = Template("components/label/recreation_umamusume", region = Region.middle)
-}
-
-object LabelOnSale : ComponentInterface {
-    override val template = Template("components/label/on_sale", region = Region.topHalf)
-}
-
-object LabelPurchased : ComponentInterface {
-    override val template = Template("components/label/purchased")
-}
-
-object LabelRivalRacer : ComponentInterface {
-    override val template = Template("components/label/rival_racer", region = Region.rightHalf)
-}
+val LabelCongratulations = label("congratulations", Region.topHalf)
+val LabelStatDistance = label("stat_distance", Region.topHalf)
+val LabelStatTrackSurface = label("stat_track_surface", Region.topHalf)
+val LabelStatStyle = label("stat_style", Region.topHalf)
+val LabelUmamusumeClassFans = label("umamusume_class_fans", Region.middle)
+val LabelStatTableHeaderSkillPoints = label("stat_table_header_skill_points", Region.bottomHalf)
+val LabelTrainingFailureChance = label("training_failure_chance", Region.bottomHalf)
+val LabelWinToBecomeRank = label("win_to_become_rank")
+val LabelUnityCupOpponentSelectionLaurel = label("unitycup_opponent_selection_laurel", Region.leftHalf)
+val LabelEnergy = label("energy")
+val LabelEnergyBarLeftPart = label("energy_bar_left_part")
+val LabelEnergyBarRightPart = label("energy_bar_right_part_0")
+val LabelEnergyBarExtendedRightPart = label("energy_bar_right_part_1")
+val LabelSkillListScreenSkillPoints = label("skill_list_screen_skill_points", Region.topHalf)
+val LabelScheduledRace = label("scheduled_race", Region.bottomHalf)
+val LabelStrategy = label("strategy")
+val LabelTrainingCannotPerform = label("training_cannot_perform", Region.middle)
+val LabelTrophyWonDialogTitle = label("trophy_won")
+val LabelConnecting = label("connecting", Region.topHalf)
+val LabelNowLoading = label("now_loading", Region.bottomHalf)
+val LabelOrdinaryCuties = label("ordinary_cuties", Region.middle)
+val LabelStatMaxed = label("stat_maxed")
+val LabelStatAptitudeA = label("stat_aptitude_A")
+val LabelStatAptitudeB = label("stat_aptitude_B")
+val LabelStatAptitudeC = label("stat_aptitude_C")
+val LabelStatAptitudeD = label("stat_aptitude_D")
+val LabelStatAptitudeE = label("stat_aptitude_E")
+val LabelStatAptitudeF = label("stat_aptitude_F")
+val LabelStatAptitudeG = label("stat_aptitude_G")
+val LabelStatAptitudeS = label("stat_aptitude_S")
+val LabelRecreationDateComplete = label("recreation_date_complete", Region.middle)
+val LabelRaceSelectionFans = label("race_selection_fans", Region.bottomHalf)
+val LabelRaceCriteriaFans = label("race_criteria_fans", Region.topHalf)
+val LabelRaceCriteriaG3OrAbove = label("race_criteria_g3_or_above", Region.topHalf)
+val LabelRaceCriteriaMaiden = label("race_criteria_maiden", Region.topHalf)
+val LabelRaceCriteriaPreOpOrAbove = label("race_criteria_pre_op_or_above", Region.topHalf)
+val LabelRaceCriteriaTrophies = label("race_criteria_trophies", Region.topHalf)
+val LabelThereAreNoRacesToCompeteIn = label("there_are_no_races_to_compete_in", Region.middle)
+val LabelEventProgress = label("event_progress", Region.middle)
+val LabelRecreationUmamusume = label("recreation_umamusume", Region.middle)
+val LabelOnSale = label("on_sale", Region.topHalf)
+val LabelPurchased = label("purchased")
+val LabelRivalRacer = label("rival_racer", Region.rightHalf)

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/llm/DocIndex.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/llm/DocIndex.kt
@@ -11,7 +11,7 @@ import java.nio.ByteOrder
  * In-memory vector store backing the documentation chatbot's retrieval step.
  *
  * Loads a compact binary index produced at build time by the indexer script, holding all chunk metadata plus
- * 384-dim L2-normalized embeddings. At 500 chunks × 384 floats × 4 bytes this is ~750 KB of RAM - linear cosine
+ * 384-dim L2-normalized embeddings. At 500 chunks x 384 floats x 4 bytes this is ~750 KB of RAM - linear cosine
  * scan over the whole set is microseconds, no ANN datastructure needed at this scale.
  *
  * Binary format (little-endian):
@@ -20,8 +20,8 @@ import java.nio.ByteOrder
  * version : u32        (currently 2)
  * count   : u32        number of chunks
  * dim     : u32        embedding dimensionality
- * chunks  : count × { idLen u16, id utf-8; sourceLen u16, source utf-8; headingLen u16, heading utf-8;
- *                     textLen u32, text utf-8; dim × f32 }
+ * chunks  : count x { idLen u16, id utf-8; sourceLen u16, source utf-8; headingLen u16, heading utf-8;
+ *                     textLen u32, text utf-8; dim x f32 }
  * ```
  *
  * @property chunks Loaded chunk records with their embeddings.

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/llm/WordPieceTokenizer.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/llm/WordPieceTokenizer.kt
@@ -39,7 +39,7 @@ class WordPieceTokenizer(private val vocab: Map<String, Int>) {
 
         /**
          * Load a tokenizer from a BERT-style vocab.txt where each line is one wordpiece in id order
-         * (line 0 → id 0, line 1 → id 1, …).
+         * (line 0 -> id 0, line 1 -> id 1, ...).
          *
          * @param stream Input stream over the vocab.txt resource.
          * @return A [WordPieceTokenizer] configured with the parsed vocabulary.

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/types/SkillList.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/types/SkillList.kt
@@ -184,62 +184,6 @@ class SkillList(private val game: Game, private val campaign: Campaign) {
     }
 
     /**
-     * Calculates the bounding region for detecting the Skill Up (+) buttons.
-     *
-     * This region is relative to the provided skill list entries' bounding box.
-     *
-     * @param bitmap Optional [Bitmap] used for debugging snapshots.
-     * @param bboxSkillListEntries The overall [BoundingBox] of all skill entries currently on screen.
-     * @param debugString Identifier string for debugging files.
-     * @return The calculated [BoundingBox] for the Skill Up buttons.
-     */
-    private fun getSkillListSkillUpBoundingRegion(bitmap: Bitmap? = null, bboxSkillListEntries: BoundingBox, debugString: String = ""): BoundingBox {
-        // Focus on the right-hand side of each entry where the (+) button is located.
-        val bbox =
-            BoundingBox(
-                x = game.imageUtils.relX((bboxSkillListEntries.x + bboxSkillListEntries.w).toDouble(), -125),
-                y = bboxSkillListEntries.y,
-                w = game.imageUtils.relWidth(70),
-                h = bboxSkillListEntries.h,
-            )
-
-        if (game.debugMode) {
-            val debugBitmap: Bitmap = bitmap ?: game.imageUtils.getSourceBitmap()
-            game.imageUtils.saveBitmapWithBbox(debugBitmap, "skillUpRegion_$debugString", bbox)
-        }
-
-        return bbox
-    }
-
-    /**
-     * Calculates the bounding region for detecting the "Obtained" pill icons.
-     *
-     * This region is relative to the provided skill list entries' bounding box.
-     *
-     * @param bitmap Optional [Bitmap] used for debugging snapshots.
-     * @param bboxSkillListEntries The overall [BoundingBox] of all skill entries currently on screen.
-     * @param debugString Identifier string for debugging files.
-     * @return The calculated [BoundingBox] for the Obtained pill icons.
-     */
-    private fun getSkillListObtainedPillBoundingRegion(bitmap: Bitmap? = null, bboxSkillListEntries: BoundingBox, debugString: String = ""): BoundingBox {
-        // Focus on the right-hand side of each entry where the "Obtained" icon is located.
-        val bbox =
-            BoundingBox(
-                x = game.imageUtils.relX((bboxSkillListEntries.x + bboxSkillListEntries.w).toDouble(), -260),
-                y = bboxSkillListEntries.y,
-                w = game.imageUtils.relWidth(140),
-                h = bboxSkillListEntries.h,
-            )
-
-        if (game.debugMode) {
-            val debugBitmap: Bitmap = bitmap ?: game.imageUtils.getSourceBitmap()
-            game.imageUtils.saveBitmapWithBbox(debugBitmap, "obtainedPillRegion_$debugString", bbox)
-        }
-
-        return bbox
-    }
-
-    /**
      * Extracts text from a specific bitmap region using OCR.
      *
      * @param bitmap The bitmap to perform OCR on.

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/types/SkillListEntry.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/types/SkillListEntry.kt
@@ -227,6 +227,16 @@ class SkillListEntry(
     }
 
     /**
+     * Looks up the evaluation-point modifier for an optional aptitude-bearing requirement.
+     *
+     * @param value The requirement (running style, track distance, or surface), or null if this skill has none.
+     * @param check Resolves the trainee's [Aptitude] for that requirement.
+     * @return The aptitude's modifier from [EVALUATION_POINT_APTITUDE_RATIO_MAP], or null when value is null.
+     */
+    private inline fun <T> aptitudeModifier(value: T?, check: (T) -> Aptitude): Double? =
+        value?.let { EVALUATION_POINT_APTITUDE_RATIO_MAP[check(it)] }
+
+    /**
      * Gets the evaluation point modifier for any running style requirements.
      *
      * Activation conditions for skills often require the uma to be in a specific [RunningStyle].
@@ -234,11 +244,8 @@ class SkillListEntry(
      * @return If this skill's activation conditions require a specific [RunningStyle], then we return the evaluation point modifier for that style. If there are no such conditions, then we return
      *    null.
      */
-    private fun getRunningStyleAptitudeEvaluationModifier(): Double? {
-        val runningStyle: RunningStyle = runningStyle ?: return null
-        val aptitude: Aptitude = campaign.trainee.checkRunningStyleAptitude(runningStyle)
-        return EVALUATION_POINT_APTITUDE_RATIO_MAP[aptitude]
-    }
+    private fun getRunningStyleAptitudeEvaluationModifier(): Double? =
+        aptitudeModifier(runningStyle) { campaign.trainee.checkRunningStyleAptitude(it) }
 
     /**
      * Gets the evaluation point modifier for any track distance requirements.
@@ -248,11 +255,8 @@ class SkillListEntry(
      * @return If this skill's activation conditions require a specific [TrackDistance], then we return the evaluation point modifier for that distance. If there are no such conditions, then we return
      *    null.
      */
-    private fun getTrackDistanceAptitudeEvaluationModifier(): Double? {
-        val trackDistance: TrackDistance = trackDistance ?: return null
-        val aptitude: Aptitude = campaign.trainee.checkTrackDistanceAptitude(trackDistance)
-        return EVALUATION_POINT_APTITUDE_RATIO_MAP[aptitude]
-    }
+    private fun getTrackDistanceAptitudeEvaluationModifier(): Double? =
+        aptitudeModifier(trackDistance) { campaign.trainee.checkTrackDistanceAptitude(it) }
 
     /**
      * Gets the evaluation point modifier for any track surface requirements.
@@ -262,11 +266,8 @@ class SkillListEntry(
      * @return If this skill's activation conditions require a specific [TrackSurface], then we return the evaluation point modifier for that surface. If there are no such conditions, then we return
      *    null.
      */
-    private fun getTrackSurfaceAptitudeEvaluationModifier(): Double? {
-        val trackSurface: TrackSurface = trackSurface ?: return null
-        val aptitude: Aptitude = campaign.trainee.checkTrackSurfaceAptitude(trackSurface)
-        return EVALUATION_POINT_APTITUDE_RATIO_MAP[aptitude]
-    }
+    private fun getTrackSurfaceAptitudeEvaluationModifier(): Double? =
+        aptitudeModifier(trackSurface) { campaign.trainee.checkTrackSurfaceAptitude(it) }
 
     /**
      * Calculates the total evaluation points (rank gain) awarded for this skill.

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/types/Trainee.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/types/Trainee.kt
@@ -713,6 +713,60 @@ class Trainee {
     }
 
     /**
+     * Applies one OCR-read stat value through the consistency-verification guard shared by the parallel and sequential update paths.
+     *
+     * @param statName The stat being updated.
+     * @param newValue The newly OCR-read value for the stat.
+     * @param viaSequential True when called from the sequential fallback, which annotates the log messages accordingly.
+     */
+    private fun applyStatUpdate(statName: StatName, newValue: Int, viaSequential: Boolean) {
+        val via = if (viaSequential) " via sequential processing" else ""
+
+        val oldValue = getStat(statName)
+        val diff = abs(newValue - oldValue)
+
+        // Reject updates that vary too wildly unless the previous value was unset (<= 0).
+        if (oldValue <= 0 || diff < 150) {
+            stats.setStat(statName, newValue)
+            bHasUpdatedStats = true
+
+            // Reset mismatch tracking for this stat.
+            mismatchCounts[statName] = 0
+            lastMismatchedValues[statName] = -1
+        } else {
+            // Start or continue a verification count if the OCR result is consistent but different.
+            val lastMismatchedValue = lastMismatchedValues[statName] ?: -1
+            val mismatchDiff = abs(newValue - lastMismatchedValue)
+            val currentCount = mismatchCounts[statName] ?: 0
+
+            if (mismatchDiff < 50) {
+                val newCount = currentCount + 1
+                mismatchCounts[statName] = newCount
+
+                // If the "incorrect" value is detected multiple times, assume the previous
+                // recorded value was the actual misread and update to the new one.
+                if (newCount >= 2) {
+                    MessageLog.d(TAG, "[DEBUG] updateStats:: New $statName stat value has been consistent for $newCount updates$via. Trusting the new value: $newValue (was $oldValue)")
+                    stats.setStat(statName, newValue)
+                    bHasUpdatedStats = true
+                    mismatchCounts[statName] = 0
+                    lastMismatchedValues[statName] = -1
+                } else {
+                    MessageLog.w(
+                        TAG,
+                        "[WARN] updateStats:: New $statName stat value has changed too much since last update (old=$oldValue, new=$newValue)$via. Consecutive mismatch count: $newCount",
+                    )
+                }
+            } else {
+                // The mismatch itself is inconsistent, so reset the counter.
+                mismatchCounts[statName] = 1
+                lastMismatchedValues[statName] = newValue
+                MessageLog.w(TAG, "[WARN] updateStats:: New $statName stat value has changed too much since last update (old=$oldValue, new=$newValue)$via. Resetting mismatch count.")
+            }
+        }
+    }
+
+    /**
      * Updates the trainee's stats by performing OCR on the screen.
      *
      * To prevent "jumping" to incorrect values due to OCR misreads, this method implements a verification process:
@@ -762,48 +816,7 @@ class Trainee {
             // Update stats with thread-safe results.
             val statMapping = threadSafeResults.toMap()
             for ((statName, newValue) in statMapping) {
-                val oldValue = getStat(statName)
-                val diff = abs(newValue - oldValue)
-
-                // Reject updates that vary too wildly unless the previous value was unset (<= 0).
-                if (oldValue <= 0 || diff < 150) {
-                    stats.setStat(statName, newValue)
-                    bHasUpdatedStats = true
-
-                    // Reset mismatch tracking for this stat.
-                    mismatchCounts[statName] = 0
-                    lastMismatchedValues[statName] = -1
-                } else {
-                    // Start or continue a verification count if the OCR result is consistent but different.
-                    val lastMismatchedValue = lastMismatchedValues[statName] ?: -1
-                    val mismatchDiff = abs(newValue - lastMismatchedValue)
-                    val currentCount = mismatchCounts[statName] ?: 0
-
-                    if (mismatchDiff < 50) {
-                        val newCount = currentCount + 1
-                        mismatchCounts[statName] = newCount
-
-                        // If the "incorrect" value is detected multiple times, assume the previous
-                        // recorded value was the actual misread and update to the new one.
-                        if (newCount >= 2) {
-                            MessageLog.d(TAG, "[DEBUG] updateStats:: New $statName stat value has been consistent for $newCount updates. Trusting the new value: $newValue (was $oldValue)")
-                            stats.setStat(statName, newValue)
-                            bHasUpdatedStats = true
-                            mismatchCounts[statName] = 0
-                            lastMismatchedValues[statName] = -1
-                        } else {
-                            MessageLog.w(
-                                TAG,
-                                "[WARN] updateStats:: New $statName stat value has changed too much since last update (old=$oldValue, new=$newValue). Consecutive mismatch count: $newCount",
-                            )
-                        }
-                    } else {
-                        // The mismatch itself is inconsistent, so reset the counter.
-                        mismatchCounts[statName] = 1
-                        lastMismatchedValues[statName] = newValue
-                        MessageLog.w(TAG, "[WARN] updateStats:: New $statName stat value has changed too much since last update (old=$oldValue, new=$newValue). Resetting mismatch count.")
-                    }
-                }
+                applyStatUpdate(statName, newValue, viaSequential = false)
             }
         } else {
             // Sequential processing (fallback).
@@ -815,48 +828,7 @@ class Trainee {
                 )
 
             for ((statName, newValue) in statMapping) {
-                val oldValue = getStat(statName)
-                val diff = abs(newValue - oldValue)
-
-                if (oldValue <= 0 || diff < 150) {
-                    stats.setStat(statName, newValue)
-                    bHasUpdatedStats = true
-
-                    mismatchCounts[statName] = 0
-                    lastMismatchedValues[statName] = -1
-                } else {
-                    val lastMismatchedValue = lastMismatchedValues[statName] ?: -1
-                    val mismatchDiff = abs(newValue - lastMismatchedValue)
-                    val currentCount = mismatchCounts[statName] ?: 0
-
-                    if (mismatchDiff < 50) {
-                        val newCount = currentCount + 1
-                        mismatchCounts[statName] = newCount
-
-                        if (newCount >= 2) {
-                            MessageLog.d(
-                                TAG,
-                                "[DEBUG] updateStats:: New $statName stat value has been consistent for $newCount updates via sequential processing. Trusting the new value: $newValue (was $oldValue)",
-                            )
-                            stats.setStat(statName, newValue)
-                            bHasUpdatedStats = true
-                            mismatchCounts[statName] = 0
-                            lastMismatchedValues[statName] = -1
-                        } else {
-                            MessageLog.w(
-                                TAG,
-                                "[WARN] updateStats:: New $statName stat value has changed too much since last update (old=$oldValue, new=$newValue) via sequential processing. Consecutive mismatch count: $newCount",
-                            )
-                        }
-                    } else {
-                        mismatchCounts[statName] = 1
-                        lastMismatchedValues[statName] = newValue
-                        MessageLog.w(
-                            TAG,
-                            "[WARN] updateStats:: New $statName stat value has changed too much since last update (old=$oldValue, new=$newValue) via sequential processing. Resetting mismatch count.",
-                        )
-                    }
-                }
+                applyStatUpdate(statName, newValue, viaSequential = true)
             }
         }
     }

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/utils/AppUpdateChecker.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/utils/AppUpdateChecker.kt
@@ -54,20 +54,20 @@ class AppUpdateChecker(private val activity: Activity) {
     enum class DisplayMode { UPDATE_AVAILABLE, CURRENT_CHANGELOG }
 
     /**
-     * Fetches the remote update XML and shows the update dialog if a newer version is available.
+     * Fetches the remote update XML off the main thread and shows the update/changelog dialog when [shouldShow] passes.
      *
-     * @param forceShow If true, always shows the dialog regardless of version comparison. Useful for testing the dialog UI.
+     * @param mode Which dialog variant to display.
+     * @param shouldShow Decides, given the parsed update info, whether the dialog should actually be shown.
      */
-    fun checkForUpdate(forceShow: Boolean = false) {
+    private fun fetchUpdateInfoAndShow(mode: DisplayMode, shouldShow: (UpdateInfo) -> Boolean) {
         CoroutineScope(Dispatchers.Main + SupervisorJob()).launch {
             try {
                 val updateInfo =
                     withContext(Dispatchers.IO) {
                         URL(UPDATE_XML_URL).openStream().use { parseUpdateXml(it) }
                     } ?: return@launch
-
-                if (forceShow || isNewerVersion(updateInfo.latestVersion, BuildConfig.VERSION_NAME)) {
-                    showUpdateDialog(updateInfo, DisplayMode.UPDATE_AVAILABLE)
+                if (shouldShow(updateInfo)) {
+                    showUpdateDialog(updateInfo, mode)
                 }
             } catch (_: Exception) {
                 // Silently ignore network or parsing failures.
@@ -76,22 +76,21 @@ class AppUpdateChecker(private val activity: Activity) {
     }
 
     /**
+     * Fetches the remote update XML and shows the update dialog if a newer version is available.
+     *
+     * @param forceShow If true, always shows the dialog regardless of version comparison. Useful for testing the dialog UI.
+     */
+    fun checkForUpdate(forceShow: Boolean = false) =
+        fetchUpdateInfoAndShow(DisplayMode.UPDATE_AVAILABLE) {
+            forceShow || isNewerVersion(it.latestVersion, BuildConfig.VERSION_NAME)
+        }
+
+    /**
      * Fetches the same remote update XML and shows the dialog as a read-only changelog for the currently installed app version. Reuses the
      * existing dialog layout/styling but rewrites the title, subtitle, and action button to reflect that no upgrade is being offered.
      */
-    fun showCurrentChangelog() {
-        CoroutineScope(Dispatchers.Main + SupervisorJob()).launch {
-            try {
-                val updateInfo =
-                    withContext(Dispatchers.IO) {
-                        URL(UPDATE_XML_URL).openStream().use { parseUpdateXml(it) }
-                    } ?: return@launch
-                showUpdateDialog(updateInfo, DisplayMode.CURRENT_CHANGELOG)
-            } catch (_: Exception) {
-                // Silently ignore network or parsing failures.
-            }
-        }
-    }
+    fun showCurrentChangelog() =
+        fetchUpdateInfoAndShow(DisplayMode.CURRENT_CHANGELOG) { true }
 
     /**
      * Parses the update XML stream and extracts version, URL, and release notes.

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/utils/CustomImageUtils.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/utils/CustomImageUtils.kt
@@ -76,7 +76,7 @@ class CustomImageUtils(context: Context, private val game: Game) : ImageUtils(co
     private val manualStatCap: Int = SettingsHelper.getIntSetting("training", "manualStatCap")
 
     /** Whether to use YOLOv8 for stat detection. */
-    private val useYolo: Boolean get() = SettingsHelper.getBooleanSetting("training", "enableYoloStatDetection")
+    private val useYolo: Boolean = SettingsHelper.getBooleanSetting("training", "enableYoloStatDetection")
 
     /**
      * Defines the details of a race.
@@ -169,6 +169,20 @@ class CustomImageUtils(context: Context, private val game: Game) : ImageUtils(co
     init {
         initTesseract("eng.traineddata")
         SharedData.templateSubfolderPathName = "images/"
+    }
+
+    /** Converts this bitmap to a new OpenCV [Mat]. */
+    private fun Bitmap.toMat(): Mat {
+        val mat = Mat()
+        Utils.bitmapToMat(this, mat)
+        return mat
+    }
+
+    /** Converts this [Mat] to a new ARGB bitmap of matching dimensions. */
+    private fun Mat.toBitmap(): Bitmap {
+        val bitmap = createBitmap(cols(), rows())
+        Utils.matToBitmap(this, bitmap)
+        return bitmap
     }
 
     // //////////////////////////////////////////////////////////////////////////////////////////////////
@@ -271,8 +285,7 @@ class CustomImageUtils(context: Context, private val game: Game) : ImageUtils(co
             return ""
         }
 
-        val tempImage = Mat()
-        Utils.bitmapToMat(croppedBitmap, tempImage)
+        val tempImage = croppedBitmap.toMat()
         if (debugMode) Imgcodecs.imwrite("$matchFilePath/debugEventTitleText.png", tempImage)
 
         // Now see if it is necessary to shift the cropped region over by 70 pixels or not to account for certain events.
@@ -286,8 +299,7 @@ class CustomImageUtils(context: Context, private val game: Game) : ImageUtils(co
             }
 
         // Make the cropped screenshot grayscale.
-        val cvImage = Mat()
-        Utils.bitmapToMat(croppedBitmap, cvImage)
+        val cvImage = croppedBitmap.toMat()
         Imgproc.cvtColor(cvImage, cvImage, Imgproc.COLOR_BGR2GRAY)
 
         // Save the cropped image before converting it to black and white in order to troubleshoot issues related to differing device sizes and cropping.
@@ -299,8 +311,7 @@ class CustomImageUtils(context: Context, private val game: Game) : ImageUtils(co
         if (debugMode) Imgcodecs.imwrite("$matchFilePath/debugEventTitleText_afterThreshold.png", bwImage)
 
         // Convert the Mat directly to Bitmap and then pass it to the text reader.
-        val resultBitmap = createBitmap(bwImage.cols(), bwImage.rows())
-        Utils.matToBitmap(bwImage, resultBitmap)
+        val resultBitmap = bwImage.toBitmap()
         tessBaseAPI.setImage(resultBitmap)
 
         var result = ""
@@ -546,6 +557,18 @@ class CustomImageUtils(context: Context, private val game: Game) : ImageUtils(co
         // Sort the combined stat blocks by ascending y-coordinate.
         allStatBlocks.sortBy { it.point.y }
 
+        return analyzeRelationshipBarFills(sourceBitmap, allStatBlocks, statName)
+    }
+
+    /**
+     * Computes the relationship-bar fill result for each detected stat block.
+     *
+     * @param sourceBitmap The screenshot the stat blocks were detected in.
+     * @param allStatBlocks The detected, de-duplicated, y-sorted stat blocks to analyze.
+     * @param statName The stat these bars belong to, stamped onto each result.
+     * @return One [BarFillResult] per analyzable stat block.
+     */
+    private fun analyzeRelationshipBarFills(sourceBitmap: Bitmap, allStatBlocks: List<StatBlock>, statName: StatName): ArrayList<BarFillResult> {
         // Define HSV color ranges.
         val blueLower = Scalar(10.0, 150.0, 150.0)
         val blueUpper = Scalar(25.0, 255.0, 255.0)
@@ -584,8 +607,7 @@ class CustomImageUtils(context: Context, private val game: Game) : ImageUtils(co
                 continue
             }
 
-            val barMat = Mat()
-            Utils.bitmapToMat(croppedBitmap, barMat)
+            val barMat = croppedBitmap.toMat()
 
             // Convert to RGB and then to HSV for better color detection.
             val rgbMat = Mat()
@@ -707,8 +729,7 @@ class CustomImageUtils(context: Context, private val game: Game) : ImageUtils(co
 
             val gaugeBitmap = createSafeBitmap(currentBitmap, gaugeStartX, gaugeStartY, gaugeWidth, gaugeHeight, "analyzeSpiritExplosionGauges") ?: continue
 
-            val gaugeMat = Mat()
-            Utils.bitmapToMat(gaugeBitmap, gaugeMat)
+            val gaugeMat = gaugeBitmap.toMat()
             if (debugMode) Imgcodecs.imwrite("$matchFilePath/debug_spiritExplosionGauge${index + 1}.png", gaugeMat)
 
             // Convert to RGB and then to HSV for better color detection.
@@ -1027,6 +1048,8 @@ class CustomImageUtils(context: Context, private val game: Game) : ImageUtils(co
             }
 
             // Process all stats in parallel using threads.
+            // Fetch the shared YOLO detector once so the per-stat threads do not race the lazy-init lock.
+            val yolo = if (useYolo) getYoloDetector(context) else null
             val statLatch = CountDownLatch(5)
             for (statName in StatName.entries) {
                 Thread {
@@ -1118,8 +1141,7 @@ class CustomImageUtils(context: Context, private val game: Game) : ImageUtils(co
                                 }
 
                                 // Convert to Mat and then turn it to grayscale.
-                                val rowMat = Mat()
-                                Utils.bitmapToMat(rowBitmap, rowMat)
+                                val rowMat = rowBitmap.toMat()
                                 matObjects.add(rowMat)
 
                                 val rowGray = Mat()
@@ -1141,8 +1163,7 @@ class CustomImageUtils(context: Context, private val game: Game) : ImageUtils(co
                                 val trainingContext = "${trainingName.name} training for ${statName.name} $effectType"
 
                                 // Process results based on detection method.
-                                if (useYolo) {
-                                    val yolo = getYoloDetector(context)
+                                if (useYolo && yolo != null) {
                                     val detections = yolo.detect(rowBitmap)
 
                                     // Parse YOLO detections into rowMatches for compatibility with constructIntegerFromMatches and debug visualization.
@@ -1838,16 +1859,13 @@ class CustomImageUtils(context: Context, private val game: Game) : ImageUtils(co
      * @return The number of fans if successful, or null if detection fails.
      */
     fun getUmamusumeClassDialogFanCount(bitmap: Bitmap): Int? {
-        val cvImage = Mat()
-        Utils.bitmapToMat(bitmap, cvImage)
+        val cvImage = bitmap.toMat()
         // Convert to grayscale.
-        Utils.bitmapToMat(bitmap, cvImage)
         Imgproc.cvtColor(cvImage, cvImage, Imgproc.COLOR_BGR2GRAY)
         if (debugMode) Imgcodecs.imwrite("$matchFilePath/debugGetUmamusumeClassDialogFanCount_afterCrop.png", cvImage)
 
         // Convert the Mat directly to Bitmap and then pass it to the text reader.
-        var resultBitmap = createBitmap(cvImage.cols(), cvImage.rows())
-        Utils.matToBitmap(cvImage, resultBitmap)
+        var resultBitmap = cvImage.toBitmap()
 
         // Thresh the grayscale cropped image to make it black and white.
         val bwImage = Mat()
@@ -1975,8 +1993,7 @@ class CustomImageUtils(context: Context, private val game: Game) : ImageUtils(co
         val colorUpper = Scalar(180.0, 255.0, 255.0)
 
         // Convert the cropped region to HSV
-        val barMat = Mat()
-        Utils.bitmapToMat(croppedBitmap, barMat)
+        val barMat = croppedBitmap.toMat()
         val hsvMat = Mat()
         Imgproc.cvtColor(barMat, hsvMat, Imgproc.COLOR_BGR2HSV)
 
@@ -2182,8 +2199,7 @@ class CustomImageUtils(context: Context, private val game: Game) : ImageUtils(co
             return RaceDetails(-1, false, rivalCheck)
         }
 
-        val cvImage = Mat()
-        Utils.bitmapToMat(croppedBitmap, cvImage)
+        val cvImage = croppedBitmap.toMat()
         if (debugMode) Imgcodecs.imwrite("$matchFilePath/debugExtraRacePrediction.png", cvImage)
 
         // Determine if the extra race has double star prediction.
@@ -2226,8 +2242,7 @@ class CustomImageUtils(context: Context, private val game: Game) : ImageUtils(co
             if (debugMode) Imgcodecs.imwrite("$matchFilePath/debugExtraRaceFans_afterCrop.png", cvImage)
 
             // Convert the Mat directly to Bitmap and then pass it to the text reader.
-            var resultBitmap = createBitmap(cvImage.cols(), cvImage.rows())
-            Utils.matToBitmap(cvImage, resultBitmap)
+            var resultBitmap = cvImage.toBitmap()
 
             // Thresh the grayscale cropped image to make it black and white.
             val bwImage = Mat()
@@ -2326,8 +2341,7 @@ class CustomImageUtils(context: Context, private val game: Game) : ImageUtils(co
         }
 
         // Convert to Mat.
-        val cvImage = Mat()
-        Utils.bitmapToMat(croppedBitmap, cvImage)
+        val cvImage = croppedBitmap.toMat()
 
         // Save the cropped image for debugging.
         if (debugMode) {
@@ -2368,8 +2382,7 @@ class CustomImageUtils(context: Context, private val game: Game) : ImageUtils(co
 
         // Convert the processed Mat to Bitmap and apply scaling.
         val clampedScale = max(0, scale.toInt()).toDouble().coerceAtLeast(1.0)
-        val baseBitmap = createBitmap(invertedMask.cols(), invertedMask.rows())
-        Utils.matToBitmap(invertedMask, baseBitmap)
+        val baseBitmap = invertedMask.toBitmap()
         val finalBitmap =
             if (clampedScale != 1.0) {
                 baseBitmap.scale((baseBitmap.width * clampedScale).toInt(), (baseBitmap.height * clampedScale).toInt())
@@ -2575,8 +2588,7 @@ class CustomImageUtils(context: Context, private val game: Game) : ImageUtils(co
      */
     fun saveBitmap(bitmap: Bitmap? = null, filename: String, fullRes: Boolean = false) {
         val bitmap = bitmap ?: getSourceBitmap()
-        val tempImage = Mat()
-        Utils.bitmapToMat(bitmap, tempImage)
+        val tempImage = bitmap.toMat()
         if (fullRes) {
             val params = MatOfInt(Imgcodecs.IMWRITE_JPEG_QUALITY, 100)
             Imgcodecs.imwrite("$matchFilePath/$filename.png", tempImage, params)
@@ -2595,8 +2607,7 @@ class CustomImageUtils(context: Context, private val game: Game) : ImageUtils(co
      * @param filename The output filename.
      */
     fun saveDebugImageWithBboxes(bitmap: Bitmap, bboxes: List<BoundingBox>, filename: String) {
-        val mat = Mat()
-        Utils.bitmapToMat(bitmap, mat)
+        val mat = bitmap.toMat()
 
         for (bbox in bboxes) {
             val pt1 = Point(bbox.x.toDouble(), bbox.y.toDouble())
@@ -2707,6 +2718,65 @@ class CustomImageUtils(context: Context, private val game: Game) : ImageUtils(co
     }
 
     /**
+     * Finds four-vertex (quad) contours in a binary image, filtered by area and approximated via convex hull.
+     *
+     * @param image The single-channel image to find contours within.
+     * @param minArea The smallest contour area to keep.
+     * @param maxArea The largest contour area to keep.
+     * @param epsilonScalar The polygon-approximation tolerance, scaled by each contour's perimeter.
+     * @return The bounding rectangles of the detected quad contours.
+     */
+    private fun findQuadRects(image: Mat, minArea: Int, maxArea: Int, epsilonScalar: Double): List<Rect> {
+        val rects = mutableListOf<Rect>()
+        val contours: MutableList<MatOfPoint> = mutableListOf()
+        val hierarchy = Mat()
+        Imgproc.findContours(
+            image,
+            contours,
+            hierarchy,
+            Imgproc.RETR_EXTERNAL,
+            Imgproc.CHAIN_APPROX_SIMPLE,
+        )
+
+        for (cnt in contours) {
+            val area = Imgproc.contourArea(cnt)
+
+            // Filter out contours with invalid areas.
+            if (area < minArea || area > maxArea) {
+                continue
+            }
+
+            // Use convex hull to ignore rounded corners.
+            val hullPoints = MatOfInt()
+            Imgproc.convexHull(cnt, hullPoints)
+            // Convert hull indices back to MatOfPoint.
+            val hullContour = getHullFromIndices(cnt, hullPoints)
+
+            // Approximate shape.
+            val approx = MatOfPoint2f()
+            val cnt2f = MatOfPoint2f(*hullContour.toArray())
+            val peri = Imgproc.arcLength(cnt2f, true)
+            Imgproc.approxPolyDP(cnt2f, approx, epsilonScalar * peri, true)
+
+            // Check for four vertices.
+            if (approx.total() == 4L) {
+                rects.add(Imgproc.boundingRect(cnt))
+            }
+
+            // Free memory for each mat.
+            hullPoints.release()
+            hullContour.release()
+            approx.release()
+            cnt2f.release()
+        }
+
+        contours.forEach { it.release() }
+        contours.clear()
+        hierarchy.release()
+        return rects
+    }
+
+    /**
      * Detects rectangles with rounded corners on the screen.
      *
      * @param bitmap Optional bitmap to analyze. If null, a screenshot is used.
@@ -2769,8 +2839,7 @@ class CustomImageUtils(context: Context, private val game: Game) : ImageUtils(co
 
         val result: MutableList<BoundingBox> = mutableListOf()
 
-        val srcImage = Mat()
-        Utils.bitmapToMat(bitmap, srcImage)
+        val srcImage = bitmap.toMat()
 
         val image = Mat()
         Imgproc.cvtColor(srcImage, image, Imgproc.COLOR_RGB2GRAY)
@@ -2797,55 +2866,15 @@ class CustomImageUtils(context: Context, private val game: Game) : ImageUtils(co
         }
 
         if (debugMode) {
-            val resultBitmap = createBitmap(image.cols(), image.rows())
-            Utils.matToBitmap(image, resultBitmap)
+            val resultBitmap = image.toBitmap()
             saveBitmap(resultBitmap, "detectRoundedRectangles_canny", fullRes = true)
         }
 
-        val contours: MutableList<MatOfPoint> = mutableListOf()
-        val hierarchy = Mat()
-        Imgproc.findContours(
-            image,
-            contours,
-            hierarchy,
-            Imgproc.RETR_EXTERNAL,
-            Imgproc.CHAIN_APPROX_SIMPLE,
-        )
-
-        for (cnt in contours) {
-            val area = Imgproc.contourArea(cnt)
-
-            // Filter out contours with invalid areas.
-            if (area < minArea || area > maxArea) {
-                continue
+        for (rect in findQuadRects(image, minArea, maxArea, epsilonScalar)) {
+            if (debugMode) {
+                Imgproc.rectangle(srcImage, rect.tl(), rect.br(), Scalar(0.0, 255.0, 0.0), 2)
             }
-
-            // Use convex hull to ignore rounded corners.
-            val hullPoints = MatOfInt()
-            Imgproc.convexHull(cnt, hullPoints)
-            // Convert hull indices back to MatOfPoint.
-            val hullContour = getHullFromIndices(cnt, hullPoints)
-
-            // Approximate shape.
-            val approx = MatOfPoint2f()
-            val cnt2f = MatOfPoint2f(*hullContour.toArray())
-            val peri = Imgproc.arcLength(cnt2f, true)
-            Imgproc.approxPolyDP(cnt2f, approx, epsilonScalar * peri, true)
-
-            // Check for four vertices.
-            if (approx.total() == 4L) {
-                val rect = Imgproc.boundingRect(cnt)
-                if (debugMode) {
-                    Imgproc.rectangle(srcImage, rect.tl(), rect.br(), Scalar(0.0, 255.0, 0.0), 2)
-                }
-                result.add(BoundingBox(rect.x, rect.y, rect.width, rect.height))
-            }
-
-            // Free memory for each mat.
-            hullPoints.release()
-            hullContour.release()
-            approx.release()
-            cnt2f.release()
+            result.add(BoundingBox(rect.x, rect.y, rect.width, rect.height))
         }
 
         if (debugMode) {
@@ -2856,9 +2885,6 @@ class CustomImageUtils(context: Context, private val game: Game) : ImageUtils(co
         }
 
         // Free memory for each mat.
-        contours.forEach { it.release() }
-        contours.clear()
-        hierarchy.release()
         image.release()
         srcImage.release()
 
@@ -2942,8 +2968,7 @@ class CustomImageUtils(context: Context, private val game: Game) : ImageUtils(co
 
         val result: MutableList<BoundingBox> = mutableListOf()
 
-        val srcImage = Mat()
-        Utils.bitmapToMat(bitmap, srcImage)
+        val srcImage = bitmap.toMat()
 
         val image = Mat()
         Imgproc.cvtColor(srcImage, image, Imgproc.COLOR_RGB2GRAY)
@@ -2962,8 +2987,7 @@ class CustomImageUtils(context: Context, private val game: Game) : ImageUtils(co
         )
 
         if (debugMode) {
-            val resultBitmap = createBitmap(image.cols(), image.rows())
-            Utils.matToBitmap(image, resultBitmap)
+            val resultBitmap = image.toBitmap()
             saveBitmap(resultBitmap, "detectRectanglesGeneric_floodFill", fullRes = true)
         }
 
@@ -2977,80 +3001,38 @@ class CustomImageUtils(context: Context, private val game: Game) : ImageUtils(co
         nonBlackMask.release()
 
         if (debugMode) {
-            val resultBitmap = createBitmap(image.cols(), image.rows())
-            Utils.matToBitmap(image, resultBitmap)
+            val resultBitmap = image.toBitmap()
             saveBitmap(resultBitmap, "detectRectanglesGeneric_masked", fullRes = true)
         }
 
         Imgproc.morphologyEx(image, image, Imgproc.MORPH_OPEN, morphKernel)
 
         if (debugMode) {
-            val resultBitmap = createBitmap(image.cols(), image.rows())
-            Utils.matToBitmap(image, resultBitmap)
+            val resultBitmap = image.toBitmap()
             saveBitmap(resultBitmap, "detectRectanglesGeneric_opened", fullRes = true)
         }
 
         // Invert binary image.
         // Core.bitwise_not(image, image)
 
-        val contours: MutableList<MatOfPoint> = mutableListOf()
-        val hierarchy = Mat()
-        Imgproc.findContours(
-            image,
-            contours,
-            hierarchy,
-            Imgproc.RETR_EXTERNAL,
-            Imgproc.CHAIN_APPROX_SIMPLE,
-        )
-
-        for (cnt in contours) {
-            val area = Imgproc.contourArea(cnt)
-
-            // Filter out contours with invalid areas.
-            if (area < minArea || area > maxArea) {
-                continue
+        for (rect in findQuadRects(image, minArea, maxArea, epsilonScalar)) {
+            // Do not include any rects that are touching the bounding region.
+            if (bIgnoreOverflowYAxis) {
+                if (rect.y <= 0 || rect.y + rect.height >= bitmap.height - 1) {
+                    continue
+                }
             }
 
-            // Use convex hull to ignore rounded corners.
-            val hullPoints = MatOfInt()
-            Imgproc.convexHull(cnt, hullPoints)
-            // Convert hull indices back to MatOfPoint
-            val hullContour = getHullFromIndices(cnt, hullPoints)
-
-            // Approximate shape.
-            val approx = MatOfPoint2f()
-            val cnt2f = MatOfPoint2f(*hullContour.toArray())
-            val peri = Imgproc.arcLength(cnt2f, true)
-            Imgproc.approxPolyDP(cnt2f, approx, epsilonScalar * peri, true)
-
-            // Check for four vertices.
-            if (approx.total() == 4L) {
-                val rect = Imgproc.boundingRect(cnt)
-
-                // Do not include any rects that are touching the bounding region.
-                if (bIgnoreOverflowYAxis) {
-                    if (rect.y <= 0 || rect.y + rect.height >= bitmap.height - 1) {
-                        continue
-                    }
+            if (bIgnoreOverflowXAxis) {
+                if (rect.x <= 0 || rect.x + rect.width >= bitmap.width - 1) {
+                    continue
                 }
-
-                if (bIgnoreOverflowXAxis) {
-                    if (rect.x <= 0 || rect.x + rect.width >= bitmap.width - 1) {
-                        continue
-                    }
-                }
-
-                if (debugMode) {
-                    Imgproc.rectangle(srcImage, rect.tl(), rect.br(), Scalar(0.0, 255.0, 0.0), 2)
-                }
-                result.add(BoundingBox(rect.x, rect.y, rect.width, rect.height))
             }
 
-            // Free memory for each mat.
-            hullPoints.release()
-            hullContour.release()
-            approx.release()
-            cnt2f.release()
+            if (debugMode) {
+                Imgproc.rectangle(srcImage, rect.tl(), rect.br(), Scalar(0.0, 255.0, 0.0), 2)
+            }
+            result.add(BoundingBox(rect.x, rect.y, rect.width, rect.height))
         }
 
         if (debugMode) {
@@ -3061,9 +3043,6 @@ class CustomImageUtils(context: Context, private val game: Game) : ImageUtils(co
         }
 
         // Free memory for each mat.
-        contours.forEach { it.release() }
-        contours.clear()
-        hierarchy.release()
         image.release()
         srcImage.release()
 
@@ -3158,8 +3137,7 @@ class CustomImageUtils(context: Context, private val game: Game) : ImageUtils(co
 
         val morphOpenKernel = Imgproc.getStructuringElement(Imgproc.MORPH_RECT, Size(5.0, 5.0))
 
-        val srcImage = Mat()
-        Utils.bitmapToMat(bitmap, srcImage)
+        val srcImage = bitmap.toMat()
 
         val image = Mat()
         Imgproc.cvtColor(srcImage, image, Imgproc.COLOR_RGB2GRAY)
@@ -3168,8 +3146,7 @@ class CustomImageUtils(context: Context, private val game: Game) : ImageUtils(co
         Imgproc.cvtColor(srcImage, hsvImage, Imgproc.COLOR_RGB2HSV)
 
         if (debugMode) {
-            val resultBitmap = createBitmap(hsvImage.cols(), hsvImage.rows())
-            Utils.matToBitmap(hsvImage, resultBitmap)
+            val resultBitmap = hsvImage.toBitmap()
             saveBitmap(resultBitmap, "detectScrollBar_hsvImage", fullRes = true)
         }
 
@@ -3219,8 +3196,7 @@ class CustomImageUtils(context: Context, private val game: Game) : ImageUtils(co
                 combinedColorRange,
             )
         if (debugMode) {
-            val resultBitmap = createBitmap(barMask.cols(), barMask.rows())
-            Utils.matToBitmap(barMask, resultBitmap)
+            val resultBitmap = barMask.toBitmap()
             saveBitmap(resultBitmap, "detectScrollBar_barMask", fullRes = true)
         }
 
@@ -3230,8 +3206,7 @@ class CustomImageUtils(context: Context, private val game: Game) : ImageUtils(co
                 listOf(thumbColorRange),
             )
         if (debugMode) {
-            val resultBitmap = createBitmap(thumbMask.cols(), thumbMask.rows())
-            Utils.matToBitmap(thumbMask, resultBitmap)
+            val resultBitmap = thumbMask.toBitmap()
             saveBitmap(resultBitmap, "detectScrollBar_thumbMask", fullRes = true)
         }
 
@@ -3245,8 +3220,7 @@ class CustomImageUtils(context: Context, private val game: Game) : ImageUtils(co
          * @return The BoundingBox of the detected scrollbar on success. Otherwise, null.
          */
         fun detectFromMask(mask: Mat, minArea: Int, maxArea: Int, debugString: String = ""): BoundingBox? {
-            val debugImage = Mat()
-            Utils.bitmapToMat(bitmap, debugImage)
+            val debugImage = bitmap.toMat()
 
             val contours: MutableList<MatOfPoint> = mutableListOf()
             val hierarchy = Mat()

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/utils/LogStreamServer.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/utils/LogStreamServer.kt
@@ -56,8 +56,8 @@ import java.util.regex.Pattern
  * Embedded WebSocket server that streams MessageLog entries in real-time to any browser on the local network. Built on Ktor Server CIO.
  *
  * When running, the server serves:
- * - HTTP GET "/" → the log viewer HTML page (from assets).
- * - WebSocket "/" → real-time log message streaming.
+ * - HTTP GET "/" -> the log viewer HTML page (from assets).
+ * - WebSocket "/" -> real-time log message streaming.
  */
 object LogStreamServer {
     private const val TAG: String = "${SharedData.loggerTag}LogStreamServer"

--- a/src/components/InfoContainer/index.tsx
+++ b/src/components/InfoContainer/index.tsx
@@ -1,44 +1,25 @@
-import { useMemo, ReactNode } from "react"
-import { View, Text, StyleSheet, StyleProp, ViewStyle } from "react-native"
-import { useTheme } from "../../context/ThemeContext"
+import { ReactNode } from "react"
+import { StyleProp, ViewStyle } from "react-native"
+import NoticeContainer from "../NoticeContainer"
 
+/** Props for InfoContainer. */
 interface Props {
     /** Custom style for the container view. */
     style?: StyleProp<ViewStyle>
-    /** The content to display inside the container. */
+    /** The content to display inside the container. Can be a string or a ReactNode. */
     children: ReactNode
 }
 
 /**
- * A reusable component for displaying informational content.
- * Renders text with default info styles if children is a string, otherwise renders children directly.
+ * A reusable component for displaying informational content. Thin wrapper over `NoticeContainer` with the "info" variant.
  * @param style Optional custom style for the container view.
  * @param children The content to display inside the container. Can be a string or a ReactNode.
+ * @returns The info-styled notice container.
  */
-const InfoContainer = ({ style, children }: Props) => {
-    const { colors } = useTheme()
-
-    const styles = useMemo(
-        () =>
-            StyleSheet.create({
-                container: {
-                    backgroundColor: (colors as any).infoBg,
-                    borderLeftWidth: 4,
-                    borderLeftColor: (colors as any).infoBorder,
-                    padding: 12,
-                    marginTop: 12,
-                    borderRadius: 8,
-                },
-                text: {
-                    fontSize: 14,
-                    color: (colors as any).infoText,
-                    lineHeight: 20,
-                },
-            }),
-        [colors]
-    )
-
-    return <View style={[styles.container, style]}>{typeof children === "string" ? <Text style={styles.text}>{children}</Text> : children}</View>
-}
+const InfoContainer = ({ style, children }: Props) => (
+    <NoticeContainer variant="info" style={style}>
+        {children}
+    </NoticeContainer>
+)
 
 export default InfoContainer

--- a/src/components/NoticeContainer/index.tsx
+++ b/src/components/NoticeContainer/index.tsx
@@ -1,0 +1,52 @@
+import { useMemo, ReactNode } from "react"
+import { View, Text, StyleSheet, StyleProp, ViewStyle } from "react-native"
+import { useTheme } from "../../context/ThemeContext"
+
+/** Visual treatment of the notice. */
+export type NoticeVariant = "warning" | "info"
+
+/** Props for NoticeContainer. */
+interface Props {
+    /** Which color treatment to render - amber "warning" or blue "info". */
+    variant: NoticeVariant
+    /** Custom style for the container view. */
+    style?: StyleProp<ViewStyle>
+    /** The content to display inside the container. */
+    children: ReactNode
+}
+
+/**
+ * A reusable callout box for warnings/errors or informational notes, selected by `variant`.
+ * Renders text with the variant's default styles if children is a string, otherwise renders children directly.
+ * @param variant Which color treatment to render ("warning" or "info").
+ * @param style Optional custom style for the container view.
+ * @param children The content to display inside the container.
+ * @returns The styled notice container.
+ */
+const NoticeContainer = ({ variant, style, children }: Props) => {
+    const { colors } = useTheme()
+
+    const styles = useMemo(() => {
+        const c = colors as Record<string, string>
+        const palette = variant === "warning" ? { bg: c.warningBg, border: c.warningBorder, text: c.warningText } : { bg: c.infoBg, border: c.infoBorder, text: c.infoText }
+        return StyleSheet.create({
+            container: {
+                backgroundColor: palette.bg,
+                borderLeftWidth: 4,
+                borderLeftColor: palette.border,
+                padding: 12,
+                marginTop: 12,
+                borderRadius: 8,
+            },
+            text: {
+                fontSize: 14,
+                color: palette.text,
+                lineHeight: 20,
+            },
+        })
+    }, [colors, variant])
+
+    return <View style={[styles.container, style]}>{typeof children === "string" ? <Text style={styles.text}>{children}</Text> : children}</View>
+}
+
+export default NoticeContainer

--- a/src/components/PageHeader/index.tsx
+++ b/src/components/PageHeader/index.tsx
@@ -7,6 +7,7 @@ import { useSearchRegistry } from "../../context/SearchRegistryContext"
 import { Portal } from "@rn-primitives/portal"
 import { circularPress } from "../../lib/pressSurface"
 import { StickyPageHeader } from "../ui/sticky-page-header"
+import { iconChipStyle } from "../ui/icon-chip"
 import { useSafeAreaInsets } from "react-native-safe-area-context"
 
 interface PageHeaderProps {
@@ -257,17 +258,7 @@ const PageHeader = ({ title, showHomeButton = true, titleComponent, leftComponen
                 },
                 menuButton: circularPress(44),
                 homeButton: circularPress(40),
-                chipButton: {
-                    width: 36,
-                    height: 36,
-                    borderRadius: 8,
-                    overflow: "hidden",
-                    alignItems: "center",
-                    justifyContent: "center",
-                    backgroundColor: colors.surfaceRaised,
-                    borderWidth: 1,
-                    borderColor: colors.borderHair,
-                },
+                chipButton: iconChipStyle(colors),
                 title: {
                     flex: 1,
                     flexShrink: 1,

--- a/src/components/ProfileCreationModal/index.tsx
+++ b/src/components/ProfileCreationModal/index.tsx
@@ -2,6 +2,7 @@ import React, { useState, useMemo, useCallback } from "react"
 import { View, Text, StyleSheet, Pressable, TextInput } from "react-native"
 import Ionicons from "@react-native-vector-icons/ionicons"
 import { SheetModal } from "../ui/sheet-modal"
+import { useModalShellStyles } from "../ui/modal-shell-styles"
 import { useTheme } from "../../context/ThemeContext"
 import { useProfileManager } from "../../hooks/useProfileManager"
 import { Settings } from "../../context/BotStateContext"
@@ -41,6 +42,7 @@ interface ProfileCreationModalProps {
  */
 const ProfileCreationModal: React.FC<ProfileCreationModalProps> = ({ visible, onClose, currentTrainingSettings, currentTrainingStatTargetSettings, onProfileCreated, onError }) => {
     const { colors } = useTheme()
+    const shell = useModalShellStyles()
     const { createProfile } = useProfileManager(onError)
     const [profileName, setProfileName] = useState("")
     const [isCreating, setIsCreating] = useState(false)
@@ -48,19 +50,6 @@ const ProfileCreationModal: React.FC<ProfileCreationModalProps> = ({ visible, on
     const styles = useMemo(
         () =>
             StyleSheet.create({
-                titleRow: { flexDirection: "row", alignItems: "center", justifyContent: "space-between" },
-                title: { ...TYPE.monoLabel, color: colors.text, fontSize: 13, letterSpacing: 1.5 },
-                closeChip: {
-                    width: 36,
-                    height: 36,
-                    borderRadius: 8,
-                    overflow: "hidden",
-                    alignItems: "center",
-                    justifyContent: "center",
-                    backgroundColor: colors.surfaceRaised,
-                    borderWidth: 1,
-                    borderColor: colors.borderHair,
-                },
                 label: { ...TYPE.monoLabel, color: colors.textMuted, marginBottom: SPACING.xs },
                 input: {
                     backgroundColor: colors.surfaceRaised,
@@ -194,9 +183,9 @@ const ProfileCreationModal: React.FC<ProfileCreationModalProps> = ({ visible, on
     }, [onClose])
 
     const header = (
-        <View style={styles.titleRow}>
-            <Text style={styles.title}>CREATE PROFILE</Text>
-            <Pressable style={styles.closeChip} onPress={handleClose} android_ripple={{ color: colors.ripple, foreground: true }} accessibilityLabel="Close">
+        <View style={shell.modalHeaderRow}>
+            <Text style={shell.modalTitleMono}>CREATE PROFILE</Text>
+            <Pressable style={shell.modalCloseChip} onPress={handleClose} android_ripple={{ color: colors.ripple, foreground: true }} accessibilityLabel="Close">
                 <Ionicons name="close" size={18} color={colors.text} />
             </Pressable>
         </View>

--- a/src/components/ProfileManagerModal/index.tsx
+++ b/src/components/ProfileManagerModal/index.tsx
@@ -3,6 +3,7 @@ import { View, Text, TextInput, Pressable, StyleSheet } from "react-native"
 import { useTheme } from "../../context/ThemeContext"
 import { GlassModal } from "../ui/glass-modal"
 import { SheetModal } from "../ui/sheet-modal"
+import { useModalShellStyles } from "../ui/modal-shell-styles"
 import { useProfileManager } from "../../hooks/useProfileManager"
 import { Settings } from "../../context/BotStateContext"
 import Ionicons from "@react-native-vector-icons/ionicons"
@@ -60,6 +61,7 @@ const ProfileManagerModal: React.FC<ProfileManagerModalProps> = ({
     activeProfileName,
 }) => {
     const { colors } = useTheme()
+    const shell = useModalShellStyles()
     const { profiles, currentProfileName, updateProfile, deleteProfile, loadProfiles, compareWithProfile } = useProfileManager(onError)
     const activeName = activeProfileName ?? currentProfileName ?? null
     const [profileName, setProfileName] = useState("")
@@ -73,21 +75,8 @@ const ProfileManagerModal: React.FC<ProfileManagerModalProps> = ({
     const styles = useMemo(
         () =>
             StyleSheet.create({
-                titleRow: { flexDirection: "row", alignItems: "center", justifyContent: "space-between" },
                 titleBlock: { gap: 2 },
-                title: { ...TYPE.monoLabel, color: colors.text, fontSize: 13, letterSpacing: 1.5 },
                 count: { ...TYPE.monoLabel, color: colors.textMuted, fontSize: 10 },
-                closeChip: {
-                    width: 36,
-                    height: 36,
-                    borderRadius: 8,
-                    overflow: "hidden",
-                    alignItems: "center",
-                    justifyContent: "center",
-                    backgroundColor: colors.surfaceRaised,
-                    borderWidth: 1,
-                    borderColor: colors.borderHair,
-                },
                 cardList: { gap: SPACING.sm },
                 card: {
                     padding: SPACING.md,
@@ -331,12 +320,12 @@ const ProfileManagerModal: React.FC<ProfileManagerModalProps> = ({
     }, [])
 
     const header = (
-        <View style={styles.titleRow}>
+        <View style={shell.modalHeaderRow}>
             <View style={styles.titleBlock}>
-                <Text style={styles.title}>PROFILES</Text>
+                <Text style={shell.modalTitleMono}>PROFILES</Text>
                 <Text style={styles.count}>{`${profiles.length} SAVED`}</Text>
             </View>
-            <Pressable style={styles.closeChip} onPress={onClose} android_ripple={{ color: colors.ripple, foreground: true }} accessibilityLabel="Close">
+            <Pressable style={shell.modalCloseChip} onPress={onClose} android_ripple={{ color: colors.ripple, foreground: true }} accessibilityLabel="Close">
                 <Ionicons name="close" size={18} color={colors.text} />
             </Pressable>
         </View>
@@ -427,7 +416,7 @@ const ProfileManagerModal: React.FC<ProfileManagerModalProps> = ({
             <GlassModal visible={showDeleteDialog} onRequestClose={handleDeleteCancel} contentStyle={styles.deleteModalContent} dismissOnBackdropPress={false}>
                 <View style={styles.deleteHeader}>
                     <Text style={styles.deleteTitle}>Delete Profile</Text>
-                    <Pressable style={styles.closeChip} onPress={handleDeleteCancel} android_ripple={{ color: colors.ripple, foreground: true }} accessibilityLabel="Close">
+                    <Pressable style={shell.modalCloseChip} onPress={handleDeleteCancel} android_ripple={{ color: colors.ripple, foreground: true }} accessibilityLabel="Close">
                         <Ionicons name="close" size={18} color={colors.text} />
                     </Pressable>
                 </View>

--- a/src/components/ThemeToggle/index.tsx
+++ b/src/components/ThemeToggle/index.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from "react"
 import { Pressable, StyleProp, StyleSheet, ViewStyle } from "react-native"
 import { Moon, Sun } from "lucide-react-native"
 import { useTheme } from "../../context/ThemeContext"
+import { iconChipStyle } from "../ui/icon-chip"
 
 interface ThemeToggleProps {
     /** Optional custom style for the toggle button. */
@@ -18,17 +19,7 @@ export const ThemeToggle: React.FC<ThemeToggleProps> = ({ style }) => {
     const styles = useMemo(
         () =>
             StyleSheet.create({
-                chip: {
-                    width: 36,
-                    height: 36,
-                    borderRadius: 8,
-                    overflow: "hidden",
-                    alignItems: "center",
-                    justifyContent: "center",
-                    backgroundColor: colors.surfaceRaised,
-                    borderWidth: 1,
-                    borderColor: colors.borderHair,
-                },
+                chip: iconChipStyle(colors),
             }),
         [colors]
     )

--- a/src/components/ToggleSetting/index.tsx
+++ b/src/components/ToggleSetting/index.tsx
@@ -1,0 +1,42 @@
+import SearchableItem from "../SearchableItem"
+import { Row } from "../ui/row"
+import { Switch } from "../ui/switch"
+
+/** Props for ToggleSetting. */
+interface ToggleSettingProps {
+    /** Unique search id, registered with the search registry via `SearchableItem`. */
+    id: string
+    /** Primary label, shown on the `Row` and indexed for search. */
+    title: string
+    /** Secondary description line, shown on the `Row` and indexed for search. */
+    description: string
+    /** Current on/off state of the switch. */
+    checked: boolean
+    /** Fired with the new state when the switch is toggled. */
+    onCheckedChange: (checked: boolean) => void
+    /** When provided and false, the row is hidden but stays searchable, falling back to its parent. */
+    condition?: boolean
+    /** Parent search id to highlight when this conditionally-hidden item is matched. */
+    parentId?: string
+}
+
+/**
+ * A boolean settings toggle: the standard `SearchableItem` > `Row` > `Switch` composition every settings page uses.
+ * Collapses the repeated triple-nest and removes the need to type `title` / `description` twice (once for search, once for display).
+ *
+ * @param id Unique search id registered via `SearchableItem`.
+ * @param title Primary label shown on the row and indexed for search.
+ * @param description Secondary line shown on the row and indexed for search.
+ * @param checked Current on/off state of the switch.
+ * @param onCheckedChange Fired with the new state when the switch is toggled.
+ * @param condition When provided and false, hides the row while keeping it searchable.
+ * @param parentId Parent search id to highlight for a conditionally-hidden item.
+ * @returns The composed searchable toggle row.
+ */
+const ToggleSetting = ({ id, title, description, checked, onCheckedChange, condition, parentId }: ToggleSettingProps) => (
+    <SearchableItem id={id} title={title} description={description} condition={condition} parentId={parentId}>
+        <Row title={title} description={description} right={<Switch checked={checked} onCheckedChange={onCheckedChange} />} />
+    </SearchableItem>
+)
+
+export default ToggleSetting

--- a/src/components/WarningContainer/index.tsx
+++ b/src/components/WarningContainer/index.tsx
@@ -1,7 +1,8 @@
-import { useMemo, ReactNode } from "react"
-import { View, Text, StyleSheet, StyleProp, ViewStyle } from "react-native"
-import { useTheme } from "../../context/ThemeContext"
+import { ReactNode } from "react"
+import { StyleProp, ViewStyle } from "react-native"
+import NoticeContainer from "../NoticeContainer"
 
+/** Props for WarningContainer. */
 interface Props {
     /** Custom style for the container view. */
     style?: StyleProp<ViewStyle>
@@ -10,35 +11,15 @@ interface Props {
 }
 
 /**
- * A reusable component for displaying warnings or errors.
- * Renders text with default warning styles if children is a string, otherwise renders children directly.
+ * A reusable component for displaying warnings or errors. Thin wrapper over `NoticeContainer` with the "warning" variant.
  * @param style Optional custom style for the container view.
  * @param children The content to display inside the container.
+ * @returns The warning-styled notice container.
  */
-const WarningContainer = ({ style, children }: Props) => {
-    const { colors } = useTheme()
-
-    const styles = useMemo(
-        () =>
-            StyleSheet.create({
-                container: {
-                    backgroundColor: colors.warningBg,
-                    borderLeftWidth: 4,
-                    borderLeftColor: colors.warningBorder,
-                    padding: 12,
-                    marginTop: 12,
-                    borderRadius: 8,
-                },
-                text: {
-                    fontSize: 14,
-                    color: colors.warningText,
-                    lineHeight: 20,
-                },
-            }),
-        [colors]
-    )
-
-    return <View style={[styles.container, style]}>{typeof children === "string" ? <Text style={styles.text}>{children}</Text> : children}</View>
-}
+const WarningContainer = ({ style, children }: Props) => (
+    <NoticeContainer variant="warning" style={style}>
+        {children}
+    </NoticeContainer>
+)
 
 export default WarningContainer

--- a/src/components/ui/icon-chip.ts
+++ b/src/components/ui/icon-chip.ts
@@ -1,0 +1,21 @@
+import { ViewStyle } from "react-native"
+import { RADII } from "../../lib/radii"
+
+/**
+ * Shared style for the app's 36x36 square icon "chip" button - the header search / menu chips, the theme
+ * toggle, and modal close buttons all use it. Splice it into a consumer's `StyleSheet.create` block.
+ *
+ * @param colors The active theme palette from `useTheme`. Only `surfaceRaised` and `borderHair` are read.
+ * @returns The icon-chip `ViewStyle`.
+ */
+export const iconChipStyle = (colors: { surfaceRaised: string; borderHair: string }): ViewStyle => ({
+    width: 36,
+    height: 36,
+    borderRadius: RADII.md,
+    overflow: "hidden",
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: colors.surfaceRaised,
+    borderWidth: 1,
+    borderColor: colors.borderHair,
+})

--- a/src/components/ui/modal-shell-styles.ts
+++ b/src/components/ui/modal-shell-styles.ts
@@ -3,7 +3,7 @@ import { StyleSheet } from "react-native"
 import { useTheme } from "../../context/ThemeContext"
 import { TYPE } from "../../lib/type"
 import { SPACING } from "../../lib/spacing"
-import { RADII } from "../../lib/radii"
+import { iconChipStyle } from "./icon-chip"
 
 /**
  * Style helpers shared by every SheetModal-based settings modal in the app. Returns the four canonical
@@ -18,17 +18,7 @@ export const useModalShellStyles = () => {
             StyleSheet.create({
                 modalHeaderRow: { flexDirection: "row", alignItems: "center", justifyContent: "space-between" },
                 modalTitleMono: { ...TYPE.monoLabel, color: colors.text, fontSize: 13, letterSpacing: 1.5 },
-                modalCloseChip: {
-                    width: 36,
-                    height: 36,
-                    borderRadius: RADII.md,
-                    overflow: "hidden",
-                    alignItems: "center",
-                    justifyContent: "center",
-                    backgroundColor: colors.surfaceRaised,
-                    borderWidth: 1,
-                    borderColor: colors.borderHair,
-                },
+                modalCloseChip: iconChipStyle(colors),
                 modalBodyList: { gap: SPACING.xs + 2 },
             }),
         [colors]

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -2,6 +2,14 @@ import * as SQLite from "expo-sqlite"
 import { startTiming } from "./performanceLogger"
 import { logWithTimestamp, logErrorWithTimestamp } from "./logger"
 
+/**
+ * Extracts a human-readable message from an unknown caught error.
+ *
+ * @param error The value caught in a catch block, which may or may not be an `Error`.
+ * @returns The `Error`'s message, or the value coerced to a string.
+ */
+const errorMessage = (error: unknown): string => (error instanceof Error ? error.message : String(error))
+
 // The schema for the database.
 export interface DatabaseSettings {
     /** The unique identifier for the setting. */
@@ -451,7 +459,7 @@ export class DatabaseManager {
             endTiming({ status: "success", category, key })
         } catch (error) {
             logErrorWithTimestamp(`[DB] Failed to save setting ${category}.${key}:`, error)
-            endTiming({ status: "error", category, key, error: error instanceof Error ? error.message : String(error) })
+            endTiming({ status: "error", category, key, error: errorMessage(error) })
             throw error
         }
     }
@@ -503,6 +511,21 @@ export class DatabaseManager {
     }
 
     /**
+     * Rolls back the active transaction, swallowing and logging any failure of the rollback itself.
+     *
+     * @param context Trailing context string appended to the rollback-failure log (e.g. the batch summary).
+     */
+    private async rollbackQuietly(context: string): Promise<void> {
+        try {
+            if (this.db && this.isTransactionActive) {
+                await this.db.runAsync("ROLLBACK")
+            }
+        } catch (rollbackError) {
+            logErrorWithTimestamp(`[DB] Failed to rollback transaction${context}:`, rollbackError)
+        }
+    }
+
+    /**
      * Save multiple settings in a single transaction for better performance.
      * @param settings - The settings to save.
      * @returns A promise that resolves when the settings are saved.
@@ -546,15 +569,9 @@ export class DatabaseManager {
             logErrorWithTimestamp(`[DB] Failed to save settings batch${settingsInfo}:`, error)
 
             // Rollback transaction on error.
-            try {
-                if (this.db && this.isTransactionActive) {
-                    await this.db.runAsync("ROLLBACK")
-                }
-            } catch (rollbackError) {
-                logErrorWithTimestamp(`[DB] Failed to rollback transaction${settingsInfo}:`, rollbackError)
-            }
+            await this.rollbackQuietly(settingsInfo)
 
-            endTiming({ status: "error", settingsCount: settings.length, error: error instanceof Error ? error.message : String(error) })
+            endTiming({ status: "error", settingsCount: settings.length, error: errorMessage(error) })
             throw error
         }
     }
@@ -582,7 +599,7 @@ export class DatabaseManager {
             return value
         } catch (error) {
             logErrorWithTimestamp(`[DB] Failed to load setting ${category}.${key}:`, error)
-            endTiming({ status: "error", category, key, error: error instanceof Error ? error.message : String(error) })
+            endTiming({ status: "error", category, key, error: errorMessage(error) })
             throw error
         }
     }
@@ -603,7 +620,7 @@ export class DatabaseManager {
             endTiming({ status: "success", category, key })
         } catch (error) {
             logErrorWithTimestamp(`[DB] Failed to delete setting ${category}.${key}:`, error)
-            endTiming({ status: "error", category, key, error: error instanceof Error ? error.message : String(error) })
+            endTiming({ status: "error", category, key, error: errorMessage(error) })
             throw error
         }
     }
@@ -632,7 +649,7 @@ export class DatabaseManager {
             return settings
         } catch (error) {
             logErrorWithTimestamp("[DB] Failed to load all settings:", error)
-            endTiming({ status: "error", error: error instanceof Error ? error.message : String(error) })
+            endTiming({ status: "error", error: errorMessage(error) })
             throw error
         }
     }
@@ -698,15 +715,9 @@ export class DatabaseManager {
             logErrorWithTimestamp(`[DB] Failed to save races batch${racesInfo}:`, error)
 
             // Rollback transaction on error.
-            try {
-                if (this.db && this.isTransactionActive) {
-                    await this.db.runAsync("ROLLBACK")
-                }
-            } catch (rollbackError) {
-                logErrorWithTimestamp(`[DB] Failed to rollback transaction${racesInfo}:`, rollbackError)
-            }
+            await this.rollbackQuietly(racesInfo)
 
-            endTiming({ status: "error", racesCount: races.length, error: error instanceof Error ? error.message : String(error) })
+            endTiming({ status: "error", racesCount: races.length, error: errorMessage(error) })
             throw error
         }
     }
@@ -726,7 +737,7 @@ export class DatabaseManager {
             endTiming({ status: "success" })
         } catch (error) {
             logErrorWithTimestamp("[DB] Failed to clear races:", error)
-            endTiming({ status: "error", error: error instanceof Error ? error.message : String(error) })
+            endTiming({ status: "error", error: errorMessage(error) })
             throw error
         }
     }
@@ -792,15 +803,9 @@ export class DatabaseManager {
             logErrorWithTimestamp(`[DB] Failed to save skills batch${skillsInfo}:\n`, error)
 
             // Rollback transaction on error.
-            try {
-                if (this.db && this.isTransactionActive) {
-                    await this.db.runAsync("ROLLBACK")
-                }
-            } catch (rollbackError) {
-                logErrorWithTimestamp(`[DB] Failed to rollback transaction${skillsInfo}:`, rollbackError)
-            }
+            await this.rollbackQuietly(skillsInfo)
 
-            endTiming({ status: "error", skillsCount: skills.length, error: error instanceof Error ? error.message : String(error) })
+            endTiming({ status: "error", skillsCount: skills.length, error: errorMessage(error) })
             throw error
         }
     }
@@ -820,7 +825,7 @@ export class DatabaseManager {
             endTiming({ status: "success" })
         } catch (error) {
             logErrorWithTimestamp("[DB] Failed to clear skills:", error)
-            endTiming({ status: "error", error: error instanceof Error ? error.message : String(error) })
+            endTiming({ status: "error", error: errorMessage(error) })
             throw error
         }
     }
@@ -860,7 +865,7 @@ export class DatabaseManager {
             return results
         } catch (error) {
             logErrorWithTimestamp("[DB] Failed to load all profiles:", error)
-            endTiming({ status: "error", error: error instanceof Error ? error.message : String(error) })
+            endTiming({ status: "error", error: errorMessage(error) })
             throw error
         }
     }
@@ -881,7 +886,7 @@ export class DatabaseManager {
             return result || null
         } catch (error) {
             logErrorWithTimestamp(`[DB] Failed to load profile ${id}:`, error)
-            endTiming({ status: "error", error: error instanceof Error ? error.message : String(error) })
+            endTiming({ status: "error", error: errorMessage(error) })
             throw error
         }
     }
@@ -947,7 +952,7 @@ export class DatabaseManager {
             }
         } catch (error) {
             logErrorWithTimestamp(`[DB] Failed to save profile ${profile.name}:`, error)
-            endTiming({ status: "error", profileName: profile.name, error: error instanceof Error ? error.message : String(error) })
+            endTiming({ status: "error", profileName: profile.name, error: errorMessage(error) })
             throw error
         }
     }
@@ -969,7 +974,7 @@ export class DatabaseManager {
             endTiming({ status: "success", profileId: id })
         } catch (error) {
             logErrorWithTimestamp(`[DB] Failed to delete profile ${id}:`, error)
-            endTiming({ status: "error", profileId: id, error: error instanceof Error ? error.message : String(error) })
+            endTiming({ status: "error", profileId: id, error: errorMessage(error) })
             throw error
         }
     }
@@ -988,7 +993,7 @@ export class DatabaseManager {
             return profileName || null
         } catch (error) {
             logErrorWithTimestamp("[DB] Failed to load current profile name:", error)
-            endTiming({ status: "error", error: error instanceof Error ? error.message : String(error) })
+            endTiming({ status: "error", error: errorMessage(error) })
             return null
         }
     }
@@ -1012,7 +1017,7 @@ export class DatabaseManager {
             endTiming({ status: "success", profileName })
         } catch (error) {
             logErrorWithTimestamp("[DB] Failed to save current profile name:", error)
-            endTiming({ status: "error", error: error instanceof Error ? error.message : String(error) })
+            endTiming({ status: "error", error: errorMessage(error) })
             throw error
         }
     }

--- a/src/lib/messageLog/buildSettingsBanner.ts
+++ b/src/lib/messageLog/buildSettingsBanner.ts
@@ -2,18 +2,29 @@ import { Settings } from "../../context/BotStateContext"
 import { SCORING_CONSTANTS_CATALOG } from "../training/scoringConstantsCatalog"
 
 /**
+ * Parse `raw` as JSON, returning `fallback` (and adopting its type) when `raw` is empty or malformed.
+ *
+ * @param raw Raw JSON string from a settings field.
+ * @param fallback Value returned on empty input or parse failure. Also fixes the return type.
+ * @returns The parsed value, or `fallback`.
+ */
+const safeJsonParse = <T>(raw: string, fallback: T): T => {
+    try {
+        return JSON.parse(raw || JSON.stringify(fallback)) as T
+    } catch {
+        return fallback
+    }
+}
+
+/**
  * Length of `json` parsed as either a JSON array or object. Returns 0 on parse failure or empty input.
  *
  * @param json Raw JSON string from a Smart Race Solver settings field.
  * @returns Number of array entries or object keys, or 0 if `json` is empty or malformed.
  */
 const safeJsonLength = (json: string): number => {
-    try {
-        const parsed = JSON.parse(json || "[]")
-        return Array.isArray(parsed) ? parsed.length : Object.keys(parsed).length
-    } catch {
-        return 0
-    }
+    const parsed = safeJsonParse<unknown[] | Record<string, unknown>>(json, [])
+    return Array.isArray(parsed) ? parsed.length : Object.keys(parsed).length
 }
 
 const csvCount = (csv: string): number => (csv ? csv.split(",").filter((s) => s.trim() !== "").length : 0)
@@ -48,6 +59,19 @@ const formatExcludedCategories = (plan: { excludeGreenSkills: boolean; excludeRe
 }
 
 /**
+ * Render an override-count summary line: "No X" when empty, otherwise "N X applied".
+ *
+ * @param overrides The override map whose key count is summarized.
+ * @param emptyLabel Phrase shown after "No " when there are no overrides.
+ * @param appliedNoun Noun phrase shown between the count and " applied".
+ * @returns The summary string for one override category.
+ */
+const formatOverrideCount = (overrides: Record<string, unknown>, emptyLabel: string, appliedNoun: string): string => {
+    const count = Object.keys(overrides).length
+    return count === 0 ? `No ${emptyLabel}` : `${count} ${appliedNoun} applied`
+}
+
+/**
  * Build the welcome / startup banner that summarizes the current bot configuration. Pure function of the
  * settings snapshot. The output is rendered at the top of the in-app message log and persisted to SQLite
  * so the Kotlin runtime (`SettingsHelper.getStringSetting`) can read the same string the user sees.
@@ -66,47 +90,19 @@ export function buildSettingsBanner(settings: Settings): string {
     const smartRaceSolverTargetCount = safeJsonLength(settings.racing.smartRaceSolverTargetEpithets)
     const smartRaceSolverForcedCount = safeJsonLength(settings.racing.smartRaceSolverForcedEpithets)
     const smartRaceSolverLockCount = safeJsonLength(settings.racing.smartRaceSolverManualLocks)
-    const smartRaceSolverWeightsObj = (() => {
-        try {
-            return JSON.parse(settings.racing.smartRaceSolverWeights || "{}") as Record<string, number | string | boolean>
-        } catch {
-            return {} as Record<string, number | string | boolean>
-        }
-    })()
+    const smartRaceSolverWeightsObj = safeJsonParse<Record<string, number | string | boolean>>(settings.racing.smartRaceSolverWeights, {})
     const smartRaceSolverFanWeight = typeof smartRaceSolverWeightsObj.fanWeight === "number" ? smartRaceSolverWeightsObj.fanWeight : 0
     const smartRaceSolverOptimizeMode = smartRaceSolverFanWeight > 0 ? "Fans + Epitaphs" : "Stat Epitaphs"
-    const smartRaceSolverAptitudesObj = (() => {
-        try {
-            return JSON.parse(settings.racing.smartRaceSolverAptitudes || "{}") as Record<string, string>
-        } catch {
-            return {} as Record<string, string>
-        }
-    })()
+    const smartRaceSolverAptitudesObj = safeJsonParse<Record<string, string>>(settings.racing.smartRaceSolverAptitudes, {})
 
     return `🏁 Campaign Selected: ${settings.general.scenario !== "" ? `${settings.general.scenario}` : "Please select one in the Select Campaign option"}
 👤 Profile Selected: ${settings.misc.currentProfileName ? `${settings.misc.currentProfileName}` : "Default Profile"}
 
 ---------- Training Event Options ----------
-🎭 Special Event Overrides: ${
-        Object.keys(settings.trainingEvent.specialEventOverrides).length === 0
-            ? "No Special Event Overrides"
-            : `${Object.keys(settings.trainingEvent.specialEventOverrides).length} Special Event Overrides applied`
-    }
-👤 Character Event Overrides: ${
-        Object.keys(settings.trainingEvent.characterEventOverrides).length === 0
-            ? "No Character Event Overrides"
-            : `${Object.keys(settings.trainingEvent.characterEventOverrides).length} Character Event Override(s) applied`
-    }
-💪 Support Event Overrides: ${
-        Object.keys(settings.trainingEvent.supportEventOverrides).length === 0
-            ? "No Support Event Overrides"
-            : `${Object.keys(settings.trainingEvent.supportEventOverrides).length} Support Event Override(s) applied`
-    }
-🎭 Scenario Event Overrides: ${
-        Object.keys(settings.trainingEvent.scenarioEventOverrides).length === 0
-            ? "No Scenario Event Overrides"
-            : `${Object.keys(settings.trainingEvent.scenarioEventOverrides).length} Scenario Event Override(s) applied`
-    }
+🎭 Special Event Overrides: ${formatOverrideCount(settings.trainingEvent.specialEventOverrides, "Special Event Overrides", "Special Event Overrides")}
+👤 Character Event Overrides: ${formatOverrideCount(settings.trainingEvent.characterEventOverrides, "Character Event Overrides", "Character Event Override(s)")}
+💪 Support Event Overrides: ${formatOverrideCount(settings.trainingEvent.supportEventOverrides, "Support Event Overrides", "Support Event Override(s)")}
+🎭 Scenario Event Overrides: ${formatOverrideCount(settings.trainingEvent.scenarioEventOverrides, "Scenario Event Overrides", "Scenario Event Override(s)")}
 🔋 Prioritize Energy Options: ${settings.trainingEvent.enablePrioritizeEnergyOptions ? "✅" : "❌"}
 🔍 Enable Automatic OCR retry: ${settings.trainingEvent.enableAutomaticOCRRetry ? "✅" : "❌"}
 🔍 Minimum OCR Confidence: ${settings.trainingEvent.ocrConfidence}

--- a/src/lib/settingsUtils.ts
+++ b/src/lib/settingsUtils.ts
@@ -106,6 +106,16 @@ export const applyMigrations = (settings: any, rawSettings?: any): { settings: a
     let anyMigrated = false
     let migratedSettings = settings
 
+    /**
+     * Marks that at least one migration ran and logs it under the shared SettingsManager prefix.
+     *
+     * @param message Human-readable description of the migration that was applied.
+     */
+    const markMigrated = (message: string): void => {
+        anyMigrated = true
+        logWithTimestamp(`[SettingsManager] ${message}`)
+    }
+
     // Migration: Move Training Event specific OCR settings to trainingEvent category.
     const ocr = (migratedSettings as any).ocr
     const debug = (migratedSettings as any).debug
@@ -113,29 +123,25 @@ export const applyMigrations = (settings: any, rawSettings?: any): { settings: a
     if (ocr?.ocrConfidence !== undefined) {
         migratedSettings.trainingEvent.ocrConfidence = ocr.ocrConfidence
         delete ocr.ocrConfidence
-        anyMigrated = true
-        logWithTimestamp("[SettingsManager] Migrated ocrConfidence to trainingEvent category.")
+        markMigrated("Migrated ocrConfidence to trainingEvent category.")
     }
 
     if (ocr?.enableAutomaticOCRRetry !== undefined) {
         migratedSettings.trainingEvent.enableAutomaticOCRRetry = ocr.enableAutomaticOCRRetry
         delete ocr.enableAutomaticOCRRetry
-        anyMigrated = true
-        logWithTimestamp("[SettingsManager] Migrated enableAutomaticOCRRetry to trainingEvent category.")
+        markMigrated("Migrated enableAutomaticOCRRetry to trainingEvent category.")
     }
 
     if (debug?.enableHideOCRComparisonResults !== undefined) {
         migratedSettings.trainingEvent.enableHideOCRComparisonResults = debug.enableHideOCRComparisonResults
         delete debug.enableHideOCRComparisonResults
-        anyMigrated = true
-        logWithTimestamp("[SettingsManager] Migrated enableHideOCRComparisonResults to trainingEvent category.")
+        markMigrated("Migrated enableHideOCRComparisonResults to trainingEvent category.")
     }
 
     if (ocr?.ocrThreshold !== undefined) {
         migratedSettings.debug.ocrThreshold = ocr.ocrThreshold
         delete ocr.ocrThreshold
-        anyMigrated = true
-        logWithTimestamp("[SettingsManager] Migrated ocrThreshold to debug category.")
+        markMigrated("Migrated ocrThreshold to debug category.")
     }
 
     // Migration: Move enableMessageIdDisplay and overlayButtonSizeDP from misc to debug category.
@@ -143,14 +149,12 @@ export const applyMigrations = (settings: any, rawSettings?: any): { settings: a
     if (misc?.enableMessageIdDisplay !== undefined) {
         migratedSettings.debug.enableMessageIdDisplay = misc.enableMessageIdDisplay
         delete misc.enableMessageIdDisplay
-        anyMigrated = true
-        logWithTimestamp("[SettingsManager] Migrated enableMessageIdDisplay to debug category.")
+        markMigrated("Migrated enableMessageIdDisplay to debug category.")
     }
     if (misc?.overlayButtonSizeDP !== undefined) {
         migratedSettings.debug.overlayButtonSizeDP = misc.overlayButtonSizeDP
         delete misc.overlayButtonSizeDP
-        anyMigrated = true
-        logWithTimestamp("[SettingsManager] Migrated overlayButtonSizeDP to debug category.")
+        markMigrated("Migrated overlayButtonSizeDP to debug category.")
     }
 
     // After moving all OCR settings, delete the empty ocr object.
@@ -166,13 +170,11 @@ export const applyMigrations = (settings: any, rawSettings?: any): { settings: a
     if (training && rawTraining) {
         if (rawTraining.eventChoiceStatPriority === undefined && Array.isArray(training.statPrioritization)) {
             training.eventChoiceStatPriority = [...training.statPrioritization]
-            anyMigrated = true
-            logWithTimestamp("[SettingsManager] Mirrored statPrioritization into eventChoiceStatPriority for upgrade.")
+            markMigrated("Mirrored statPrioritization into eventChoiceStatPriority for upgrade.")
         }
         if (rawTraining.summerTrainingStatPriority === undefined && Array.isArray(training.statPrioritization)) {
             training.summerTrainingStatPriority = [...training.statPrioritization]
-            anyMigrated = true
-            logWithTimestamp("[SettingsManager] Mirrored statPrioritization into summerTrainingStatPriority for upgrade.")
+            markMigrated("Mirrored statPrioritization into summerTrainingStatPriority for upgrade.")
         }
     }
 
@@ -181,23 +183,20 @@ export const applyMigrations = (settings: any, rawSettings?: any): { settings: a
     if (general?.stopAtDate !== undefined && typeof general.stopAtDate === "string") {
         migratedSettings.general.stopAtDates = [general.stopAtDate]
         delete general.stopAtDate
-        anyMigrated = true
-        logWithTimestamp("[SettingsManager] Migrated stopAtDate to stopAtDates array.")
+        markMigrated("Migrated stopAtDate to stopAtDates array.")
     }
 
     // Migration: Drop the removed enablePopupCheck setting.
     if (general?.enablePopupCheck !== undefined) {
         delete general.enablePopupCheck
-        anyMigrated = true
-        logWithTimestamp("[SettingsManager] Dropped removed setting enablePopupCheck.")
+        markMigrated("Dropped removed setting enablePopupCheck.")
     }
 
     // Migration: Rename the Crane Game setting to Claw Machine.
     if (general?.enableCraneGameAttempt !== undefined) {
         migratedSettings.general.enableClawMachineAttempt = general.enableCraneGameAttempt
         delete general.enableCraneGameAttempt
-        anyMigrated = true
-        logWithTimestamp("[SettingsManager] Migrated enableCraneGameAttempt to enableClawMachineAttempt.")
+        markMigrated("Migrated enableCraneGameAttempt to enableClawMachineAttempt.")
     }
 
     // Migration: Rename Trackblazer Charm and Item Floor settings to behavior-first names.
@@ -209,14 +208,12 @@ export const applyMigrations = (settings: any, rawSettings?: any): { settings: a
         if (rawScenarioOverrides.trackblazerMinStatGainForCharm !== undefined) {
             scenarioOverrides.trackblazerSkipRiskyCharmTrainingBelowGain = rawScenarioOverrides.trackblazerMinStatGainForCharm
             delete scenarioOverrides.trackblazerMinStatGainForCharm
-            anyMigrated = true
-            logWithTimestamp("[SettingsManager] Migrated trackblazerMinStatGainForCharm to trackblazerSkipRiskyCharmTrainingBelowGain.")
+            markMigrated("Migrated trackblazerMinStatGainForCharm to trackblazerSkipRiskyCharmTrainingBelowGain.")
         }
         if (rawScenarioOverrides.trackblazerLowMainStatGainItemFloor !== undefined) {
             scenarioOverrides.trackblazerSkipBadMoodItemsBelowGain = rawScenarioOverrides.trackblazerLowMainStatGainItemFloor
             delete scenarioOverrides.trackblazerLowMainStatGainItemFloor
-            anyMigrated = true
-            logWithTimestamp("[SettingsManager] Migrated trackblazerLowMainStatGainItemFloor to trackblazerSkipBadMoodItemsBelowGain.")
+            markMigrated("Migrated trackblazerLowMainStatGainItemFloor to trackblazerSkipBadMoodItemsBelowGain.")
         }
     }
 

--- a/src/lib/training/scoringConstantsCatalog.ts
+++ b/src/lib/training/scoringConstantsCatalog.ts
@@ -30,6 +30,26 @@ export interface ScoringConstantEntry {
 
 const D = DEFAULT_TRAINING_SCORING_CONSTANTS
 
+/** Per-bucket label and description for the 7 ratio multipliers, in ascending completion-percent order. */
+const RATIO_BUCKETS: ReadonlyArray<{ label: string; description: string }> = [
+    { label: "Multiplier: <15%", description: "Applied to a stat that is below 15% of its target. Highest tier because the stat is farthest from its goal." },
+    { label: "Multiplier: 15-30%", description: "Applied to a stat between 15% and 30% of its target." },
+    { label: "Multiplier: 30-45%", description: "Applied to a stat between 30% and 45% of its target." },
+    { label: "Multiplier: 45-60%", description: "Applied to a stat between 45% and 60% of its target." },
+    { label: "Multiplier: 60-75%", description: "Applied to a stat between 60% and 75% of its target." },
+    { label: "Multiplier: 75-90%", description: "Applied to a stat between 75% and 90% of its target." },
+    { label: "Multiplier: 90%+", description: "Applied to a stat at or above 90% of its target. Lowest tier because the stat is at or past its goal." },
+]
+
+/** Stat display name plus its `StatName` key for the 5 main-stat thresholds, in canonical stat order. */
+const MAIN_STAT_ROWS: ReadonlyArray<{ name: string; stat: StatName }> = [
+    { name: "Speed", stat: StatName.SPEED },
+    { name: "Stamina", stat: StatName.STAMINA },
+    { name: "Power", stat: StatName.POWER },
+    { name: "Guts", stat: StatName.GUTS },
+    { name: "Wit", stat: StatName.WIT },
+]
+
 /** Catalog driving the Advanced section's slider rows. Order within each group is the rendered order. */
 export const SCORING_CONSTANTS_CATALOG: ReadonlyArray<ScoringConstantEntry> = [
     // Priority group
@@ -45,83 +65,19 @@ export const SCORING_CONSTANTS_CATALOG: ReadonlyArray<ScoringConstantEntry> = [
     },
 
     // Ratio group: 7 user-tunable multipliers (one per completion-percent bucket; bucket boundaries are fixed at 15/30/45/60/75/90)
-    {
-        key: "ratioMultiplier1",
-        label: "Multiplier: <15%",
-        description: "Applied to a stat that is below 15% of its target. Highest tier because the stat is farthest from its goal.",
-        group: "ratio",
-        defaultValue: D.ratioMultipliers[0],
-        min: 0,
-        max: 10,
-        step: 0.1,
-        monotonicGroup: "ratio-multipliers",
-    },
-    {
-        key: "ratioMultiplier2",
-        label: "Multiplier: 15-30%",
-        description: "Applied to a stat between 15% and 30% of its target.",
-        group: "ratio",
-        defaultValue: D.ratioMultipliers[1],
-        min: 0,
-        max: 10,
-        step: 0.1,
-        monotonicGroup: "ratio-multipliers",
-    },
-    {
-        key: "ratioMultiplier3",
-        label: "Multiplier: 30-45%",
-        description: "Applied to a stat between 30% and 45% of its target.",
-        group: "ratio",
-        defaultValue: D.ratioMultipliers[2],
-        min: 0,
-        max: 10,
-        step: 0.1,
-        monotonicGroup: "ratio-multipliers",
-    },
-    {
-        key: "ratioMultiplier4",
-        label: "Multiplier: 45-60%",
-        description: "Applied to a stat between 45% and 60% of its target.",
-        group: "ratio",
-        defaultValue: D.ratioMultipliers[3],
-        min: 0,
-        max: 10,
-        step: 0.1,
-        monotonicGroup: "ratio-multipliers",
-    },
-    {
-        key: "ratioMultiplier5",
-        label: "Multiplier: 60-75%",
-        description: "Applied to a stat between 60% and 75% of its target.",
-        group: "ratio",
-        defaultValue: D.ratioMultipliers[4],
-        min: 0,
-        max: 10,
-        step: 0.1,
-        monotonicGroup: "ratio-multipliers",
-    },
-    {
-        key: "ratioMultiplier6",
-        label: "Multiplier: 75-90%",
-        description: "Applied to a stat between 75% and 90% of its target.",
-        group: "ratio",
-        defaultValue: D.ratioMultipliers[5],
-        min: 0,
-        max: 10,
-        step: 0.1,
-        monotonicGroup: "ratio-multipliers",
-    },
-    {
-        key: "ratioMultiplier7",
-        label: "Multiplier: 90%+",
-        description: "Applied to a stat at or above 90% of its target. Lowest tier because the stat is at or past its goal.",
-        group: "ratio",
-        defaultValue: D.ratioMultipliers[6],
-        min: 0,
-        max: 10,
-        step: 0.1,
-        monotonicGroup: "ratio-multipliers",
-    },
+    ...RATIO_BUCKETS.map(
+        (bucket, index): ScoringConstantEntry => ({
+            key: `ratioMultiplier${index + 1}`,
+            label: bucket.label,
+            description: bucket.description,
+            group: "ratio",
+            defaultValue: D.ratioMultipliers[index],
+            min: 0,
+            max: 10,
+            step: 0.1,
+            monotonicGroup: "ratio-multipliers",
+        })
+    ),
 
     // Weight group (composition of the final score)
     {
@@ -156,56 +112,18 @@ export const SCORING_CONSTANTS_CATALOG: ReadonlyArray<ScoringConstantEntry> = [
     },
 
     // Bonuses group
-    {
-        key: "mainStatThresholdSpeed",
-        label: "Main-stat threshold (Speed)",
-        description: "Minimum Speed gain that triggers the main-stat bonus on Speed training.",
-        group: "bonuses",
-        defaultValue: D.mainStatThresholds[StatName.SPEED],
-        min: 5,
-        max: 60,
-        step: 1,
-    },
-    {
-        key: "mainStatThresholdStamina",
-        label: "Main-stat threshold (Stamina)",
-        description: "Minimum Stamina gain that triggers the main-stat bonus on Stamina training.",
-        group: "bonuses",
-        defaultValue: D.mainStatThresholds[StatName.STAMINA],
-        min: 5,
-        max: 60,
-        step: 1,
-    },
-    {
-        key: "mainStatThresholdPower",
-        label: "Main-stat threshold (Power)",
-        description: "Minimum Power gain that triggers the main-stat bonus on Power training.",
-        group: "bonuses",
-        defaultValue: D.mainStatThresholds[StatName.POWER],
-        min: 5,
-        max: 60,
-        step: 1,
-    },
-    {
-        key: "mainStatThresholdGuts",
-        label: "Main-stat threshold (Guts)",
-        description: "Minimum Guts gain that triggers the main-stat bonus on Guts training.",
-        group: "bonuses",
-        defaultValue: D.mainStatThresholds[StatName.GUTS],
-        min: 5,
-        max: 60,
-        step: 1,
-    },
-    {
-        key: "mainStatThresholdWit",
-        label: "Main-stat threshold (Wit)",
-        description: "Minimum Wit gain that triggers the main-stat bonus on Wit training.",
-        group: "bonuses",
-        defaultValue: D.mainStatThresholds[StatName.WIT],
-        min: 5,
-        max: 60,
-        step: 1,
-    },
+    ...MAIN_STAT_ROWS.map(
+        ({ name, stat }): ScoringConstantEntry => ({
+            key: `mainStatThreshold${name}`,
+            label: `Main-stat threshold (${name})`,
+            description: `Minimum ${name} gain that triggers the main-stat bonus on ${name} training.`,
+            group: "bonuses",
+            defaultValue: D.mainStatThresholds[stat],
+            min: 5,
+            max: 60,
+            step: 1,
+        })
+    ),
     {
         key: "mainStatBonusMagnitude",
         label: "Main-stat bonus magnitude",

--- a/src/pages/DebugSettings/index.tsx
+++ b/src/pages/DebugSettings/index.tsx
@@ -8,6 +8,7 @@ import CustomSlider from "../../components/CustomSlider"
 import PageHeader from "../../components/PageHeader"
 import WarningContainer from "../../components/WarningContainer"
 import SearchableItem from "../../components/SearchableItem"
+import ToggleSetting from "../../components/ToggleSetting"
 import SystemChecksWizard from "../../components/SystemChecksWizard"
 import { SearchPageProvider } from "../../context/SearchPageContext"
 import { usePerformanceLogging } from "../../hooks/usePerformanceLogging"
@@ -206,13 +207,7 @@ const DebugSettings = () => {
                             //////////////////////////////////////////////////////////////////////////////////////////////////
                             Debug Mode */}
                         <Section label="Debug Mode">
-                            <SearchableItem id="enable-debug-mode" title="Enable Debug Mode" description="Allows debugging messages in the log and test images to be created in the /temp/ folder.">
-                                <Row
-                                    title="Enable Debug Mode"
-                                    description="Allows debugging messages in the log and test images to be created in the /temp/ folder."
-                                    right={<Switch checked={debug.enableDebugMode} onCheckedChange={(checked) => updateDebug({ enableDebugMode: checked })} />}
-                                />
-                            </SearchableItem>
+                            <ToggleSetting id="enable-debug-mode" title="Enable Debug Mode" description="Allows debugging messages in the log and test images to be created in the /temp/ folder." checked={debug.enableDebugMode} onCheckedChange={(checked) => updateDebug({ enableDebugMode: checked })} />
                         </Section>
                         {debug.enableDebugMode && (
                             <WarningContainer style={{ marginTop: 0, marginBottom: SPACING.md }}>
@@ -345,17 +340,7 @@ const DebugSettings = () => {
                             <View style={{ padding: SPACING.md, paddingBottom: 0 }}>
                                 <Text style={[TYPE.caption, { color: colors.textMuted }]}>Configure the quality settings for screen recording.</Text>
                             </View>
-                            <SearchableItem
-                                id="enable-screen-recording"
-                                title="Enable Screen Recording"
-                                description="Records the screen while the bot is running. The mp4 file will be saved to the /recordings folder of the app's data directory. Note that performance and battery life may be impacted while recording."
-                            >
-                                <Row
-                                    title="Enable Screen Recording"
-                                    description="Records the screen while the bot is running. The mp4 file will be saved to the /recordings folder of the app's data directory. Note that performance and battery life may be impacted while recording."
-                                    right={<Switch checked={debug.enableScreenRecording} onCheckedChange={(checked) => updateDebug({ enableScreenRecording: checked })} />}
-                                />
-                            </SearchableItem>
+                            <ToggleSetting id="enable-screen-recording" title="Enable Screen Recording" description="Records the screen while the bot is running. The mp4 file will be saved to the /recordings folder of the app's data directory. Note that performance and battery life may be impacted while recording." checked={debug.enableScreenRecording} onCheckedChange={(checked) => updateDebug({ enableScreenRecording: checked })} />
                             <View style={{ paddingHorizontal: SPACING.md }}>
                                 <CustomSlider
                                     searchId="recording-bit-rate"
@@ -438,13 +423,7 @@ const DebugSettings = () => {
                                 />
                             </View>
 
-                            <SearchableItem id="settings-enable-message-id-display" title="Enable Message ID Display" description="Shows message IDs in the message log to help with debugging.">
-                                <Row
-                                    title="Enable Message ID Display"
-                                    description="Shows message IDs in the message log to help with debugging."
-                                    right={<Switch checked={debug.enableMessageIdDisplay} onCheckedChange={(checked) => updateDebug({ enableMessageIdDisplay: checked })} />}
-                                />
-                            </SearchableItem>
+                            <ToggleSetting id="settings-enable-message-id-display" title="Enable Message ID Display" description="Shows message IDs in the message log to help with debugging." checked={debug.enableMessageIdDisplay} onCheckedChange={(checked) => updateDebug({ enableMessageIdDisplay: checked })} />
                         </Section>
 
                         {/* //////////////////////////////////////////////////////////////////////////////////////////////////
@@ -463,13 +442,7 @@ const DebugSettings = () => {
                                 </View>
                                 {DEBUG_TESTS.map((test, idx) => (
                                     <View key={test.key}>
-                                        <SearchableItem id={test.searchId} title={test.title} description={test.description}>
-                                            <Row
-                                                title={test.title}
-                                                description={test.description}
-                                                right={<Switch checked={!!debug[test.key]} onCheckedChange={(checked) => handleDebugTestToggle(test.key, checked)} />}
-                                            />
-                                        </SearchableItem>
+                                        <ToggleSetting id={test.searchId} title={test.title} description={test.description} checked={!!debug[test.key]} onCheckedChange={(checked) => handleDebugTestToggle(test.key, checked)} />
                                         {idx < DEBUG_TESTS.length - 1 && <View style={{ height: 1, backgroundColor: colors.borderHair, marginLeft: SPACING.lg }} />}
                                     </View>
                                 ))}

--- a/src/pages/RacingSettings/index.tsx
+++ b/src/pages/RacingSettings/index.tsx
@@ -12,11 +12,11 @@ import PageHeader from "../../components/PageHeader"
 import InfoContainer from "../../components/InfoContainer"
 import WarningContainer from "../../components/WarningContainer"
 import SearchableItem from "../../components/SearchableItem"
+import ToggleSetting from "../../components/ToggleSetting"
 import { usePerformanceLogging } from "../../hooks/usePerformanceLogging"
 import { Row } from "../../components/ui/row"
 import { Section } from "../../components/ui/section"
 import { SectionLabel } from "../../components/ui/section-label"
-import { Switch } from "../../components/ui/switch"
 import { GlassSurface } from "../../components/ui/glass-surface"
 import { SheetModal } from "../../components/ui/sheet-modal"
 import { ModalRadioRow } from "../../components/ui/modal-list"
@@ -181,13 +181,7 @@ const RacingSettings = () => {
                             //////////////////////////////////////////////////////////////////////////////////////////////////
                             Race Behavior */}
                         <Section label="Race Behavior">
-                            <SearchableItem id="enable-farming-fans" title="Enable Farming Fans" description="When enabled, the bot will start running extra races to gain fans.">
-                                <Row
-                                    title="Enable Farming Fans"
-                                    description="When enabled, the bot will start running extra races to gain fans."
-                                    right={<Switch checked={enableFarmingFans} onCheckedChange={(checked) => updateRacingSetting("enableFarmingFans", checked)} />}
-                                />
-                            </SearchableItem>
+                            <ToggleSetting id="enable-farming-fans" title="Enable Farming Fans" description="When enabled, the bot will start running extra races to gain fans." checked={enableFarmingFans} onCheckedChange={(checked) => updateRacingSetting("enableFarmingFans", checked)} />
                             <View style={{ padding: SPACING.md }}>
                                 <CustomSlider
                                     searchId="days-to-run-extra-races"
@@ -203,81 +197,13 @@ const RacingSettings = () => {
                                     description="Extra races are eligible only on days where current day % value == 0. For example, 5 means days 5, 10, 15, etc. Has no effect when Smart Race Solver is enabled."
                                 />
                             </View>
-                            <SearchableItem
-                                id="ignore-consecutive-race-warning"
-                                title="Ignore Consecutive Race Warning"
-                                description="When enabled, the bot will ignore the warning popup about consecutive races and continue racing."
-                            >
-                                <Row
-                                    title="Ignore Consecutive Race Warning"
-                                    description="When enabled, the bot will ignore the warning popup about consecutive races and continue racing."
-                                    right={<Switch checked={ignoreConsecutiveRaceWarning} onCheckedChange={(checked) => updateRacingSetting("ignoreConsecutiveRaceWarning", checked)} />}
-                                />
-                            </SearchableItem>
-                            <SearchableItem
-                                id="ignore-low-energy-racing-block"
-                                title="Ignore Low Energy Racing Block"
-                                description="When enabled, the Trackblazer bot will not block racing when energy is critically low (<=1%) with 3+ consecutive races."
-                            >
-                                <Row
-                                    title="Ignore Low Energy Racing Block"
-                                    description="When enabled, the Trackblazer bot will not block racing when energy is critically low (<=1%) with 3+ consecutive races."
-                                    right={<Switch checked={ignoreLowEnergyRacingBlock} onCheckedChange={(checked) => updateRacingSetting("ignoreLowEnergyRacingBlock", checked)} />}
-                                />
-                            </SearchableItem>
-                            <SearchableItem id="disable-race-retries" title="Disable Race Retries" description="When enabled, the bot will not retry mandatory races if they fail and will stop.">
-                                <Row
-                                    title="Disable Race Retries"
-                                    description="When enabled, the bot will not retry mandatory races if they fail and will stop."
-                                    right={<Switch checked={disableRaceRetries} onCheckedChange={(checked) => updateRacingSetting("disableRaceRetries", checked)} />}
-                                />
-                            </SearchableItem>
-                            <SearchableItem
-                                id="enable-free-race-retry"
-                                title="Allow Daily Free Race Retry"
-                                description="When enabled, the bot will attempt to retry a failed mandatory race only if the daily free race retry is available."
-                                condition={disableRaceRetries}
-                                parentId="disable-race-retries"
-                            >
-                                <Row
-                                    title="Allow Daily Free Race Retry"
-                                    description="When enabled, the bot will attempt to retry a failed mandatory race only if the daily free race retry is available."
-                                    right={<Switch checked={enableFreeRaceRetry} onCheckedChange={(checked) => updateRacingSetting("enableFreeRaceRetry", checked)} />}
-                                />
-                            </SearchableItem>
-                            <SearchableItem
-                                id="enable-complete-career-on-failure"
-                                title="Complete Career on Failure"
-                                description="When enabled, the bot will proceed to the career completion screen when a mandatory race fails and retries are exhausted."
-                            >
-                                <Row
-                                    title="Complete Career on Failure"
-                                    description="When enabled, the bot will proceed to the career completion screen when a mandatory race fails and retries are exhausted."
-                                    right={<Switch checked={enableCompleteCareerOnFailure} onCheckedChange={(checked) => updateRacingSetting("enableCompleteCareerOnFailure", checked)} />}
-                                />
-                            </SearchableItem>
-                            <SearchableItem
-                                id="enable-stop-on-mandatory-races"
-                                title="Stop on Mandatory Races"
-                                description="When enabled, the bot will automatically stop when it encounters a mandatory race, allowing you to manually handle them."
-                            >
-                                <Row
-                                    title="Stop on Mandatory Races"
-                                    description="When enabled, the bot will automatically stop when it encounters a mandatory race, allowing you to manually handle them."
-                                    right={<Switch checked={enableStopOnMandatoryRaces} onCheckedChange={(checked) => updateRacingSetting("enableStopOnMandatoryRaces", checked)} />}
-                                />
-                            </SearchableItem>
-                            <SearchableItem
-                                id="enable-force-racing"
-                                title="Force Racing"
-                                description="When enabled, the bot will skip all training, rest, and mood recovery activities and focus exclusively on racing every day."
-                            >
-                                <Row
-                                    title="Force Racing"
-                                    description="When enabled, the bot will skip all training, rest, and mood recovery activities and focus exclusively on racing every day."
-                                    right={<Switch checked={enableForceRacing} onCheckedChange={(checked) => updateRacingSetting("enableForceRacing", checked)} />}
-                                />
-                            </SearchableItem>
+                            <ToggleSetting id="ignore-consecutive-race-warning" title="Ignore Consecutive Race Warning" description="When enabled, the bot will ignore the warning popup about consecutive races and continue racing." checked={ignoreConsecutiveRaceWarning} onCheckedChange={(checked) => updateRacingSetting("ignoreConsecutiveRaceWarning", checked)} />
+                            <ToggleSetting id="ignore-low-energy-racing-block" title="Ignore Low Energy Racing Block" description="When enabled, the Trackblazer bot will not block racing when energy is critically low (<=1%) with 3+ consecutive races." checked={ignoreLowEnergyRacingBlock} onCheckedChange={(checked) => updateRacingSetting("ignoreLowEnergyRacingBlock", checked)} />
+                            <ToggleSetting id="disable-race-retries" title="Disable Race Retries" description="When enabled, the bot will not retry mandatory races if they fail and will stop." checked={disableRaceRetries} onCheckedChange={(checked) => updateRacingSetting("disableRaceRetries", checked)} />
+                            <ToggleSetting id="enable-free-race-retry" title="Allow Daily Free Race Retry" description="When enabled, the bot will attempt to retry a failed mandatory race only if the daily free race retry is available." condition={disableRaceRetries} parentId="disable-race-retries" checked={enableFreeRaceRetry} onCheckedChange={(checked) => updateRacingSetting("enableFreeRaceRetry", checked)} />
+                            <ToggleSetting id="enable-complete-career-on-failure" title="Complete Career on Failure" description="When enabled, the bot will proceed to the career completion screen when a mandatory race fails and retries are exhausted." checked={enableCompleteCareerOnFailure} onCheckedChange={(checked) => updateRacingSetting("enableCompleteCareerOnFailure", checked)} />
+                            <ToggleSetting id="enable-stop-on-mandatory-races" title="Stop on Mandatory Races" description="When enabled, the bot will automatically stop when it encounters a mandatory race, allowing you to manually handle them." checked={enableStopOnMandatoryRaces} onCheckedChange={(checked) => updateRacingSetting("enableStopOnMandatoryRaces", checked)} />
+                            <ToggleSetting id="enable-force-racing" title="Force Racing" description="When enabled, the bot will skip all training, rest, and mood recovery activities and focus exclusively on racing every day." checked={enableForceRacing} onCheckedChange={(checked) => updateRacingSetting("enableForceRacing", checked)} />
                             {enableForceRacing && <WarningContainer>Warning: Enabling this will override all other racing settings and they will be ignored.</WarningContainer>}
                         </Section>
 
@@ -285,17 +211,7 @@ const RacingSettings = () => {
                             //////////////////////////////////////////////////////////////////////////////////////////////////
                             Strategy */}
                         <Section label="Strategy">
-                            <SearchableItem
-                                id="enable-per-distance-strategy"
-                                title="Per-Distance Strategy"
-                                description="When enabled, allows setting different race strategies for each track distance."
-                            >
-                                <Row
-                                    title="Per-Distance Strategy"
-                                    description="When enabled, allows setting different race strategies for each track distance."
-                                    right={<Switch checked={enablePerDistanceStrategy} onCheckedChange={(checked) => updateRacingSetting("enablePerDistanceStrategy", checked)} />}
-                                />
-                            </SearchableItem>
+                            <ToggleSetting id="enable-per-distance-strategy" title="Per-Distance Strategy" description="When enabled, allows setting different race strategies for each track distance." checked={enablePerDistanceStrategy} onCheckedChange={(checked) => updateRacingSetting("enablePerDistanceStrategy", checked)} />
 
                             {!enablePerDistanceStrategy ? (
                                 <>
@@ -381,17 +297,7 @@ const RacingSettings = () => {
                             //////////////////////////////////////////////////////////////////////////////////////////////////
                             In-Game Race Agenda */}
                         <Section label="In-Game Race Agenda">
-                            <SearchableItem
-                                id="enable-user-in-game-race-agenda"
-                                title="Enable User In-Game Race Agenda"
-                                description="When enabled, the bot will load your selected in-game race agenda instead of using the racing plan settings. Note that this will disable the farming fans and racing plan settings."
-                            >
-                                <Row
-                                    title="Enable User In-Game Race Agenda"
-                                    description="When enabled, the bot will load your selected in-game race agenda instead of using the racing plan settings. Note that this will disable the farming fans and racing plan settings."
-                                    right={<Switch checked={enableUserInGameRaceAgenda} onCheckedChange={(checked) => updateRacingSetting("enableUserInGameRaceAgenda", checked)} />}
-                                />
-                            </SearchableItem>
+                            <ToggleSetting id="enable-user-in-game-race-agenda" title="Enable User In-Game Race Agenda" description="When enabled, the bot will load your selected in-game race agenda instead of using the racing plan settings. Note that this will disable the farming fans and racing plan settings." checked={enableUserInGameRaceAgenda} onCheckedChange={(checked) => updateRacingSetting("enableUserInGameRaceAgenda", checked)} />
                             {enableUserInGameRaceAgenda && (
                                 <>
                                     <InfoContainer style={{ marginHorizontal: SPACING.md }}>
@@ -448,30 +354,8 @@ const RacingSettings = () => {
                                             />
                                         </View>
                                     </SearchableItem>
-                                    <SearchableItem
-                                        id="limit-races-to-in-game-agenda"
-                                        title="Limit Extra Races to Agenda"
-                                        description="When enabled, the bot will override the racing behavior of any scenario such that it will not run any extra races except for the ones scheduled by the selected user's in-game racing agenda."
-                                        parentId="enable-user-in-game-race-agenda"
-                                    >
-                                        <Row
-                                            title="Limit Extra Races to Agenda"
-                                            description="When enabled, the bot will override the racing behavior of any scenario such that it will not run any extra races except for the ones scheduled by the selected user's in-game racing agenda."
-                                            right={<Switch checked={limitRacesToInGameAgenda} onCheckedChange={(checked) => updateRacingSetting("limitRacesToInGameAgenda", checked)} />}
-                                        />
-                                    </SearchableItem>
-                                    <SearchableItem
-                                        id="skip-summer-training-for-agenda"
-                                        title="Skip Summer Training for Agenda"
-                                        description="When enabled, the bot will perform scheduled races from the in-game racing agenda during Summer instead of prioritizing Summer training. Note that this requires 'Enable User In-Game Race Agenda' to be enabled."
-                                        parentId="enable-user-in-game-race-agenda"
-                                    >
-                                        <Row
-                                            title="Skip Summer Training for Agenda"
-                                            description="When enabled, the bot will perform scheduled races from the in-game racing agenda during Summer instead of prioritizing Summer training. Note that this requires 'Enable User In-Game Race Agenda' to be enabled."
-                                            right={<Switch checked={skipSummerTrainingForAgenda} onCheckedChange={(checked) => updateRacingSetting("skipSummerTrainingForAgenda", checked)} />}
-                                        />
-                                    </SearchableItem>
+                                    <ToggleSetting id="limit-races-to-in-game-agenda" title="Limit Extra Races to Agenda" description="When enabled, the bot will override the racing behavior of any scenario such that it will not run any extra races except for the ones scheduled by the selected user's in-game racing agenda." parentId="enable-user-in-game-race-agenda" checked={limitRacesToInGameAgenda} onCheckedChange={(checked) => updateRacingSetting("limitRacesToInGameAgenda", checked)} />
+                                    <ToggleSetting id="skip-summer-training-for-agenda" title="Skip Summer Training for Agenda" description="When enabled, the bot will perform scheduled races from the in-game racing agenda during Summer instead of prioritizing Summer training. Note that this requires 'Enable User In-Game Race Agenda' to be enabled." parentId="enable-user-in-game-race-agenda" checked={skipSummerTrainingForAgenda} onCheckedChange={(checked) => updateRacingSetting("skipSummerTrainingForAgenda", checked)} />
                                 </>
                             )}
                         </Section>

--- a/src/pages/ScenarioOverridesSettings/index.tsx
+++ b/src/pages/ScenarioOverridesSettings/index.tsx
@@ -9,12 +9,10 @@ import CustomSlider from "../../components/CustomSlider"
 import CustomButton from "../../components/CustomButton"
 import PageHeader from "../../components/PageHeader"
 import { Input } from "../../components/ui/input"
-import { Row } from "../../components/ui/row"
-import { Switch } from "../../components/ui/switch"
 import { SheetModal } from "../../components/ui/sheet-modal"
 import { ModalRadioRow } from "../../components/ui/modal-list"
 import { useModalShellStyles } from "../../components/ui/modal-shell-styles"
-import SearchableItem from "../../components/SearchableItem"
+import ToggleSetting from "../../components/ToggleSetting"
 import { CircleCheckBig, Trash2 } from "lucide-react-native"
 import { usePerformanceLogging } from "../../hooks/usePerformanceLogging"
 import trackblazerIcons from "./icons"
@@ -500,22 +498,7 @@ const ScenarioOverridesSettings = () => {
                                         />
                                     </View>
 
-                                    <SearchableItem
-                                        id="trackblazer-enable-irregular-training"
-                                        title="Enable Irregular Training"
-                                        description="When enabled, the bot will occasionally check for highly profitable training sessions before opting for extra races."
-                                    >
-                                        <Row
-                                            title="Enable Irregular Training"
-                                            description="When enabled, the bot will occasionally check for highly profitable training sessions before opting for extra races."
-                                            right={
-                                                <Switch
-                                                    checked={scenarioOverrides.trackblazerEnableIrregularTraining}
-                                                    onCheckedChange={(checked) => updateOverrideSetting("trackblazerEnableIrregularTraining", checked)}
-                                                />
-                                            }
-                                        />
-                                    </SearchableItem>
+                                    <ToggleSetting id="trackblazer-enable-irregular-training" title="Enable Irregular Training" description="When enabled, the bot will occasionally check for highly profitable training sessions before opting for extra races." checked={scenarioOverrides.trackblazerEnableIrregularTraining} onCheckedChange={(checked) => updateOverrideSetting("trackblazerEnableIrregularTraining", checked)} />
 
                                     {scenarioOverrides.trackblazerEnableIrregularTraining && (
                                         <View style={{ padding: SPACING.md }}>
@@ -539,22 +522,7 @@ const ScenarioOverridesSettings = () => {
                                         </View>
                                     )}
 
-                                    <SearchableItem
-                                        id="trackblazer-whistle-forces-training"
-                                        title="Reset Whistle Forces Training"
-                                        description="Whether or not using a Reset Whistle means it can ignore the failure chance thresholds in the Training Settings page. If enabled, the bot will pick the best available training after usage even if it's risky."
-                                    >
-                                        <Row
-                                            title="Reset Whistle Forces Training"
-                                            description="Whether or not using a Reset Whistle means it can ignore the failure chance thresholds in the Training Settings page. If enabled, the bot will pick the best available training after usage even if it's risky."
-                                            right={
-                                                <Switch
-                                                    checked={scenarioOverrides.trackblazerWhistleForcesTraining}
-                                                    onCheckedChange={(checked) => updateOverrideSetting("trackblazerWhistleForcesTraining", checked)}
-                                                />
-                                            }
-                                        />
-                                    </SearchableItem>
+                                    <ToggleSetting id="trackblazer-whistle-forces-training" title="Reset Whistle Forces Training" description="Whether or not using a Reset Whistle means it can ignore the failure chance thresholds in the Training Settings page. If enabled, the bot will pick the best available training after usage even if it's risky." checked={scenarioOverrides.trackblazerWhistleForcesTraining} onCheckedChange={(checked) => updateOverrideSetting("trackblazerWhistleForcesTraining", checked)} />
                                 </Section>
 
                                 {/* Shop & Items */}

--- a/src/pages/Settings/index.tsx
+++ b/src/pages/Settings/index.tsx
@@ -13,10 +13,10 @@ import CustomButton from "../../components/CustomButton"
 import PageHeader from "../../components/PageHeader"
 import { Row } from "../../components/ui/row"
 import { Section } from "../../components/ui/section"
-import { Switch } from "../../components/ui/switch"
 import WarningContainer from "../../components/WarningContainer"
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from "../../components/ui/alert-dialog"
 import SearchableItem from "../../components/SearchableItem"
+import ToggleSetting from "../../components/ToggleSetting"
 import { useSettings } from "../../context/SettingsContext"
 import { useSettingsFileManager } from "../../hooks/useSettingsFileManager"
 import { usePerformanceLogging } from "../../hooks/usePerformanceLogging"
@@ -227,21 +227,9 @@ const Settings = () => {
         return (
             <View>
                 <Section label="MISC">
-                    <SearchableItem id="settings-stop-before-finals" title="Stop before Finals" description="Pause to buy skills before the final races">
-                        <Row
-                            title="Stop before Finals"
-                            description="Pause to buy skills before the final races"
-                            right={<Switch checked={general.enableStopBeforeFinals} onCheckedChange={(checked) => updateGeneral({ enableStopBeforeFinals: checked })} />}
-                        />
-                    </SearchableItem>
+                    <ToggleSetting id="settings-stop-before-finals" title="Stop before Finals" description="Pause to buy skills before the final races" checked={general.enableStopBeforeFinals} onCheckedChange={(checked) => updateGeneral({ enableStopBeforeFinals: checked })} />
 
-                    <SearchableItem id="settings-stop-at-date" title="Stop at Date" description="Stop on one or more specified dates">
-                        <Row
-                            title="Stop at Date"
-                            description="Stop on one or more specified dates"
-                            right={<Switch checked={general.enableStopAtDate} onCheckedChange={(checked) => updateGeneral({ enableStopAtDate: checked })} />}
-                        />
-                    </SearchableItem>
+                    <ToggleSetting id="settings-stop-at-date" title="Stop at Date" description="Stop on one or more specified dates" checked={general.enableStopAtDate} onCheckedChange={(checked) => updateGeneral({ enableStopAtDate: checked })} />
 
                     {general.enableStopAtDate && (
                         <SearchableItem id="settings-target-dates" title="Target Dates" description="Stops the bot on the specified dates." parentId="settings-stop-at-date">
@@ -314,33 +302,11 @@ const Settings = () => {
                         </SearchableItem>
                     )}
 
-                    <SearchableItem id="settings-claw-machine-attempt" title="Enable Claw Machine Attempt" description="Attempt to complete the claw machine instead of stopping">
-                        <Row
-                            title="Enable Claw Machine Attempt"
-                            description="Attempt to complete the claw machine instead of stopping"
-                            right={<Switch checked={general.enableClawMachineAttempt} onCheckedChange={(checked) => updateGeneral({ enableClawMachineAttempt: checked })} />}
-                        />
-                    </SearchableItem>
+                    <ToggleSetting id="settings-claw-machine-attempt" title="Enable Claw Machine Attempt" description="Attempt to complete the claw machine instead of stopping" checked={general.enableClawMachineAttempt} onCheckedChange={(checked) => updateGeneral({ enableClawMachineAttempt: checked })} />
 
-                    <SearchableItem
-                        id="settings-enable-swipe-based-scrolling"
-                        title="Enable Swipe-Based Scrolling"
-                        description="Scroll lists by swiping instead of detecting the in-game scrollbar. Enable this if the bot cannot scroll lists normally. This may or may not work depending on the device."
-                    >
-                        <Row
-                            title="Enable Swipe-Based Scrolling"
-                            description="Scroll lists by swiping instead of detecting the in-game scrollbar. Enable this if the bot cannot scroll lists normally. This may or may not work depending on the device."
-                            right={<Switch checked={general.enableSwipeBasedScrolling} onCheckedChange={(checked) => updateGeneral({ enableSwipeBasedScrolling: checked })} />}
-                        />
-                    </SearchableItem>
+                    <ToggleSetting id="settings-enable-swipe-based-scrolling" title="Enable Swipe-Based Scrolling" description="Scroll lists by swiping instead of detecting the in-game scrollbar. Enable this if the bot cannot scroll lists normally. This may or may not work depending on the device." checked={general.enableSwipeBasedScrolling} onCheckedChange={(checked) => updateGeneral({ enableSwipeBasedScrolling: checked })} />
 
-                    <SearchableItem id="settings-enable-settings-display" title="Enable Settings Display in Message Log" description="Show current bot configuration in the message log">
-                        <Row
-                            title="Enable Settings Display in Message Log"
-                            description="Show current bot configuration in the message log"
-                            right={<Switch checked={misc.enableSettingsDisplay} onCheckedChange={(checked) => updateMisc({ enableSettingsDisplay: checked })} />}
-                        />
-                    </SearchableItem>
+                    <ToggleSetting id="settings-enable-settings-display" title="Enable Settings Display in Message Log" description="Show current bot configuration in the message log" checked={misc.enableSettingsDisplay} onCheckedChange={(checked) => updateMisc({ enableSettingsDisplay: checked })} />
                 </Section>
 
                 <Section label="WAIT DELAY">

--- a/src/pages/SmartRaceSolverSettings/index.tsx
+++ b/src/pages/SmartRaceSolverSettings/index.tsx
@@ -45,6 +45,7 @@ import characterPresetsData from "../../data/characterPresets.json"
 import PageHeader from "../../components/PageHeader"
 import { usePerformanceLogging } from "../../hooks/usePerformanceLogging"
 import SearchableItem from "../../components/SearchableItem"
+import ToggleSetting from "../../components/ToggleSetting"
 import CustomSlider from "../../components/CustomSlider"
 import { useNavigation, useFocusEffect } from "@react-navigation/native"
 import { AptitudeRow, EpithetChip } from "./components/Helpers"
@@ -1286,19 +1287,7 @@ const SmartRaceSolverSettings = () => {
 
                         {enableSmartRaceSolver && (
                             <Section label="General" collapsible defaultOpen={true}>
-                                <SearchableItem
-                                    id="disable-schedule-replan-on-race-loss"
-                                    condition={enableSmartRaceSolver}
-                                    parentId="enable-smart-race-solver"
-                                    title="Disable Schedule Re-Plan Upon Race Loss"
-                                    description="When a race is lost, keep the original schedule instead of re-planning the remaining turns. The loss is still recorded; epithets that depended on the lost race won't be re-routed."
-                                >
-                                    <Row
-                                        title="Disable Schedule Re-Plan Upon Race Loss"
-                                        description="When a race is lost, keep the original schedule instead of re-planning the remaining turns. The loss is still recorded; epithets that depended on the lost race won't be re-routed."
-                                        right={<Switch checked={disableScheduleReplanOnRaceLoss} onCheckedChange={(checked) => updateRacingSetting("disableScheduleReplanOnRaceLoss", checked)} />}
-                                    />
-                                </SearchableItem>
+                                <ToggleSetting id="disable-schedule-replan-on-race-loss" title="Disable Schedule Re-Plan Upon Race Loss" description="When a race is lost, keep the original schedule instead of re-planning the remaining turns. The loss is still recorded; epithets that depended on the lost race won't be re-routed." condition={enableSmartRaceSolver} parentId="enable-smart-race-solver" checked={disableScheduleReplanOnRaceLoss} onCheckedChange={(checked) => updateRacingSetting("disableScheduleReplanOnRaceLoss", checked)} />
 
                                 <View style={{ paddingHorizontal: SPACING.md, paddingVertical: SPACING.sm }}>
                                     <CustomSlider

--- a/src/pages/TrainingEventSettings/index.tsx
+++ b/src/pages/TrainingEventSettings/index.tsx
@@ -10,7 +10,7 @@ import { TrainingEventContext, defaultSettings } from "../../context/BotStateCon
 import { SearchPageProvider } from "../../context/SearchPageContext"
 import CustomSelect from "../../components/CustomSelect"
 import SearchableItem from "../../components/SearchableItem"
-import { Row } from "../../components/ui/row"
+import ToggleSetting from "../../components/ToggleSetting"
 import { Section } from "../../components/ui/section"
 import { Switch } from "../../components/ui/switch"
 import { TYPE } from "../../lib/type"
@@ -589,17 +589,7 @@ const TrainingEventSettings = () => {
                 <ScrollView ref={scrollViewRef} nestedScrollEnabled={true} showsVerticalScrollIndicator={false} showsHorizontalScrollIndicator={false} contentContainerStyle={{ flexGrow: 1 }}>
                     <View className="m-1">
                         <Section label="General">
-                            <SearchableItem
-                                id="prioritize-energy-options"
-                                title="Prioritize Energy Options"
-                                description="When enabled, the bot will prioritize training event choices that provide energy recovery or avoid energy consumption, helping to maintain optimal energy levels for training sessions."
-                            >
-                                <Row
-                                    title="Prioritize Energy Options"
-                                    description="When enabled, the bot will prioritize training event choices that provide energy recovery or avoid energy consumption, helping to maintain optimal energy levels for training sessions."
-                                    right={<Switch checked={enablePrioritizeEnergyOptions} onCheckedChange={(checked) => updateTrainingEventSetting("enablePrioritizeEnergyOptions", checked)} />}
-                                />
-                            </SearchableItem>
+                            <ToggleSetting id="prioritize-energy-options" title="Prioritize Energy Options" description="When enabled, the bot will prioritize training event choices that provide energy recovery or avoid energy consumption, helping to maintain optimal energy levels for training sessions." checked={enablePrioritizeEnergyOptions} onCheckedChange={(checked) => updateTrainingEventSetting("enablePrioritizeEnergyOptions", checked)} />
                         </Section>
 
                         <Section label="OCR Recognition Settings">
@@ -615,17 +605,7 @@ const TrainingEventSettings = () => {
                                 </SearchableItem>
                             </View>
 
-                            <SearchableItem
-                                id="automatic-ocr-retry-training"
-                                title="Enable Automatic OCR Retry for Training Events"
-                                description="When enabled, the bot will automatically retry OCR detection with adjusted settings if the initial attempt for a training event title fails or has low confidence."
-                            >
-                                <Row
-                                    title="Enable Automatic OCR Retry for Training Events"
-                                    description="When enabled, the bot will automatically retry OCR detection with adjusted settings if the initial attempt for a training event title fails or has low confidence."
-                                    right={<Switch checked={enableAutomaticOCRRetry} onCheckedChange={(checked) => updateTrainingEventSetting("enableAutomaticOCRRetry", checked)} />}
-                                />
-                            </SearchableItem>
+                            <ToggleSetting id="automatic-ocr-retry-training" title="Enable Automatic OCR Retry for Training Events" description="When enabled, the bot will automatically retry OCR detection with adjusted settings if the initial attempt for a training event title fails or has low confidence." checked={enableAutomaticOCRRetry} onCheckedChange={(checked) => updateTrainingEventSetting("enableAutomaticOCRRetry", checked)} />
 
                             <View style={{ padding: SPACING.md }}>
                                 <CustomSlider
@@ -642,17 +622,7 @@ const TrainingEventSettings = () => {
                                 />
                             </View>
 
-                            <SearchableItem
-                                id="hide-ocr-comparison-results-training"
-                                title="Hide OCR String Comparison Results"
-                                description="If enabled, the bot will suppress detailed logging of individual string similarity scores during training event detection to keep the logs cleaner."
-                            >
-                                <Row
-                                    title="Hide OCR String Comparison Results"
-                                    description="If enabled, the bot will suppress detailed logging of individual string similarity scores during training event detection to keep the logs cleaner."
-                                    right={<Switch checked={enableHideOCRComparisonResults} onCheckedChange={(checked) => updateTrainingEventSetting("enableHideOCRComparisonResults", checked)} />}
-                                />
-                            </SearchableItem>
+                            <ToggleSetting id="hide-ocr-comparison-results-training" title="Hide OCR String Comparison Results" description="If enabled, the bot will suppress detailed logging of individual string similarity scores during training event detection to keep the logs cleaner." checked={enableHideOCRComparisonResults} onCheckedChange={(checked) => updateTrainingEventSetting("enableHideOCRComparisonResults", checked)} />
                         </Section>
 
                         <Section label="Training Event Option Overrides">

--- a/src/pages/TrainingSettings/index.tsx
+++ b/src/pages/TrainingSettings/index.tsx
@@ -17,6 +17,7 @@ import { databaseManager } from "../../lib/database"
 import PageHeader from "../../components/PageHeader"
 import { SearchPageProvider } from "../../context/SearchPageContext"
 import SearchableItem from "../../components/SearchableItem"
+import ToggleSetting from "../../components/ToggleSetting"
 import { usePerformanceLogging } from "../../hooks/usePerformanceLogging"
 import { shallowArrayEqual } from "../../lib/utils"
 import { computePrioritySync } from "../../lib/training/syncPriorities"
@@ -648,29 +649,9 @@ const TrainingSettings = () => {
                                         />
                                     </View>
 
-                                    <SearchableItem
-                                        id="disable-training-on-maxed-stats"
-                                        title="Disable Training on Maxed Stats"
-                                        description="When enabled, training will be skipped for stats that have reached their maximum value."
-                                    >
-                                        <Row
-                                            title="Disable Training on Maxed Stats"
-                                            description="When enabled, training will be skipped for stats that have reached their maximum value."
-                                            right={<Switch checked={disableTrainingOnMaxedStat} onCheckedChange={(checked) => updateTrainingSetting("disableTrainingOnMaxedStat", checked)} />}
-                                        />
-                                    </SearchableItem>
+                                    <ToggleSetting id="disable-training-on-maxed-stats" title="Disable Training on Maxed Stats" description="When enabled, training will be skipped for stats that have reached their maximum value." checked={disableTrainingOnMaxedStat} onCheckedChange={(checked) => updateTrainingSetting("disableTrainingOnMaxedStat", checked)} />
 
-                                    <SearchableItem
-                                        id="enable-riskier-training"
-                                        title="Enable Riskier Training"
-                                        description="When enabled, trainings with high main stat gains will use a separate, higher maximum failure chance threshold."
-                                    >
-                                        <Row
-                                            title="Enable Riskier Training"
-                                            description="When enabled, trainings with high main stat gains will use a separate, higher maximum failure chance threshold."
-                                            right={<Switch checked={enableRiskyTraining} onCheckedChange={(checked) => updateTrainingSetting("enableRiskyTraining", checked)} />}
-                                        />
-                                    </SearchableItem>
+                                    <ToggleSetting id="enable-riskier-training" title="Enable Riskier Training" description="When enabled, trainings with high main stat gains will use a separate, higher maximum failure chance threshold." checked={enableRiskyTraining} onCheckedChange={(checked) => updateTrainingSetting("enableRiskyTraining", checked)} />
                                     {enableRiskyTraining && (
                                         <View style={styles.sliderShell}>
                                             <CustomSlider
@@ -710,53 +691,13 @@ const TrainingSettings = () => {
                                         </View>
                                     )}
 
-                                    <SearchableItem
-                                        id="enable-prioritize-skill-hints"
-                                        title="Prioritize Skill Hints"
-                                        description="When enabled, the bot will prioritize acquiring skill hints, bypassing stat prioritization and blacklist, while still being constrained by the failure chance thresholds."
-                                    >
-                                        <Row
-                                            title="Prioritize Skill Hints"
-                                            description="When enabled, the bot will prioritize acquiring skill hints, bypassing stat prioritization and blacklist, while still being constrained by the failure chance thresholds."
-                                            right={<Switch checked={enablePrioritizeSkillHints} onCheckedChange={(checked) => updateTrainingSetting("enablePrioritizeSkillHints", checked)} />}
-                                        />
-                                    </SearchableItem>
-                                    <SearchableItem
-                                        id="must-rest-before-summer"
-                                        title="Must Rest before Summer"
-                                        description="Optimizes June Late Phase in Classic and Senior Years for Summer Training. If Energy < 70%, it will Rest. If Energy >= 70% and Mood < Great, it will recover Mood. If Energy >= 70% and Mood is Great, it will train Wit."
-                                    >
-                                        <Row
-                                            title="Must Rest before Summer"
-                                            description="Optimizes June Late Phase in Classic and Senior Years for Summer Training. If Energy < 70%, it will Rest. If Energy >= 70% and Mood < Great, it will recover Mood. If Energy >= 70% and Mood is Great, it will train Wit."
-                                            right={<Switch checked={mustRestBeforeSummer} onCheckedChange={(checked) => updateTrainingSetting("mustRestBeforeSummer", checked)} />}
-                                        />
-                                    </SearchableItem>
-                                    <SearchableItem
-                                        id="train-wit-during-finale"
-                                        title="Train Wit During Finale"
-                                        description="When enabled, the bot will train Wit during URA finale turns (73, 74, 75) instead of recovering energy or mood, even if the failure chance is high."
-                                    >
-                                        <Row
-                                            title="Train Wit During Finale"
-                                            description="When enabled, the bot will train Wit during URA finale turns (73, 74, 75) instead of recovering energy or mood, even if the failure chance is high."
-                                            right={<Switch checked={trainWitDuringFinale} onCheckedChange={(checked) => updateTrainingSetting("trainWitDuringFinale", checked)} />}
-                                        />
-                                    </SearchableItem>
+                                    <ToggleSetting id="enable-prioritize-skill-hints" title="Prioritize Skill Hints" description="When enabled, the bot will prioritize acquiring skill hints, bypassing stat prioritization and blacklist, while still being constrained by the failure chance thresholds." checked={enablePrioritizeSkillHints} onCheckedChange={(checked) => updateTrainingSetting("enablePrioritizeSkillHints", checked)} />
+                                    <ToggleSetting id="must-rest-before-summer" title="Must Rest before Summer" description="Optimizes June Late Phase in Classic and Senior Years for Summer Training. If Energy < 70%, it will Rest. If Energy >= 70% and Mood < Great, it will recover Mood. If Energy >= 70% and Mood is Great, it will train Wit." checked={mustRestBeforeSummer} onCheckedChange={(checked) => updateTrainingSetting("mustRestBeforeSummer", checked)} />
+                                    <ToggleSetting id="train-wit-during-finale" title="Train Wit During Finale" description="When enabled, the bot will train Wit during URA finale turns (73, 74, 75) instead of recovering energy or mood, even if the failure chance is high." checked={trainWitDuringFinale} onCheckedChange={(checked) => updateTrainingSetting("trainWitDuringFinale", checked)} />
                                 </Section>
 
                                 <Section label="Scoring">
-                                    <SearchableItem
-                                        id="enable-training-level-weighting"
-                                        title="Weight Score by Training Level"
-                                        description="When enabled (Year 2+), the bot reads each training's level (1-5) via OCR and boosts the score for trainings whose stat sits in the top 3 of your Stat Prioritization list. Helps the bot stick with stats you've invested in. OCR is skipped during Pre-Debut, Junior, and Summer."
-                                    >
-                                        <Row
-                                            title="Weight Score by Training Level"
-                                            description="When enabled (Year 2+), the bot reads each training's level (1-5) via OCR and boosts the score for trainings whose stat sits in the top 3 of your Stat Prioritization list. Helps the bot stick with stats you've invested in. OCR is skipped during Pre-Debut, Junior, and Summer."
-                                            right={<Switch checked={enableTrainingLevelWeighting} onCheckedChange={(checked) => updateTrainingSetting("enableTrainingLevelWeighting", checked)} />}
-                                        />
-                                    </SearchableItem>
+                                    <ToggleSetting id="enable-training-level-weighting" title="Weight Score by Training Level" description="When enabled (Year 2+), the bot reads each training's level (1-5) via OCR and boosts the score for trainings whose stat sits in the top 3 of your Stat Prioritization list. Helps the bot stick with stats you've invested in. OCR is skipped during Pre-Debut, Junior, and Summer." checked={enableTrainingLevelWeighting} onCheckedChange={(checked) => updateTrainingSetting("enableTrainingLevelWeighting", checked)} />
                                     <SearchableItem
                                         id="enable-rainbow-training-bonus"
                                         title="Enable Rainbow Training Bonus"
@@ -844,17 +785,7 @@ const TrainingSettings = () => {
                                             }
                                         />
                                     </SearchableItem>
-                                    <SearchableItem
-                                        id="disable-stat-targets"
-                                        title="Disable Stat Targets"
-                                        description="When enabled, all per-distance stat targets below are ignored. Every stat is treated as having a target equal to the in-game stat cap (1200), so the bot will keep pushing your top priority stats even after they would normally be considered 'done.' Useful when you want strict adherence to your Stat Prioritization list."
-                                    >
-                                        <Row
-                                            title="Disable Stat Targets"
-                                            description="When enabled, all per-distance stat targets below are ignored. Every stat is treated as having a target equal to the in-game stat cap (1200), so the bot will keep pushing your top priority stats even after they would normally be considered 'done.' Useful when you want strict adherence to your Stat Prioritization list."
-                                            right={<Switch checked={disableStatTargets} onCheckedChange={(checked) => updateTrainingSetting("disableStatTargets", checked)} />}
-                                        />
-                                    </SearchableItem>
+                                    <ToggleSetting id="disable-stat-targets" title="Disable Stat Targets" description="When enabled, all per-distance stat targets below are ignored. Every stat is treated as having a target equal to the in-game stat cap (1200), so the bot will keep pushing your top priority stats even after they would normally be considered 'done.' Useful when you want strict adherence to your Stat Prioritization list." checked={disableStatTargets} onCheckedChange={(checked) => updateTrainingSetting("disableStatTargets", checked)} />
 
                                     {/* Per-distance stat targets stay nested inside the Distance section so the whole distance domain reads as one block. */}
                                     <View style={disableStatTargets ? { opacity: 0.5 } : undefined} pointerEvents={disableStatTargets ? "none" : "auto"}>


### PR DESCRIPTION
## Description

- This PR refactors the Kotlin backend by moving data classes, interfaces, and cached `SettingsHelper` getters to the top of their classes and extracting shared helpers, so each setting is read once instead of re-queried from SQLite on every call.
- This PR extracts reusable frontend primitives (`NoticeContainer`, `ToggleSetting`, `iconChipStyle()`, `useModalShellStyles()`) and `lib` helpers (`errorMessage()`, `markMigrated()`, `safeJsonParse()`), slimming the settings pages and components down to those shared pieces.
- This PR reorganizes the remote log viewer (`log_viewer.html`) into proper banner sections and collapses duplicated tooltip and chart code, with every change across all three areas behavior-preserving (43 files, ~-2,000 lines net).
