### PR TITLE
Add support-card recreation dating schedule

### DIFF
--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Campaign.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Campaign.kt
@@ -173,6 +173,9 @@ abstract class Campaign(game: Game) : Task(game) {
     /** Whether the support-card recreation ("dating") schedule is enabled. */
     protected val enableDatingSchedule: Boolean = SettingsHelper.getBooleanSetting("general", "enableDatingSchedule", false)
 
+    /** Whether a scheduled recreation outing that got pre-empted (a race, or recreation not yet available) should be made up on the next available turn. */
+    protected val enableRecreationCatchUp: Boolean = SettingsHelper.getBooleanSetting("general", "enableRecreationCatchUp", true)
+
     /** The set of 1-indexed career turns (1-72) pinned for regular recreation outings. */
     protected val recreationTurns: Set<Int> =
         run {
@@ -190,7 +193,7 @@ abstract class Campaign(game: Game) : Task(game) {
     /** The total outings in the active support card's recreation chain (Team Sirius 7, Heirs to the Throne 5). */
     protected val recreationTotalOutings: Int = SettingsHelper.getIntSetting("general", "recreationTotalOutings", 7)
 
-    /** Whether a recreation date event has been completed today. */
+    /** Whether the recreation chain is complete for this run - no more dates are available. Latched true once done (from the in-game complete label) and never reset. */
     protected var recreationDateCompleted: Boolean = false
 
     /** The number of recreation outings actually started this run. Used to hold the final outing for the Pure Passion turn. */
@@ -1221,9 +1224,10 @@ abstract class Campaign(game: Game) : Task(game) {
 
         // First, try to handle recreation date which also recovers energy if a date is available.
         // Skip recreation date if it's already completed (will only be used for mood recovery).
-        // With the dating schedule on, a pending date is reserved for the schedule and trainee recreation does not restore energy, so skip straight to resting.
+        // While the schedule is active, a pending date is reserved for it and trainee recreation does not restore energy, so skip straight to resting.
+        // Once the schedule is abandoned, resting here advances the date chain again.
         if (
-            !enableDatingSchedule &&
+            !isScheduleActive() &&
             !recreationDateCompleted &&
             IconRecreationDate.check(game.imageUtils, sourceBitmap = sourceBitmap) &&
             handleRecreationDate(recoverMoodIfCompleted = false)
@@ -1298,7 +1302,7 @@ abstract class Campaign(game: Game) : Task(game) {
 
             // Check if a date is available.
             if (!recreationDateCompleted && IconRecreationDate.check(game.imageUtils, sourceBitmap = sourceBitmap)) {
-                if (handleRecreationDate(recoverMoodIfCompleted = true, doDateRecreation = !enableDatingSchedule)) {
+                if (handleRecreationDate(recoverMoodIfCompleted = true, doDateRecreation = !isScheduleActive())) {
                     MessageLog.v(TAG, "[MOOD] Successfully recovered mood via recreation date.")
                 }
             } else {
@@ -1346,8 +1350,12 @@ abstract class Campaign(game: Game) : Task(game) {
      * @return True if the bot should perform a recreation outing this turn.
      */
     open fun shouldDoRecreationToday(sourceBitmap: Bitmap? = null): Boolean {
-        if (!enableDatingSchedule || recreationDateCompleted) return false
-        if (!DatingSchedule.isPinnedRecreationTurn(date.day, recreationTurns, purePassionTurn)) return false
+        if (!isScheduleActive() || recreationDateCompleted) return false
+        // Do an outing on a pinned turn, or - when catch-up is on - on any turn where a missed outing has left us behind schedule.
+        val pinnedOrBehind =
+            DatingSchedule.isPinnedRecreationTurn(date.day, recreationTurns, purePassionTurn) ||
+                (enableRecreationCatchUp && DatingSchedule.isBehindSchedule(date.day, recreationTurns, recreationOutingsStarted))
+        if (!pinnedOrBehind) return false
         // If only the final outing remains and this is not the Pure Passion turn, hold it: spend the turn on a normal action instead of opening the recreation.
         if (DatingSchedule.shouldHoldFinalOuting(recreationOutingsStarted, recreationTotalOutingsKnown, allowFinalOutingNow())) return false
         val bitmap = sourceBitmap ?: game.imageUtils.getSourceBitmap()
@@ -1411,6 +1419,9 @@ abstract class Campaign(game: Game) : Task(game) {
 
     /** Whether the final chain outing may be taken right now - only on the Pure Passion turn (or when the schedule or Pure Passion turn is off). */
     private fun allowFinalOutingNow(): Boolean = DatingSchedule.allowFinalOuting(enableDatingSchedule, purePassionTurn, date.day)
+
+    /** Whether the recreation schedule is actively driving decisions: enabled and not abandoned (the Pure Passion window has not passed with the chain unfinished). */
+    private fun isScheduleActive(): Boolean = enableDatingSchedule && !DatingSchedule.isScheduleAbandoned(purePassionTurn, date.day, recreationDateCompleted)
 
     /**
      * Handles the Recreation date event if detected on the screen.

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Campaign.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Campaign.kt
@@ -93,9 +93,16 @@ enum class MainScreenAction {
     /** Indicates a mood recovery action. */
     RECOVER_MOOD,
 
+    /** Indicates a recreation/dating outing action. */
+    DATE,
+
     /** Indicates no action. */
     NONE,
 }
+
+// Position of the "Group Event Progress X/Y" text relative to the right edge of the matched "Group Event Progress" pill ([LabelEventProgress]), for OCR. Tune if the "GroupEventProgress" debug crop misses the digits.
+private const val GROUP_PROGRESS_GAP_X = 15
+private const val GROUP_PROGRESS_WIDTH = 120
 
 /**
  * Defines the base campaign class that contains all shared logic for campaign automation.
@@ -163,8 +170,34 @@ abstract class Campaign(game: Game) : Task(game) {
             }
         }
 
+    /** Whether the support-card recreation ("dating") schedule is enabled. */
+    protected val enableDatingSchedule: Boolean = SettingsHelper.getBooleanSetting("general", "enableDatingSchedule", false)
+
+    /** The set of 1-indexed career turns (1-72) pinned for regular recreation outings. */
+    protected val recreationTurns: Set<Int> =
+        run {
+            val json = SettingsHelper.getStringSetting("general", "recreationTurns", "[]")
+            try {
+                org.json.JSONArray(json).let { arr -> (0 until arr.length()).map { arr.getInt(it) }.toSet() }
+            } catch (_: Exception) {
+                setOf()
+            }
+        }
+
+    /** The single career turn pinned for the final outing / Pure Passion activation, or a non-positive value when unset. */
+    protected val purePassionTurn: Int = SettingsHelper.getIntSetting("general", "purePassionTurn", 60)
+
+    /** The total outings in the active support card's recreation chain (Team Sirius 7, Heirs to the Throne 5). */
+    protected val recreationTotalOutings: Int = SettingsHelper.getIntSetting("general", "recreationTotalOutings", 7)
+
     /** Whether a recreation date event has been completed today. */
     protected var recreationDateCompleted: Boolean = false
+
+    /** The number of recreation outings actually started this run. Used to hold the final outing for the Pure Passion turn. */
+    protected var recreationOutingsStarted: Int = 0
+
+    /** The group-event chain length as last read from the game's "X/Y" progress, or the configured fallback until the partner dialog is first read. */
+    protected var recreationTotalOutingsKnown: Int = recreationTotalOutings
 
     /** The turn number when the stop-at-date check first started. */
     protected var stopAtDateInitialTurnNumber: Int = -1
@@ -561,6 +594,12 @@ abstract class Campaign(game: Game) : Task(game) {
                     // Reset this flag since our preferred running style has changed.
                     trainee.bHasSetRunningStyle = false
                 }
+                result.dialog.close(game.imageUtils)
+            }
+
+            "choose_recreation_partner" -> {
+                // The recreation was opened but the outing is being held (reserved for the Pure Passion turn), leaving this dialog up. Close it.
+                MessageLog.i(TAG, "[RECREATION_DATE] Choose Recreation Partner dialog left open. Closing it.")
                 result.dialog.close(game.imageUtils)
             }
 
@@ -1182,7 +1221,9 @@ abstract class Campaign(game: Game) : Task(game) {
 
         // First, try to handle recreation date which also recovers energy if a date is available.
         // Skip recreation date if it's already completed (will only be used for mood recovery).
+        // With the dating schedule on, a pending date is reserved for the schedule and trainee recreation does not restore energy, so skip straight to resting.
         if (
+            !enableDatingSchedule &&
             !recreationDateCompleted &&
             IconRecreationDate.check(game.imageUtils, sourceBitmap = sourceBitmap) &&
             handleRecreationDate(recoverMoodIfCompleted = false)
@@ -1257,7 +1298,7 @@ abstract class Campaign(game: Game) : Task(game) {
 
             // Check if a date is available.
             if (!recreationDateCompleted && IconRecreationDate.check(game.imageUtils, sourceBitmap = sourceBitmap)) {
-                if (handleRecreationDate(recoverMoodIfCompleted = true)) {
+                if (handleRecreationDate(recoverMoodIfCompleted = true, doDateRecreation = !enableDatingSchedule)) {
                     MessageLog.v(TAG, "[MOOD] Successfully recovered mood via recreation date.")
                 }
             } else {
@@ -1297,12 +1338,89 @@ abstract class Campaign(game: Game) : Task(game) {
     }
 
     /**
+     * Whether the bot should spend this turn on a scheduled recreation outing. True only when the dating schedule is enabled, the chain is not yet
+     * complete, a recreation date is on screen, the current turn is pinned (regular or Pure Passion), and no mandatory career-goal race is present.
+     * Scheduled (in-game agenda) and Smart Race Solver races do NOT block it - a pinned recreation outranks them.
+     *
+     * @param sourceBitmap An already-captured screen frame to reuse, or null to capture lazily only after the cheap pinned-turn checks pass.
+     * @return True if the bot should perform a recreation outing this turn.
+     */
+    open fun shouldDoRecreationToday(sourceBitmap: Bitmap? = null): Boolean {
+        if (!enableDatingSchedule || recreationDateCompleted) return false
+        if (!DatingSchedule.isPinnedRecreationTurn(date.day, recreationTurns, purePassionTurn)) return false
+        // If only the final outing remains and this is not the Pure Passion turn, hold it: spend the turn on a normal action instead of opening the recreation.
+        if (DatingSchedule.shouldHoldFinalOuting(recreationOutingsStarted, recreationTotalOutingsKnown, allowFinalOutingNow())) return false
+        val bitmap = sourceBitmap ?: game.imageUtils.getSourceBitmap()
+        // Mandatory career-goal races cannot be skipped, so they still outrank a recreation. Scheduled (in-game agenda) and Smart Race Solver races do not - the recreation overrides them.
+        if (IconRaceDayRibbon.check(game.imageUtils, sourceBitmap = bitmap) || IconGoalRibbon.check(game.imageUtils, sourceBitmap = bitmap)) {
+            return false
+        }
+        if (!IconRecreationDate.check(game.imageUtils, sourceBitmap = bitmap)) return false
+        return true
+    }
+
+    /**
+     * Reads the in-game "Group Event Progress X/Y" (e.g. "3/4") from the open Choose Recreation Partner dialog by OCR-ing just to the right of the [LabelEventProgress] label.
+     * This is the authoritative chain position - unlike the per-run counter it survives a bot restart and any dates done manually. The offset region is display-dependent,
+     * so it may need on-device calibration. The debugName dumps the cropped region for tuning.
+     *
+     * @param sourceBitmap The current screen capture with the partner dialog open.
+     * @return The (completed, total) outing counts, or null when the label or the numbers could not be read.
+     */
+    open fun getGroupEventProgress(sourceBitmap: Bitmap): Pair<Int, Int>? {
+        val templateBitmap = LabelEventProgress.template.getBitmap(game.imageUtils) ?: return null
+        val point = LabelEventProgress.findImageWithBitmap(game.imageUtils, sourceBitmap = sourceBitmap) ?: return null
+        // The "X/Y" sits just right of the "Group Event Progress" pill, so anchor to the pill's right edge and match its height. This survives scrolling and resolution changes.
+        val text =
+            game.imageUtils.performOCROnRegion(
+                sourceBitmap,
+                game.imageUtils.relX(0.0, (point.x + (templateBitmap.width / 2)).toInt() + GROUP_PROGRESS_GAP_X),
+                game.imageUtils.relY(0.0, (point.y - (templateBitmap.height / 2) - 4).toInt()),
+                game.imageUtils.relWidth(GROUP_PROGRESS_WIDTH),
+                game.imageUtils.relHeight(templateBitmap.height + 8),
+                useThreshold = true,
+                useGrayscale = true,
+                scale = 2.0,
+                ocrEngine = "tesseract",
+                debugName = "GroupEventProgress",
+            )
+        val numbers = Regex("\\d+").findAll(text).mapNotNull { it.value.toIntOrNull() }.toList()
+        if (numbers.size < 2) {
+            MessageLog.w(TAG, "[WARN] getGroupEventProgress:: Could not read an X/Y progress from \"$text\".")
+            return null
+        }
+        val completed = numbers[0]
+        val total = numbers[1]
+        if (total < 1 || completed < 0 || completed > total) {
+            MessageLog.w(TAG, "[WARN] getGroupEventProgress:: Implausible progress $completed/$total from \"$text\".")
+            return null
+        }
+        return Pair(completed, total)
+    }
+
+    /**
+     * Backs out of the open Choose Recreation Partner dialog and waits for the screen to settle.
+     *
+     * @return Always false, so a caller can return it directly as the "did not start an outing" result.
+     */
+    private fun cancelPartnerDialog(): Boolean {
+        ButtonCancel.click(game.imageUtils)
+        game.waitForLoading()
+        return false
+    }
+
+    /** Whether the final chain outing may be taken right now - only on the Pure Passion turn (or when the schedule or Pure Passion turn is off). */
+    private fun allowFinalOutingNow(): Boolean = DatingSchedule.allowFinalOuting(enableDatingSchedule, purePassionTurn, date.day)
+
+    /**
      * Handles the Recreation date event if detected on the screen.
      *
      * @param recoverMoodIfCompleted If true, recovers mood if the date was already completed.
+     * @param allowFinalOuting If false, the final outing in the chain is held back (the bot backs out of the partner dialog) so it can be done on the Pure Passion turn.
+     * @param doDateRecreation If true, advance the support-card date chain (tap the group event). If false, recreate with the trainee instead - used for opportunistic mood / energy recovery so the schedule alone drives the date chain.
      * @return True if the Recreation date event was successfully completed, false otherwise.
      */
-    open fun handleRecreationDate(recoverMoodIfCompleted: Boolean = false): Boolean {
+    open fun handleRecreationDate(recoverMoodIfCompleted: Boolean = false, allowFinalOuting: Boolean = true, doDateRecreation: Boolean = true): Boolean {
         return if (ButtonRecreation.click(game.imageUtils)) {
             // Tap OK for the possibility of a scheduled race warning popup.
             game.wait(game.dialogWaitDelay)
@@ -1331,31 +1449,58 @@ abstract class Campaign(game: Game) : Task(game) {
                     game.wait(1.0)
                     MessageLog.v(TAG, "[RECREATION_DATE] Choose Recreation Partner dialog opened.")
 
-                    // Use the ScrollList processor to find and click the first available date progress label.
-                    val bResult =
-                        ScrollList.processWithFallback(
-                            game,
-                            fallbackComponent = ButtonEventProgressChevron,
-                            bForceComponentDetection = true,
-                            onEntry = { _, entry ->
-                                MessageLog.i(TAG, "[INFO] Found entry: $entry at ${entry.bbox.cx}, ${entry.bbox.cy}")
-                                game.tap(entry.bbox.cx.toDouble(), entry.bbox.cy.toDouble())
+                    if (!doDateRecreation) {
+                        // The schedule drives the date chain, so an opportunistic recovery recreation goes to the trainee (normal recreation) and leaves the chain alone.
+                        if (LabelRecreationUmamusume.click(game.imageUtils)) {
+                            MessageLog.v(TAG, "[RECREATION_DATE] Recreating with the trainee (normal recreation), leaving the date chain for the schedule.")
+                            game.waitForLoading()
+                            true
+                        } else {
+                            // The trainee option was not found, so back out of the partner dialog rather than leave it open to desync the next turn.
+                            MessageLog.w(TAG, "[WARN] handleRecreationDate:: Could not find the trainee recreation option. Backing out of the partner dialog.")
+                            cancelPartnerDialog()
+                        }
+                    } else {
+                        // Read the in-game group-event progress (e.g. "3/4"). This is the authoritative chain position, so it holds correctly even after a bot restart or manual play.
+                        getGroupEventProgress(game.imageUtils.getSourceBitmap())?.let { (completed, total) ->
+                            recreationOutingsStarted = completed
+                            recreationTotalOutingsKnown = total
+                            MessageLog.i(TAG, "[RECREATION_DATE] Group event progress read as $completed/$total.")
+                        }
+
+                        if (DatingSchedule.shouldHoldFinalOuting(recreationOutingsStarted, recreationTotalOutingsKnown, allowFinalOuting)) {
+                            // The next outing would complete the chain and trigger Pure Passion. This is not the Pure Passion turn, so back out and leave the final for that turn.
+                            MessageLog.i(TAG, "[RECREATION_DATE] Next outing is the final one. Holding it for the Pure Passion turn. Backing out.")
+                            cancelPartnerDialog()
+                        } else {
+                            // Use the ScrollList processor to find and click the first available date progress label.
+                            val bResult =
+                                ScrollList.processWithFallback(
+                                    game,
+                                    fallbackComponent = ButtonEventProgressChevron,
+                                    bForceComponentDetection = true,
+                                    onEntry = { _, entry ->
+                                        MessageLog.i(TAG, "[INFO] Found entry: $entry at ${entry.bbox.cx}, ${entry.bbox.cy}")
+                                        game.tap(entry.bbox.cx.toDouble(), entry.bbox.cy.toDouble())
+                                        game.waitForLoading()
+                                        true
+                                    },
+                                )
+
+                            if (bResult) {
+                                recreationOutingsStarted++
+                                MessageLog.v(TAG, "[RECREATION_DATE] Started a date from the partner selection dialog. Outings started this run: $recreationOutingsStarted.")
                                 game.waitForLoading()
                                 true
-                            },
-                        )
-
-                    if (bResult) {
-                        MessageLog.v(TAG, "[RECREATION_DATE] Started a date from the partner selection dialog.")
-                        game.waitForLoading()
-                        true
-                    } else {
-                        MessageLog.e(TAG, "[ERROR] handleRecreationDate:: Failed to find any date progress labels in the partner selection dialog.")
-                        game.waitForLoading()
-                        false
+                            } else {
+                                MessageLog.e(TAG, "[ERROR] handleRecreationDate:: Failed to find any date progress labels in the partner selection dialog. Backing out.")
+                                cancelPartnerDialog()
+                            }
+                        }
                     }
                 } else if (LabelEventProgress.click(game.imageUtils)) {
                     // Legacy support cards or situations where the dialog doesn't apply.
+                    recreationOutingsStarted++
                     game.waitForLoading()
                     MessageLog.v(TAG, "[RECREATION_DATE] Recreation date can be done.")
                     true
@@ -1880,14 +2025,25 @@ abstract class Campaign(game: Game) : Task(game) {
         val bIsScheduledRaceDay = LabelScheduledRace.check(game.imageUtils, sourceBitmap = sourceBitmap)
         val bIsMandatoryRaceDay = IconRaceDayRibbon.check(game.imageUtils, sourceBitmap = sourceBitmap)
 
-        if (bIsMandatoryRaceDay || bIsScheduledRaceDay) {
-            val reason = if (bIsMandatoryRaceDay) "Mandatory race day" else "Scheduled race day"
-            decisionTracer.recordActionChoice(MainScreenAction.RACE, reason)
+        // Mandatory career-goal races cannot be skipped, so they outrank everything - including a pinned recreation.
+        if (bIsMandatoryRaceDay) {
+            decisionTracer.recordActionChoice(MainScreenAction.RACE, "Mandatory race day")
             return MainScreenAction.RACE
         }
 
         if (racing.encounteredRacingPopup) {
             decisionTracer.recordActionChoice(MainScreenAction.RACE, "Racing popup already on screen from prior turn")
+            return MainScreenAction.RACE
+        }
+
+        // A pinned recreation outing takes priority over every remaining action, including scheduled (in-game racing agenda) races. Only mandatory races, handled above, outrank it.
+        if (shouldDoRecreationToday(sourceBitmap)) {
+            decisionTracer.recordActionChoice(MainScreenAction.DATE, "Dating schedule: pinned recreation turn ${date.day}")
+            return MainScreenAction.DATE
+        }
+
+        if (bIsScheduledRaceDay) {
+            decisionTracer.recordActionChoice(MainScreenAction.RACE, "Scheduled race day")
             return MainScreenAction.RACE
         }
 
@@ -2005,6 +2161,12 @@ abstract class Campaign(game: Game) : Task(game) {
                     bHasCheckedDateThisTurn = false
                     forcedTargetMood = null
                 }
+            }
+
+            MainScreenAction.DATE -> {
+                MessageLog.i(TAG, "[INFO] Decision made to perform a scheduled recreation outing.")
+                handleRecreationDate(recoverMoodIfCompleted = false, allowFinalOuting = allowFinalOutingNow(), doDateRecreation = true)
+                bHasCheckedDateThisTurn = false
             }
 
             MainScreenAction.NONE -> {

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/DatingSchedule.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/DatingSchedule.kt
@@ -42,4 +42,30 @@ object DatingSchedule {
     fun shouldHoldFinalOuting(outingsStarted: Int, totalOutings: Int, allowFinalOuting: Boolean): Boolean {
         return !allowFinalOuting && outingsStarted >= totalOutings - 1
     }
+
+    /**
+     * Whether the bot has fallen behind the schedule - fewer outings started than the number of regular pinned turns already due. Drives the optional catch-up
+     * behavior, where a missed outing (a race pre-empted its pinned turn, or recreation was unavailable) is made up on the next available turn.
+     *
+     * @param currentTurn The current 1-indexed career turn (1-72).
+     * @param recreationTurns The set of turns pinned for regular recreation outings (excludes the Pure Passion turn).
+     * @param outingsStarted The number of outings already started this run, kept in sync with the in-game progress.
+     * @return True if fewer outings have started than the number of pinned turns whose turn has passed or is today.
+     */
+    fun isBehindSchedule(currentTurn: Int, recreationTurns: Set<Int>, outingsStarted: Int): Boolean {
+        return outingsStarted < recreationTurns.count { it <= currentTurn }
+    }
+
+    /**
+     * Whether the schedule should be abandoned because the Pure Passion window has passed with the chain unfinished. Once abandoned, recreation drops back to the
+     * regular opportunistic logic (finish the chain during rest / mood recovery) instead of holding or forcing outings. Only applies when a Pure Passion turn is set.
+     *
+     * @param purePassionTurn The single turn pinned for the final outing / Pure Passion activation, or a non-positive value when unset (e.g. Team Sirius).
+     * @param currentTurn The current 1-indexed career turn (1-72).
+     * @param chainComplete Whether the recreation chain has already been completed.
+     * @return True once the current turn is past the Pure Passion turn and the chain is still incomplete.
+     */
+    fun isScheduleAbandoned(purePassionTurn: Int, currentTurn: Int, chainComplete: Boolean): Boolean {
+        return purePassionTurn > 0 && currentTurn > purePassionTurn && !chainComplete
+    }
 }

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/DatingSchedule.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/DatingSchedule.kt
@@ -1,0 +1,45 @@
+package com.steve1316.uma_android_automation.bot
+
+/**
+ * Pure helpers for the support-card recreation ("dating") schedule. The bot performs a recreation outing on user-pinned turns and holds the final
+ * outing until a designated Pure Passion turn. These functions are side-effect free so they can be unit tested without the OCR / settings machinery.
+ */
+object DatingSchedule {
+    /**
+     * Whether [turn] is one the user pinned for a recreation outing - either a regular recreation turn or the single Pure Passion turn.
+     *
+     * @param turn The current 1-indexed career turn (1-72).
+     * @param recreationTurns The set of turns pinned for regular recreation outings.
+     * @param purePassionTurn The single turn pinned for the final outing / Pure Passion activation, or a non-positive value when unset.
+     * @return True if the bot should consider doing a recreation outing on this turn.
+     */
+    fun isPinnedRecreationTurn(turn: Int, recreationTurns: Set<Int>, purePassionTurn: Int): Boolean {
+        return turn in recreationTurns || turn == purePassionTurn
+    }
+
+    /**
+     * Whether the final outing in the chain may start this turn. The final is held back only when a Pure Passion turn is configured and today is not it.
+     * With no Pure Passion turn (e.g. Team Sirius, where Pure Passion is not timed for summer) every outing proceeds, so the chain completes on its pinned turns.
+     *
+     * @param enableDatingSchedule Whether the recreation schedule feature is on.
+     * @param purePassionTurn The single turn pinned for the final outing / Pure Passion activation, or a non-positive value when unset.
+     * @param currentTurn The current 1-indexed career turn (1-72).
+     * @return True if the final outing is allowed to start now, so it is not held back.
+     */
+    fun allowFinalOuting(enableDatingSchedule: Boolean, purePassionTurn: Int, currentTurn: Int): Boolean {
+        return !enableDatingSchedule || purePassionTurn <= 0 || currentTurn == purePassionTurn
+    }
+
+    /**
+     * Whether the final recreation outing should be held back rather than started now. On a regular pinned turn the final outing is reserved so that
+     * completing it - and triggering Pure Passion - happens on the Pure Passion turn instead.
+     *
+     * @param outingsStarted The number of outings already started this run.
+     * @param totalOutings The total outings in the active card's recreation chain (Team Sirius 7, Heirs to the Throne 5).
+     * @param allowFinalOuting True on the Pure Passion turn, where the final outing is allowed to start.
+     * @return True if the only remaining outing is the final one and it is not yet allowed - i.e. back out without starting.
+     */
+    fun shouldHoldFinalOuting(outingsStarted: Int, totalOutings: Int, allowFinalOuting: Boolean): Boolean {
+        return !allowFinalOuting && outingsStarted >= totalOutings - 1
+    }
+}

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/Trackblazer.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/Trackblazer.kt
@@ -1277,6 +1277,13 @@ class Trackblazer(game: Game) : Campaign(game) {
             return MainScreenAction.TRAIN
         }
 
+        // A pinned recreation outing outranks every action below here - scheduled (in-game agenda) races, Smart Race Solver races, and the low-energy guard.
+        // Only mandatory career-goal races outrank it (deferred to inside shouldDoRecreationToday). Pinned turns never fall in Summer, so this sits just below Summer / Finale training.
+        if (shouldDoRecreationToday()) {
+            decisionTracer.recordActionChoice(MainScreenAction.DATE, "Dating schedule (Trackblazer): pinned recreation turn ${date.day}")
+            return MainScreenAction.DATE
+        }
+
         // Avoid racing and training analysis at low energy with 3+ consecutive races to prevent
         // -30 stat penalty. Energy items were already attempted in onMainScreenEntry().
         // A Good-Luck Charm in inventory is not a justification to enter training here: the

--- a/android/app/src/test/java/com/steve1316/uma_android_automation/bot/DatingScheduleTest.kt
+++ b/android/app/src/test/java/com/steve1316/uma_android_automation/bot/DatingScheduleTest.kt
@@ -89,4 +89,62 @@ class DatingScheduleTest {
             assertFalse(DatingSchedule.shouldHoldFinalOuting(4, 5, true))
         }
     }
+
+    @Nested
+    @DisplayName("isBehindSchedule()")
+    inner class IsBehindScheduleTests {
+        @Test
+        fun `on track when every due turn has an outing`() {
+            assertFalse(DatingSchedule.isBehindSchedule(currentTurn = 44, recreationTurns = setOf(35, 43, 52, 58), outingsStarted = 2))
+        }
+
+        @Test
+        fun `behind when a due turn was missed`() {
+            assertTrue(DatingSchedule.isBehindSchedule(currentTurn = 44, recreationTurns = setOf(35, 43, 52, 58), outingsStarted = 1))
+        }
+
+        @Test
+        fun `not behind before the first pinned turn`() {
+            assertFalse(DatingSchedule.isBehindSchedule(currentTurn = 30, recreationTurns = setOf(35, 43, 52, 58), outingsStarted = 0))
+        }
+
+        @Test
+        fun `not behind when caught up exactly on a pinned turn`() {
+            assertFalse(DatingSchedule.isBehindSchedule(currentTurn = 52, recreationTurns = setOf(35, 43, 52, 58), outingsStarted = 3))
+        }
+
+        @Test
+        fun `behind when several later turns are missed`() {
+            assertTrue(DatingSchedule.isBehindSchedule(currentTurn = 58, recreationTurns = setOf(35, 43, 52, 58), outingsStarted = 2))
+        }
+    }
+
+    @Nested
+    @DisplayName("isScheduleAbandoned()")
+    inner class IsScheduleAbandonedTests {
+        @Test
+        fun `abandoned once past the pure passion turn with the chain incomplete`() {
+            assertTrue(DatingSchedule.isScheduleAbandoned(purePassionTurn = 60, currentTurn = 61, chainComplete = false))
+        }
+
+        @Test
+        fun `not abandoned on the pure passion turn itself`() {
+            assertFalse(DatingSchedule.isScheduleAbandoned(purePassionTurn = 60, currentTurn = 60, chainComplete = false))
+        }
+
+        @Test
+        fun `not abandoned before the pure passion turn`() {
+            assertFalse(DatingSchedule.isScheduleAbandoned(purePassionTurn = 60, currentTurn = 58, chainComplete = false))
+        }
+
+        @Test
+        fun `not abandoned when the chain is already complete`() {
+            assertFalse(DatingSchedule.isScheduleAbandoned(purePassionTurn = 60, currentTurn = 61, chainComplete = true))
+        }
+
+        @Test
+        fun `Sirius is never abandoned without a pure passion turn`() {
+            assertFalse(DatingSchedule.isScheduleAbandoned(purePassionTurn = -1, currentTurn = 70, chainComplete = false))
+        }
+    }
 }

--- a/android/app/src/test/java/com/steve1316/uma_android_automation/bot/DatingScheduleTest.kt
+++ b/android/app/src/test/java/com/steve1316/uma_android_automation/bot/DatingScheduleTest.kt
@@ -1,0 +1,92 @@
+package com.steve1316.uma_android_automation.bot
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit tests for [DatingSchedule], the pure helpers driving the support-card recreation schedule.
+ *
+ * Covers pinned-turn membership, whether the final outing may start, and the hold-the-final-outing gating for both Team Sirius (7 outings) and Heirs to the Throne (5 outings).
+ */
+@DisplayName("DatingSchedule Tests")
+class DatingScheduleTest {
+    @Nested
+    @DisplayName("isPinnedRecreationTurn()")
+    inner class IsPinnedRecreationTurnTests {
+        @Test
+        fun `regular recreation turn is pinned`() {
+            assertTrue(DatingSchedule.isPinnedRecreationTurn(56, setOf(50, 56), 60))
+        }
+
+        @Test
+        fun `pure passion turn is pinned`() {
+            assertTrue(DatingSchedule.isPinnedRecreationTurn(60, setOf(50, 56), 60))
+        }
+
+        @Test
+        fun `unpinned turn is not pinned`() {
+            assertFalse(DatingSchedule.isPinnedRecreationTurn(40, setOf(50, 56), 60))
+        }
+
+        @Test
+        fun `unset pure passion turn does not match turn zero`() {
+            assertFalse(DatingSchedule.isPinnedRecreationTurn(0, setOf(50, 56), -1))
+        }
+    }
+
+    @Nested
+    @DisplayName("allowFinalOuting()")
+    inner class AllowFinalOutingTests {
+        @Test
+        fun `final outing is allowed when the schedule is disabled`() {
+            assertTrue(DatingSchedule.allowFinalOuting(enableDatingSchedule = false, purePassionTurn = 60, currentTurn = 35))
+        }
+
+        @Test
+        fun `Sirius allows every outing when no pure passion turn is set`() {
+            assertTrue(DatingSchedule.allowFinalOuting(enableDatingSchedule = true, purePassionTurn = -1, currentTurn = 58))
+        }
+
+        @Test
+        fun `Throne holds the final before the pure passion turn`() {
+            assertFalse(DatingSchedule.allowFinalOuting(enableDatingSchedule = true, purePassionTurn = 60, currentTurn = 58))
+        }
+
+        @Test
+        fun `Throne allows the final on the pure passion turn`() {
+            assertTrue(DatingSchedule.allowFinalOuting(enableDatingSchedule = true, purePassionTurn = 60, currentTurn = 60))
+        }
+    }
+
+    @Nested
+    @DisplayName("shouldHoldFinalOuting()")
+    inner class ShouldHoldFinalOutingTests {
+        @Test
+        fun `holds the final on a regular turn when six of seven outings are done`() {
+            assertTrue(DatingSchedule.shouldHoldFinalOuting(6, 7, false))
+        }
+
+        @Test
+        fun `starts an outing on a regular turn when five of seven outings are done`() {
+            assertFalse(DatingSchedule.shouldHoldFinalOuting(5, 7, false))
+        }
+
+        @Test
+        fun `starts the final once the final outing is allowed`() {
+            assertFalse(DatingSchedule.shouldHoldFinalOuting(6, 7, true))
+        }
+
+        @Test
+        fun `Throne holds the final on a regular turn when four of five outings are done`() {
+            assertTrue(DatingSchedule.shouldHoldFinalOuting(4, 5, false))
+        }
+
+        @Test
+        fun `Throne starts the final once the final outing is allowed`() {
+            assertFalse(DatingSchedule.shouldHoldFinalOuting(4, 5, true))
+        }
+    }
+}

--- a/src/components/SeasonCalendar/index.tsx
+++ b/src/components/SeasonCalendar/index.tsx
@@ -1,0 +1,153 @@
+import { ReactNode, useMemo } from "react"
+import { View, Text, StyleSheet } from "react-native"
+import { useTheme } from "../../context/ThemeContext"
+import { YEAR_LABELS, turnDateLabel } from "../../lib/solver/constants"
+
+// //////////////////////////////////////////////////////////////////////////////////////////////////
+// //////////////////////////////////////////////////////////////////////////////////////////////////
+// Styles
+
+/**
+ * Themed styles for the 72-turn season-calendar grid. Shared by every consumer (Smart Race Solver schedule preview and the recreation-date picker)
+ * so the calendars look identical. Includes the grid scaffolding plus the race/lock/mandatory/highlight cell styles consumers compose onto their cells.
+ * @returns The memoized StyleSheet for the calendar grid.
+ */
+export const useSeasonCalendarStyles = () => {
+    const { colors } = useTheme()
+    return useMemo(
+        () =>
+            StyleSheet.create({
+                yearCard: {
+                    marginVertical: 8,
+                    padding: 12,
+                    borderWidth: 1,
+                    borderColor: colors.borderHair,
+                    borderRadius: 8,
+                    backgroundColor: colors.bg,
+                },
+                yearCardTitle: { fontSize: 16, fontWeight: "700", color: colors.text, marginBottom: 6 },
+                calendarRow: { flexDirection: "row", alignItems: "stretch", paddingVertical: 4 },
+                calendarCellWrapper: { flex: 1, marginHorizontal: 3, alignItems: "stretch" },
+                calendarCell: {
+                    flexDirection: "column",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    paddingVertical: 6,
+                    paddingHorizontal: 4,
+                    borderRadius: 6,
+                    borderWidth: 1,
+                    borderColor: colors.borderHair,
+                    backgroundColor: colors.surface,
+                    minHeight: 56,
+                },
+                calendarCellRace: {
+                    backgroundColor: colors.surface,
+                },
+                calendarBadge: {
+                    minWidth: 30,
+                    height: 18,
+                    borderRadius: 3,
+                    paddingHorizontal: 4,
+                    marginBottom: 4,
+                    alignItems: "center",
+                    justifyContent: "center",
+                },
+                calendarBadgeText: { color: "#fff", fontSize: 10, fontWeight: "700" },
+                calendarRaceName: { fontSize: 10, color: colors.text, fontWeight: "600", textAlign: "center" },
+                calendarCellEmpty: { fontSize: 11, color: colors.textMuted, textAlign: "center" },
+                calendarCellPreDebut: {
+                    backgroundColor: colors.surfaceRaised,
+                    borderColor: colors.borderHair,
+                    borderStyle: "dashed",
+                    opacity: 0.6,
+                },
+                calendarCellPreDebutText: {
+                    fontSize: 10,
+                    color: colors.textMuted,
+                    fontStyle: "italic",
+                    fontWeight: "600",
+                    textAlign: "center",
+                },
+                calendarDateLabel: { fontSize: 10, color: colors.textMuted, textAlign: "center", marginTop: 3 },
+                calendarCellLocked: {
+                    borderWidth: 2,
+                    borderColor: colors.brand,
+                },
+                calendarCellMandatory: {
+                    borderWidth: 2,
+                    borderColor: "#f59e0b",
+                    backgroundColor: "rgba(245, 158, 11, 0.12)",
+                },
+                calendarCellHighlighted: {
+                    borderColor: "#ca8a04",
+                    borderWidth: 3,
+                    shadowColor: "#facc15",
+                    shadowOpacity: 0.9,
+                    shadowRadius: 6,
+                    shadowOffset: { width: 0, height: 0 },
+                    elevation: 4,
+                },
+            }),
+        [colors]
+    )
+}
+
+// //////////////////////////////////////////////////////////////////////////////////////////////////
+// //////////////////////////////////////////////////////////////////////////////////////////////////
+// Component
+
+/** Props for SeasonCalendar. */
+interface SeasonCalendarProps {
+    /** When false (the default), the Summer training-camp turns (37-40 and 61-64) render as non-tappable "Summer" placeholders alongside the Pre-Debut turns. */
+    allowSummer?: boolean
+    /** Renders the full interactive cell for a tappable (non-blocked) turn. Must return an element keyed by `turn` (e.g. wrapped in `calendarCellWrapper`). */
+    renderCell: (turn: number, turnInYear: number) => ReactNode
+    /** Dependency list controlling when the memoized grid rebuilds. Pass the state that `renderCell` closes over so the calendar refreshes when it changes. */
+    deps?: unknown[]
+}
+
+/**
+ * Renders the 72-turn career as three year cards (Junior / Classic / Senior), each a 6x4 grid of turns. Pre-Debut turns (<= 13) and, unless `allowSummer`
+ * is set, the Summer camp turns render as non-tappable placeholders. Every other turn is delegated to `renderCell` so each consumer supplies its own cell content.
+ * @param allowSummer Whether the Summer camp turns are tappable rather than blocked placeholders.
+ * @param renderCell Renders the interactive cell for a tappable turn.
+ * @param deps Dependency list that triggers a grid rebuild when changed.
+ * @returns The rendered three-year calendar grid.
+ */
+export default function SeasonCalendar({ allowSummer = false, renderCell, deps = [] }: SeasonCalendarProps) {
+    const styles = useSeasonCalendarStyles()
+
+    const renderBlockedCell = (turn: number, turnInYear: number, isPreDebut: boolean) => (
+        <View key={turn} style={styles.calendarCellWrapper}>
+            <View style={[styles.calendarCell, styles.calendarCellPreDebut]}>
+                <Text style={styles.calendarCellPreDebutText}>{isPreDebut ? "Pre-Debut" : "Summer"}</Text>
+            </View>
+            <Text style={styles.calendarDateLabel}>{turnDateLabel(turnInYear)}</Text>
+        </View>
+    )
+
+    const renderTurn = (turn: number, turnInYear: number) => {
+        const isPreDebut = turn <= 13
+        const isSummerBlocked = !allowSummer && ((turn >= 37 && turn <= 40) || (turn >= 61 && turn <= 64))
+        if (isPreDebut || isSummerBlocked) return renderBlockedCell(turn, turnInYear, isPreDebut)
+        return renderCell(turn, turnInYear)
+    }
+
+    const renderYearCard = (year: { name: string; startTurn: number }) => {
+        const rows: number[][] = []
+        for (let r = 0; r < 6; r++) rows.push([0, 1, 2, 3].map((c) => r * 4 + c))
+        return (
+            <View key={year.name} style={styles.yearCard}>
+                <Text style={styles.yearCardTitle}>{year.name} Year</Text>
+                {rows.map((row, ridx) => (
+                    <View key={`row-${ridx}`} style={styles.calendarRow}>
+                        {row.map((turnInYear) => renderTurn(year.startTurn + turnInYear, turnInYear))}
+                    </View>
+                ))}
+            </View>
+        )
+    }
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    return useMemo(() => <>{YEAR_LABELS.map(renderYearCard)}</>, [styles, allowSummer, ...deps])
+}

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -11,6 +11,8 @@ const Popover = PopoverPrimitive.Root
 
 const PopoverTrigger = PopoverPrimitive.Trigger
 
+const usePopoverRootContext = PopoverPrimitive.useRootContext
+
 const FullWindowOverlay = Platform.OS === "ios" ? RNFullWindowOverlay : React.Fragment
 
 function PopoverContent({
@@ -74,4 +76,4 @@ function PopoverContent({
     )
 }
 
-export { Popover, PopoverContent, PopoverTrigger }
+export { Popover, PopoverContent, PopoverTrigger, usePopoverRootContext }

--- a/src/context/BotStateContext.tsx
+++ b/src/context/BotStateContext.tsx
@@ -42,6 +42,7 @@ export interface Settings {
         enableStopAtDate: boolean
         stopAtDates: string[]
         enableDatingSchedule: boolean
+        enableRecreationCatchUp: boolean
         datingSchedulePreset: string
         recreationTurns: number[]
         purePassionTurn: number
@@ -253,6 +254,7 @@ export const defaultSettings: Settings = {
         enableStopAtDate: false,
         stopAtDates: ["Senior January Early"],
         enableDatingSchedule: false,
+        enableRecreationCatchUp: true,
         datingSchedulePreset: "siriusSenior",
         recreationTurns: [...DATING_SCHEDULE_PRESETS.siriusSenior.recreationTurns],
         purePassionTurn: DATING_SCHEDULE_PRESETS.siriusSenior.purePassionTurn,

--- a/src/context/BotStateContext.tsx
+++ b/src/context/BotStateContext.tsx
@@ -1,5 +1,6 @@
 import { createContext, useState, useMemo, useCallback, useContext } from "react"
 import { startTiming } from "../lib/performanceLogger"
+import { DATING_SCHEDULE_PRESETS } from "../lib/datingSchedule"
 import { skillPlanSettingsPages } from "../pages/SkillPlanSettings/config"
 
 /**
@@ -40,6 +41,11 @@ export interface Settings {
         enableStopBeforeFinals: boolean
         enableStopAtDate: boolean
         stopAtDates: string[]
+        enableDatingSchedule: boolean
+        datingSchedulePreset: string
+        recreationTurns: number[]
+        purePassionTurn: number
+        recreationTotalOutings: number
         waitDelay: number
         dialogWaitDelay: number
     }
@@ -246,6 +252,11 @@ export const defaultSettings: Settings = {
         enableStopBeforeFinals: false,
         enableStopAtDate: false,
         stopAtDates: ["Senior January Early"],
+        enableDatingSchedule: false,
+        datingSchedulePreset: "siriusSenior",
+        recreationTurns: [...DATING_SCHEDULE_PRESETS.siriusSenior.recreationTurns],
+        purePassionTurn: DATING_SCHEDULE_PRESETS.siriusSenior.purePassionTurn,
+        recreationTotalOutings: DATING_SCHEDULE_PRESETS.siriusSenior.totalOutings,
         waitDelay: 0.5,
         dialogWaitDelay: 0.5,
     },

--- a/src/context/searchConfig.ts
+++ b/src/context/searchConfig.ts
@@ -30,6 +30,13 @@ const searchConfig: SearchOption[] = [
         page: "SettingsMain",
     },
     {
+        id: "settings-recreation-catch-up",
+        title: "Catch Up On Missed Dates",
+        description: "If a scheduled outing gets skipped (e.g. a mandatory race lands on it), make it up on the next available turn instead of losing it.",
+        page: "SettingsMain",
+        parentId: "settings-dating-schedule",
+    },
+    {
         id: "settings-dating-preset",
         title: "Schedule Preset",
         description: "Pick an optimized preset (Pure Passion timed for a summer camp) or Custom to hand-pick turns on the recreation calendar.",

--- a/src/context/searchConfig.ts
+++ b/src/context/searchConfig.ts
@@ -23,6 +23,35 @@ const searchConfig: SearchOption[] = [
         page: "SettingsMain",
     },
     {
+        id: "settings-dating-schedule",
+        title: "Support Card Dating Schedule",
+        description:
+            "On a pinned turn the bot does a support-card recreation outing over every other action, including scheduled races (in-game racing agenda or Smart Race Solver). Only mandatory career-goal races take priority.",
+        page: "SettingsMain",
+    },
+    {
+        id: "settings-dating-preset",
+        title: "Schedule Preset",
+        description: "Pick an optimized preset (Pure Passion timed for a summer camp) or Custom to hand-pick turns on the recreation calendar.",
+        page: "SettingsMain",
+        parentId: "settings-dating-schedule",
+    },
+    {
+        id: "settings-recreation-calendar",
+        title: "Recreation Calendar",
+        description: "Tap a turn to mark it as a Recreation date or the single Pure Passion date (editing switches the preset to Custom). Pre-Debut and Summer turns are unavailable.",
+        page: "SettingsMain",
+        parentId: "settings-dating-schedule",
+    },
+    {
+        id: "settings-recreation-total-outings",
+        title: "Total Recreation Outings",
+        description:
+            "Number of outings in your support card's recreation chain. Team Sirius = 7, Heirs to the Throne = 4. Read from the game automatically when possible; this is the fallback. Used to hold the final outing for the Pure Passion turn.",
+        page: "SettingsMain",
+        parentId: "settings-dating-schedule",
+    },
+    {
         id: "settings-claw-machine-attempt",
         title: "Enable Claw Machine Attempt",
         description: "Attempt to complete the claw machine instead of stopping",
@@ -496,7 +525,8 @@ const searchConfig: SearchOption[] = [
     {
         id: "disable-schedule-replan-on-race-loss",
         title: "Disable Schedule Re-Plan Upon Race Loss",
-        description: "When a race is lost, keep the original schedule instead of re-planning the remaining turns. The loss is still recorded; epithets that depended on the lost race won't be re-routed.",
+        description:
+            "When a race is lost, keep the original schedule instead of re-planning the remaining turns. The loss is still recorded; epithets that depended on the lost race won't be re-routed.",
         page: "SmartRaceSolverSettings",
         parentId: "enable-smart-race-solver",
     },
@@ -832,8 +862,7 @@ const searchConfig: SearchOption[] = [
     {
         id: "trackblazer-skip-coaching-megaphone-below-gain",
         title: "Trackblazer Skip Coaching Megaphone Below Main Stat Gain",
-        description:
-            "Skip the Coaching Megaphone (+20% for 4 turns) when the selected training's main stat gain is below this value. 0 = always allowed.",
+        description: "Skip the Coaching Megaphone (+20% for 4 turns) when the selected training's main stat gain is below this value. 0 = always allowed.",
         page: "ScenarioOverridesSettings",
     },
     {

--- a/src/lib/datingSchedule.ts
+++ b/src/lib/datingSchedule.ts
@@ -1,0 +1,34 @@
+/** A named dating-schedule preset that fills the recreation calendar in one tap. */
+export interface DatingSchedulePreset {
+    /** Display label shown in the preset selector and the settings banner. */
+    label: string
+    /** Career turns (1-72) pinned for regular recreation outings - one per outing in the chain except the held final. */
+    recreationTurns: number[]
+    /** Career turn pinned for the single final outing that triggers Pure Passion. */
+    purePassionTurn: number
+    /** Length of the card's recreation chain - drives the hold-final counter so the last outing is saved for the Pure Passion date. */
+    totalOutings: number
+}
+
+/** Preset key meaning the user hand-edited the calendar, so no built-in preset turns apply. */
+export const DATING_SCHEDULE_CUSTOM = "custom"
+
+/**
+ * Built-in dating-schedule presets, keyed by a stable id stored in settings. Each preset is card-specific. The Heirs to the Throne preset holds its final outing
+ * for a Pure Passion turn late in the Senior year so the ~3-turn buff lands on Senior summer camp (the timing uma.guide recommends). The Team Sirius preset pins
+ * every recreation date and sets no Pure Passion turn, since Pure Passion summer-timing applies only to Heirs to the Throne. Each preset sets `totalOutings` to match its card.
+ */
+export const DATING_SCHEDULE_PRESETS: Record<string, DatingSchedulePreset> = {
+    siriusSenior: {
+        label: "Team Sirius",
+        recreationTurns: [29, 35, 43, 47, 52, 55, 58],
+        purePassionTurn: -1,
+        totalOutings: 7,
+    },
+    throneSenior: {
+        label: "Heirs to the Throne - Senior Summer",
+        recreationTurns: [35, 43, 52, 58],
+        purePassionTurn: 60,
+        totalOutings: 4,
+    },
+}

--- a/src/lib/messageLog/__tests__/buildSettingsBanner.test.ts
+++ b/src/lib/messageLog/__tests__/buildSettingsBanner.test.ts
@@ -4,7 +4,7 @@ import { buildSettingsBanner } from "../buildSettingsBanner"
 /**
  * Recursive proxy that returns sensible defaults for any property access. Any property reads as `0` when
  * coerced to a number, `""` when coerced to a string, `false` when coerced to boolean, and `[]` / `{}` for
- * the array/object methods this banner builder calls (`length`, `join`, `Object.keys`). Avoids hand-rolling
+ * the array/object methods this banner builder calls (`length`, `join`, `map`, `Object.keys`). Avoids hand-rolling
  * the full `Settings` shape just for a banner regression check.
  *
  * @returns A proxy object usable as a `Settings`-shaped stub.
@@ -14,6 +14,7 @@ const makeStubSettings = (): Settings => {
         get(_target, prop) {
             if (prop === "length") return 0
             if (prop === "join") return () => ""
+            if (prop === "map") return () => []
             if (prop === "split") return () => []
             if (prop === "trim") return () => ""
             if (prop === Symbol.toPrimitive) return () => 0

--- a/src/lib/messageLog/buildSettingsBanner.ts
+++ b/src/lib/messageLog/buildSettingsBanner.ts
@@ -239,7 +239,7 @@ ${longTargetsString}${formatAdvancedScoringSection(settings.training)}
 🌀 Enable Swipe-Based Scrolling: ${settings.general.enableSwipeBasedScrolling ? "✅" : "❌"}
 🛑 Stop Before Finals: ${settings.general.enableStopBeforeFinals ? "✅" : "❌"}
 🛑 Stop At Date: ${settings.general.enableStopAtDate ? `✅ (${settings.general.stopAtDates.join(", ")})` : "❌"}
-📅 Dating Schedule: ${settings.general.enableDatingSchedule ? `✅ (${DATING_SCHEDULE_PRESETS[settings.general.datingSchedulePreset]?.label ?? "Custom"} | Recreation: ${settings.general.recreationTurns.map(formatCareerTurn).join(", ") || "none"} | Pure Passion: ${settings.general.purePassionTurn > 0 ? formatCareerTurn(settings.general.purePassionTurn) : "none"} | Outings: ${settings.general.recreationTotalOutings})` : "❌"}
+📅 Dating Schedule: ${settings.general.enableDatingSchedule ? `✅ (${DATING_SCHEDULE_PRESETS[settings.general.datingSchedulePreset]?.label ?? "Custom"} | Recreation: ${settings.general.recreationTurns.map(formatCareerTurn).join(", ") || "none"} | Pure Passion: ${settings.general.purePassionTurn > 0 ? formatCareerTurn(settings.general.purePassionTurn) : "none"} | Outings: ${settings.general.recreationTotalOutings} | Catch-up: ${settings.general.enableRecreationCatchUp ? "on" : "off"})` : "❌"}
 ⏰ Wait Delay: ${settings.general.waitDelay}s
 ⏰ Dialog Wait Delay: ${settings.general.dialogWaitDelay}s
 

--- a/src/lib/messageLog/buildSettingsBanner.ts
+++ b/src/lib/messageLog/buildSettingsBanner.ts
@@ -1,5 +1,7 @@
 import { Settings } from "../../context/BotStateContext"
 import { SCORING_CONSTANTS_CATALOG } from "../training/scoringConstantsCatalog"
+import { formatCareerTurn } from "../solver/constants"
+import { DATING_SCHEDULE_PRESETS } from "../datingSchedule"
 
 /**
  * Parse `raw` as JSON, returning `fallback` (and adopting its type) when `raw` is empty or malformed.
@@ -237,6 +239,7 @@ ${longTargetsString}${formatAdvancedScoringSection(settings.training)}
 🌀 Enable Swipe-Based Scrolling: ${settings.general.enableSwipeBasedScrolling ? "✅" : "❌"}
 🛑 Stop Before Finals: ${settings.general.enableStopBeforeFinals ? "✅" : "❌"}
 🛑 Stop At Date: ${settings.general.enableStopAtDate ? `✅ (${settings.general.stopAtDates.join(", ")})` : "❌"}
+📅 Dating Schedule: ${settings.general.enableDatingSchedule ? `✅ (${DATING_SCHEDULE_PRESETS[settings.general.datingSchedulePreset]?.label ?? "Custom"} | Recreation: ${settings.general.recreationTurns.map(formatCareerTurn).join(", ") || "none"} | Pure Passion: ${settings.general.purePassionTurn > 0 ? formatCareerTurn(settings.general.purePassionTurn) : "none"} | Outings: ${settings.general.recreationTotalOutings})` : "❌"}
 ⏰ Wait Delay: ${settings.general.waitDelay}s
 ⏰ Dialog Wait Delay: ${settings.general.dialogWaitDelay}s
 

--- a/src/lib/solver/constants.ts
+++ b/src/lib/solver/constants.ts
@@ -221,6 +221,18 @@ export const turnDateLabel = (turnInYear: number): string => {
     return `${half} ${month}`
 }
 
+/**
+ * Full "Year Month Phase" label for an absolute 1-indexed career turn (1-72). Junior is turns 1-24, Classic 25-48, Senior 49-72.
+ * Example: turn 60 returns "Senior Late Jun".
+ *
+ * @param turn The absolute 1-indexed career turn number (1-72).
+ * @returns The "Junior/Classic/Senior Early/Late <Month>" label.
+ */
+export const formatCareerTurn = (turn: number): string => {
+    const yearName = turn <= 24 ? "Junior" : turn <= 48 ? "Classic" : "Senior"
+    return `${yearName} ${turnDateLabel((turn - 1) % 24)}`
+}
+
 const RACE_NAME_ABBREVIATIONS: Record<string, string> = {
     "Hanshin Juvenile Fillies": "Hanshin Juv. F.",
     "Mile Championship": "Mile Champ.",

--- a/src/pages/Settings/index.tsx
+++ b/src/pages/Settings/index.tsx
@@ -519,6 +519,14 @@ const Settings = () => {
 
                     {general.enableDatingSchedule && (
                         <>
+                            <ToggleSetting
+                                id="settings-recreation-catch-up"
+                                title="Catch Up On Missed Dates"
+                                description="If a scheduled outing gets skipped (e.g. a mandatory race lands on it), make it up on the next available turn instead of losing it."
+                                checked={general.enableRecreationCatchUp}
+                                onCheckedChange={(checked) => updateGeneral({ enableRecreationCatchUp: checked })}
+                            />
+
                             <SearchableItem
                                 id="settings-dating-preset"
                                 title="Schedule Preset"

--- a/src/pages/Settings/index.tsx
+++ b/src/pages/Settings/index.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useContext, useEffect, useState, useRef, useCallback } from "react"
 import { SearchPageProvider } from "../../context/SearchPageContext"
 import { BotMetaContext, GeneralMiscContext } from "../../context/BotStateContext"
-import { InteractionManager, Pressable, ScrollView, StyleSheet, Text, View } from "react-native"
+import { Dimensions, InteractionManager, Pressable, ScrollView, StyleSheet, Text, View } from "react-native"
 import { Snackbar } from "react-native-paper"
 import { useNavigation } from "@react-navigation/native"
 import { Ionicons } from "@react-native-vector-icons/ionicons"
@@ -12,17 +12,73 @@ import CustomSlider from "../../components/CustomSlider"
 import CustomButton from "../../components/CustomButton"
 import PageHeader from "../../components/PageHeader"
 import { Row } from "../../components/ui/row"
+import { Switch } from "../../components/ui/switch"
 import { Section } from "../../components/ui/section"
 import WarningContainer from "../../components/WarningContainer"
+import InfoContainer from "../../components/InfoContainer"
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from "../../components/ui/alert-dialog"
 import SearchableItem from "../../components/SearchableItem"
 import ToggleSetting from "../../components/ToggleSetting"
+import SeasonCalendar, { useSeasonCalendarStyles } from "../../components/SeasonCalendar"
+import { Popover, PopoverContent, PopoverTrigger, usePopoverRootContext } from "../../components/ui/popover"
+import { formatCareerTurn, turnDateLabel } from "../../lib/solver/constants"
+import { DATING_SCHEDULE_CUSTOM, DATING_SCHEDULE_PRESETS } from "../../lib/datingSchedule"
 import { useSettings } from "../../context/SettingsContext"
 import { useSettingsFileManager } from "../../hooks/useSettingsFileManager"
 import { usePerformanceLogging } from "../../hooks/usePerformanceLogging"
 import { TYPE } from "../../lib/type"
 import { SPACING } from "../../lib/spacing"
 import { RADII } from "../../lib/radii"
+
+/** Preset options for the recreation dating-schedule selector, plus a Custom entry for hand-editing the calendar. */
+const datingPresetOptions = [...Object.entries(DATING_SCHEDULE_PRESETS).map(([value, preset]) => ({ label: preset.label, value })), { label: "Custom", value: DATING_SCHEDULE_CUSTOM }]
+
+/** Props for RecreationDateActions. */
+interface RecreationDateActionsProps {
+    /** The career turn (1-72) this popover is acting on. */
+    turn: number
+    /** Whether this turn is currently pinned as a regular recreation date. */
+    isRecreation: boolean
+    /** Whether this turn is currently the single Pure Passion final date. */
+    isPurePassion: boolean
+    /** Marks the turn as a regular recreation date, or clears it when toggled off. */
+    onMark: (turn: number) => void
+    /** Sets the turn as the single Pure Passion final date. */
+    onSetPurePassion: (turn: number) => void
+    /** Clears the turn from whichever role it currently holds. */
+    onClear: (turn: number) => void
+}
+
+/**
+ * The recreation-cell popover body: one switch pins the turn as a regular Recreation date and one marks it as the single Pure Passion final date.
+ * Only one turn can be the Pure Passion date, so toggling it on moves it here off any other turn. Reads the popover root context so each toggle also dismisses the popover.
+ * @param turn The career turn this popover is acting on.
+ * @param isRecreation Whether this turn is currently pinned as a regular recreation date.
+ * @param isPurePassion Whether this turn is currently the single Pure Passion final date.
+ * @param onMark Marks the turn as a regular recreation date.
+ * @param onSetPurePassion Sets the turn as the single Pure Passion final date.
+ * @param onClear Clears the turn from whichever role it currently holds.
+ * @returns The rendered switch rows.
+ */
+function RecreationDateActions({ turn, isRecreation, isPurePassion, onMark, onSetPurePassion, onClear }: RecreationDateActionsProps) {
+    const { onOpenChange } = usePopoverRootContext()
+    // Toggling a role on applies it; toggling off clears the turn. Either way the popover dismisses.
+    const toggleRole = (value: boolean, apply: (turn: number) => void) => {
+        if (value) apply(turn)
+        else onClear(turn)
+        onOpenChange(false)
+    }
+    return (
+        <>
+            <Row title="Recreation date" right={<Switch checked={isRecreation} onCheckedChange={(value) => toggleRole(value, onMark)} />} />
+            <Row
+                title="Pure Passion final date"
+                description="Only one date can trigger Pure Passion."
+                right={<Switch checked={isPurePassion} onCheckedChange={(value) => toggleRole(value, onSetPurePassion)} />}
+            />
+        </>
+    )
+}
 
 /**
  * The main Settings page of the application.
@@ -35,7 +91,10 @@ const Settings = () => {
 
     const { defaultSettings } = useContext(BotMetaContext)
     const { general, misc, updateGeneral, updateMisc } = useContext(GeneralMiscContext)
+    const calStyles = useSeasonCalendarStyles()
     const { colors } = useTheme()
+    // Width for the recreation-cell popovers, computed once instead of per calendar cell.
+    const recreationPopoverStyle = useMemo(() => ({ width: Math.min(280, Dimensions.get("window").width - 24) }), [])
     const navigation = useNavigation()
 
     const { openDataDirectory, resetSettings } = useSettings()
@@ -87,6 +146,7 @@ const Settings = () => {
                 dateRemoveButton: { padding: SPACING.xs, borderRadius: 999, overflow: "hidden" as const },
                 dateSelectorRow: { flexDirection: "row" },
                 dateSelectorCell: { flex: 1 },
+                resetLink: { ...TYPE.caption, color: colors.brand, fontWeight: "600" as const },
             }),
         [colors]
     )
@@ -223,13 +283,134 @@ const Settings = () => {
         )
     }
 
+    const handleDatingPresetChange = useCallback(
+        (preset: string) => {
+            const selected = DATING_SCHEDULE_PRESETS[preset]
+            if (selected) {
+                updateGeneral({
+                    datingSchedulePreset: preset,
+                    recreationTurns: [...selected.recreationTurns],
+                    purePassionTurn: selected.purePassionTurn,
+                    recreationTotalOutings: selected.totalOutings,
+                })
+            } else {
+                updateGeneral({ datingSchedulePreset: DATING_SCHEDULE_CUSTOM, recreationTurns: [], purePassionTurn: -1 })
+            }
+        },
+        [updateGeneral]
+    )
+
+    const handleMarkRecreationTurn = useCallback(
+        (turn: number) => {
+            updateGeneral((prev) => ({
+                ...prev,
+                datingSchedulePreset: DATING_SCHEDULE_CUSTOM,
+                recreationTurns: prev.recreationTurns.includes(turn) ? prev.recreationTurns : [...prev.recreationTurns, turn].sort((a, b) => a - b),
+                purePassionTurn: prev.purePassionTurn === turn ? -1 : prev.purePassionTurn,
+            }))
+        },
+        [updateGeneral]
+    )
+
+    const handleSetPurePassionTurn = useCallback(
+        (turn: number) => {
+            updateGeneral((prev) => ({ ...prev, datingSchedulePreset: DATING_SCHEDULE_CUSTOM, purePassionTurn: turn, recreationTurns: prev.recreationTurns.filter((t) => t !== turn) }))
+        },
+        [updateGeneral]
+    )
+
+    const handleClearRecreationTurn = useCallback(
+        (turn: number) => {
+            updateGeneral((prev) => ({
+                ...prev,
+                datingSchedulePreset: DATING_SCHEDULE_CUSTOM,
+                recreationTurns: prev.recreationTurns.filter((t) => t !== turn),
+                purePassionTurn: prev.purePassionTurn === turn ? -1 : prev.purePassionTurn,
+            }))
+        },
+        [updateGeneral]
+    )
+
+    const resetDatingSchedule = useCallback(() => {
+        updateGeneral({
+            datingSchedulePreset: defaultSettings.general.datingSchedulePreset,
+            recreationTurns: [...defaultSettings.general.recreationTurns],
+            purePassionTurn: defaultSettings.general.purePassionTurn,
+            recreationTotalOutings: defaultSettings.general.recreationTotalOutings,
+        })
+    }, [updateGeneral, defaultSettings])
+
+    /** Shared "Reset" pressable used in a section label's right slot. */
+    const makeResetLink = (onPress: () => void) => (
+        <Pressable onPress={onPress} android_ripple={{ color: colors.ripple, foreground: true }} hitSlop={8}>
+            <Text style={styles.resetLink}>Reset</Text>
+        </Pressable>
+    )
+
     const renderMiscSettings = () => {
+        const renderRecreationPopover = (turn: number) => {
+            const isRecreation = general.recreationTurns.includes(turn)
+            const isPurePassion = general.purePassionTurn === turn
+            return (
+                <View style={{ gap: SPACING.sm }}>
+                    <Text style={styles.dateTitle}>{formatCareerTurn(turn)}</Text>
+                    <RecreationDateActions
+                        turn={turn}
+                        isRecreation={isRecreation}
+                        isPurePassion={isPurePassion}
+                        onMark={handleMarkRecreationTurn}
+                        onSetPurePassion={handleSetPurePassionTurn}
+                        onClear={handleClearRecreationTurn}
+                    />
+                </View>
+            )
+        }
+
+        // A turn set as the Pure Passion final date shows the amber "mandatory" border and the Pure Passion marker. A plain recreation turn shows the brand border and the recreation marker.
+        const renderRecreationCell = (turn: number, turnInYear: number) => {
+            const isRecreation = general.recreationTurns.includes(turn)
+            const isPurePassion = general.purePassionTurn === turn
+            return (
+                <View key={turn} style={calStyles.calendarCellWrapper}>
+                    <Popover>
+                        <PopoverTrigger asChild>
+                            <Pressable
+                                style={[calStyles.calendarCell, isRecreation && calStyles.calendarCellLocked, isPurePassion && calStyles.calendarCellMandatory]}
+                                android_ripple={{ color: colors.ripple, foreground: true }}
+                            >
+                                <Text style={calStyles.calendarCellEmpty}>{isPurePassion ? "✨" : isRecreation ? "📅" : "—"}</Text>
+                            </Pressable>
+                        </PopoverTrigger>
+                        <PopoverContent side="top" align="center" insets={{ top: 60, bottom: 60, left: 12, right: 12 }} className="p-3" style={recreationPopoverStyle}>
+                            {renderRecreationPopover(turn)}
+                        </PopoverContent>
+                    </Popover>
+                    <Text style={calStyles.calendarDateLabel}>
+                        {isPurePassion ? "✨ " : isRecreation ? "📅 " : ""}
+                        {turnDateLabel(turnInYear)}
+                    </Text>
+                </View>
+            )
+        }
+
         return (
             <View>
                 <Section label="MISC">
-                    <ToggleSetting id="settings-stop-before-finals" title="Stop before Finals" description="Pause to buy skills before the final races" checked={general.enableStopBeforeFinals} onCheckedChange={(checked) => updateGeneral({ enableStopBeforeFinals: checked })} />
+                    <ToggleSetting
+                        id="settings-stop-before-finals"
+                        title="Stop before Finals"
+                        description="Pause to buy skills before the final races"
+                        checked={general.enableStopBeforeFinals}
+                        onCheckedChange={(checked) => updateGeneral({ enableStopBeforeFinals: checked })}
+                    />
 
-                    <ToggleSetting id="settings-stop-at-date" title="Stop at Date" description="Stop on one or more specified dates" checked={general.enableStopAtDate} onCheckedChange={(checked) => updateGeneral({ enableStopAtDate: checked })} />
+                    <ToggleSetting
+                        id="settings-stop-at-date"
+                        title="Stop at Date"
+                        description="Stop on one or more specified dates"
+                        checked={general.enableStopAtDate}
+                        onCheckedChange={(checked) => updateGeneral({ enableStopAtDate: checked })}
+                    />
 
                     {general.enableStopAtDate && (
                         <SearchableItem id="settings-target-dates" title="Target Dates" description="Stops the bot on the specified dates." parentId="settings-stop-at-date">
@@ -302,11 +483,104 @@ const Settings = () => {
                         </SearchableItem>
                     )}
 
-                    <ToggleSetting id="settings-claw-machine-attempt" title="Enable Claw Machine Attempt" description="Attempt to complete the claw machine instead of stopping" checked={general.enableClawMachineAttempt} onCheckedChange={(checked) => updateGeneral({ enableClawMachineAttempt: checked })} />
+                    <ToggleSetting
+                        id="settings-claw-machine-attempt"
+                        title="Enable Claw Machine Attempt"
+                        description="Attempt to complete the claw machine instead of stopping"
+                        checked={general.enableClawMachineAttempt}
+                        onCheckedChange={(checked) => updateGeneral({ enableClawMachineAttempt: checked })}
+                    />
 
-                    <ToggleSetting id="settings-enable-swipe-based-scrolling" title="Enable Swipe-Based Scrolling" description="Scroll lists by swiping instead of detecting the in-game scrollbar. Enable this if the bot cannot scroll lists normally. This may or may not work depending on the device." checked={general.enableSwipeBasedScrolling} onCheckedChange={(checked) => updateGeneral({ enableSwipeBasedScrolling: checked })} />
+                    <ToggleSetting
+                        id="settings-enable-swipe-based-scrolling"
+                        title="Enable Swipe-Based Scrolling"
+                        description="Scroll lists by swiping instead of detecting the in-game scrollbar. Enable this if the bot cannot scroll lists normally. This may or may not work depending on the device."
+                        checked={general.enableSwipeBasedScrolling}
+                        onCheckedChange={(checked) => updateGeneral({ enableSwipeBasedScrolling: checked })}
+                    />
 
-                    <ToggleSetting id="settings-enable-settings-display" title="Enable Settings Display in Message Log" description="Show current bot configuration in the message log" checked={misc.enableSettingsDisplay} onCheckedChange={(checked) => updateMisc({ enableSettingsDisplay: checked })} />
+                    <ToggleSetting
+                        id="settings-enable-settings-display"
+                        title="Enable Settings Display in Message Log"
+                        description="Show current bot configuration in the message log"
+                        checked={misc.enableSettingsDisplay}
+                        onCheckedChange={(checked) => updateMisc({ enableSettingsDisplay: checked })}
+                    />
+                </Section>
+
+                <Section label="SUPPORT CARD DATING" labelRight={makeResetLink(resetDatingSchedule)}>
+                    <ToggleSetting
+                        id="settings-dating-schedule"
+                        title="Support Card Dating Schedule"
+                        description="On a pinned turn the bot does a support-card recreation outing over every other action, including scheduled races (your in-game racing agenda or the Smart Race Solver). Only mandatory career-goal races take priority."
+                        checked={general.enableDatingSchedule}
+                        onCheckedChange={(checked) => updateGeneral({ enableDatingSchedule: checked })}
+                    />
+
+                    {general.enableDatingSchedule && (
+                        <>
+                            <SearchableItem
+                                id="settings-dating-preset"
+                                title="Schedule Preset"
+                                description="Pick an optimized preset (Pure Passion timed for a summer camp) or Custom to hand-pick turns on the calendar below."
+                                parentId="settings-dating-schedule"
+                            >
+                                <View style={{ padding: SPACING.md, paddingBottom: 0 }}>
+                                    <CustomSelect
+                                        placeholder="Preset"
+                                        width="100%"
+                                        options={datingPresetOptions}
+                                        value={general.datingSchedulePreset}
+                                        onValueChange={(value) => handleDatingPresetChange(value || DATING_SCHEDULE_CUSTOM)}
+                                    />
+                                </View>
+                                {general.purePassionTurn > 0 && (
+                                    <View style={{ paddingHorizontal: SPACING.md }}>
+                                        <InfoContainer>
+                                            Pure Passion activates when you complete the Heir to the Throne's final recreation date. For about 3 turns, Friendship Training occurs on a facility
+                                            regardless of bond. This preset pins one date per outing and holds the final one for Senior June Late, so those turns land on Senior Summer Training where
+                                            the gains matter most.
+                                        </InfoContainer>
+                                    </View>
+                                )}
+                            </SearchableItem>
+
+                            <SearchableItem
+                                id="settings-recreation-calendar"
+                                title="Recreation Calendar"
+                                description="Tap a turn to mark it as a Recreation date or the single Pure Passion date (editing switches the preset to Custom). Pre-Debut and Summer turns are unavailable."
+                                parentId="settings-dating-schedule"
+                            >
+                                <View style={{ paddingHorizontal: SPACING.md }}>
+                                    <SeasonCalendar renderCell={renderRecreationCell} deps={[general.recreationTurns, general.purePassionTurn]} />
+                                </View>
+                            </SearchableItem>
+
+                            <SearchableItem
+                                id="settings-recreation-total-outings"
+                                title="Total Recreation Outings"
+                                description="Number of outings in your support card's recreation chain. Team Sirius = 7, Heirs to the Throne = 4. Read from the game automatically when possible; this is the fallback. Used to hold the final outing for the Pure Passion turn."
+                                parentId="settings-dating-schedule"
+                            >
+                                <View style={{ padding: SPACING.md }}>
+                                    <CustomSlider
+                                        searchId="settings-recreation-total-outings"
+                                        value={general.recreationTotalOutings}
+                                        placeholder={defaultSettings.general.recreationTotalOutings}
+                                        onValueChange={(value) => updateGeneral({ recreationTotalOutings: value })}
+                                        onSlidingComplete={(value) => updateGeneral({ recreationTotalOutings: value })}
+                                        min={1}
+                                        max={10}
+                                        step={1}
+                                        label="Total Recreation Outings"
+                                        showValue={true}
+                                        showLabels={true}
+                                        description="Team Sirius = 7, Heirs to the Throne = 4. Pin enough Recreation dates before the Pure Passion date."
+                                    />
+                                </View>
+                            </SearchableItem>
+                        </>
+                    )}
                 </Section>
 
                 <Section label="WAIT DELAY">

--- a/src/pages/SmartRaceSolverSettings/index.tsx
+++ b/src/pages/SmartRaceSolverSettings/index.tsx
@@ -14,11 +14,11 @@ import {
     OPTIMIZE_MODE_PRESETS,
     OptimizeModeKey,
     RaceEntry,
+    formatCareerTurn,
     shortenRaceName,
     TRAIN_LOCK_SENTINEL,
     turnDateLabel,
     WeightsMap,
-    YEAR_LABELS,
 } from "../../lib/solver/constants"
 import {
     charactersForEpithet,
@@ -46,6 +46,7 @@ import PageHeader from "../../components/PageHeader"
 import { usePerformanceLogging } from "../../hooks/usePerformanceLogging"
 import SearchableItem from "../../components/SearchableItem"
 import ToggleSetting from "../../components/ToggleSetting"
+import SeasonCalendar, { useSeasonCalendarStyles } from "../../components/SeasonCalendar"
 import CustomSlider from "../../components/CustomSlider"
 import { useNavigation, useFocusEffect } from "@react-navigation/native"
 import { AptitudeRow, EpithetChip } from "./components/Helpers"
@@ -778,67 +779,6 @@ const SmartRaceSolverSettings = () => {
                     borderRadius: RADII.pill,
                 },
                 countBadgeText: { ...TYPE.monoLabel, color: colors.onBrand, fontSize: 9 },
-                yearCard: {
-                    marginVertical: 8,
-                    padding: 12,
-                    borderWidth: 1,
-                    borderColor: colors.borderHair,
-                    borderRadius: 8,
-                    backgroundColor: colors.bg,
-                },
-                yearCardTitle: { fontSize: 16, fontWeight: "700", color: colors.text, marginBottom: 6 },
-                calendarRow: { flexDirection: "row", alignItems: "stretch", paddingVertical: 4 },
-                calendarCellWrapper: { flex: 1, marginHorizontal: 3, alignItems: "stretch" },
-                calendarCell: {
-                    flexDirection: "column",
-                    alignItems: "center",
-                    justifyContent: "center",
-                    paddingVertical: 6,
-                    paddingHorizontal: 4,
-                    borderRadius: 6,
-                    borderWidth: 1,
-                    borderColor: colors.borderHair,
-                    backgroundColor: colors.surface,
-                    minHeight: 56,
-                },
-                calendarCellRace: {
-                    backgroundColor: colors.surface,
-                },
-                calendarBadge: {
-                    minWidth: 30,
-                    height: 18,
-                    borderRadius: 3,
-                    paddingHorizontal: 4,
-                    marginBottom: 4,
-                    alignItems: "center",
-                    justifyContent: "center",
-                },
-                calendarBadgeText: { color: "#fff", fontSize: 10, fontWeight: "700" },
-                calendarRaceName: { fontSize: 10, color: colors.text, fontWeight: "600", textAlign: "center" },
-                calendarCellEmpty: { fontSize: 11, color: colors.textMuted, textAlign: "center" },
-                calendarCellPreDebut: {
-                    backgroundColor: colors.surfaceRaised,
-                    borderColor: colors.borderHair,
-                    borderStyle: "dashed",
-                    opacity: 0.6,
-                },
-                calendarCellPreDebutText: {
-                    fontSize: 10,
-                    color: colors.textMuted,
-                    fontStyle: "italic",
-                    fontWeight: "600",
-                    textAlign: "center",
-                },
-                calendarDateLabel: { fontSize: 10, color: colors.textMuted, textAlign: "center", marginTop: 3 },
-                calendarCellLocked: {
-                    borderWidth: 2,
-                    borderColor: colors.brand,
-                },
-                calendarCellMandatory: {
-                    borderWidth: 2,
-                    borderColor: "#f59e0b",
-                    backgroundColor: "rgba(245, 158, 11, 0.12)",
-                },
                 popoverColumn: { flexShrink: 1 },
                 popoverHeader: { flexShrink: 0 },
                 popoverBodyScroll: { flexShrink: 1, marginTop: 4 },
@@ -892,15 +832,6 @@ const SmartRaceSolverSettings = () => {
                     borderWidth: 2,
                     backgroundColor: colors.surfaceRaised,
                 },
-                calendarCellHighlighted: {
-                    borderColor: "#ca8a04",
-                    borderWidth: 3,
-                    shadowColor: "#facc15",
-                    shadowOpacity: 0.9,
-                    shadowRadius: 6,
-                    shadowOffset: { width: 0, height: 0 },
-                    elevation: 4,
-                },
                 epithetCardName: { fontSize: 13, fontWeight: "700", color: colors.text, marginBottom: 2 },
                 epithetCardReward: { fontSize: 11, color: colors.text, marginBottom: 1 },
                 epithetCardCondition: { fontSize: 11, color: colors.textMuted, fontStyle: "italic" },
@@ -921,6 +852,8 @@ const SmartRaceSolverSettings = () => {
         [colors]
     )
 
+    const calStyles = useSeasonCalendarStyles()
+
     // //////////////////////////////////////////////////////////////////////////////////////////////////
     // //////////////////////////////////////////////////////////////////////////////////////////////////
     // Helpers
@@ -936,9 +869,7 @@ const SmartRaceSolverSettings = () => {
      * @returns The popover body element.
      */
     const renderPopoverBody = (turn: number, entry: ScheduleEntry | undefined) => {
-        const turnYearOffset = (turn - 1) % 24
-        const yearName = turn <= 24 ? "Junior" : turn <= 48 ? "Classic" : "Senior"
-        const fullDateLabel = `${yearName} ${turnDateLabel(turnYearOffset)}`
+        const fullDateLabel = formatCareerTurn(turn)
         const isRace = entry?.type === "Race"
         const race = isRace && entry?.raceKey ? racesByKey[entry.raceKey] : undefined
         // Only list epithets this race actually contributes to: drop ones whose required count is already satisfied earlier in the schedule.
@@ -1037,7 +968,7 @@ const SmartRaceSolverSettings = () => {
                                             android_ripple={{ color: colors.ripple, foreground: true }}
                                         >
                                             <View style={[styles.popoverAltBadge, { backgroundColor: altColor }]}>
-                                                <Text style={styles.calendarBadgeText}>{alt.grade.replace("PRE_OP", "Pre").replace("PRE-OP", "Pre")}</Text>
+                                                <Text style={calStyles.calendarBadgeText}>{alt.grade.replace("PRE_OP", "Pre").replace("PRE-OP", "Pre")}</Text>
                                             </View>
                                             <View style={{ flex: 1 }}>
                                                 <Text style={styles.popoverAltName}>{alt.name}</Text>
@@ -1100,47 +1031,34 @@ const SmartRaceSolverSettings = () => {
         const color = isRace ? (GRADE_COLORS[entry.grade ?? ""] ?? colors.brand) : null
         const shortRaceName = isRace ? shortenRaceName(entry.name ?? entry.raceKey ?? "") : ""
         const dateLabel = turnDateLabel(turnInYear)
-        const isPreDebut = turn <= 13
-        const isSummerBlocked = !weights.allowSummerRacing && ((turn >= 37 && turn <= 40) || (turn >= 61 && turn <= 64))
         const isLocked = manualLocks[String(turn)] != null
         const isMandatory = isRace && entry?.mandatory === true
         const highlightHit = isRace && contributingTurnsForHighlight.has(turn)
 
-        if (isPreDebut || isSummerBlocked) {
-            return (
-                <View key={turn} style={styles.calendarCellWrapper}>
-                    <View style={[styles.calendarCell, styles.calendarCellPreDebut]}>
-                        <Text style={styles.calendarCellPreDebutText}>{isPreDebut ? "Pre-Debut" : "Summer"}</Text>
-                    </View>
-                    <Text style={styles.calendarDateLabel}>{dateLabel}</Text>
-                </View>
-            )
-        }
-
         const cellInner = isRace ? (
             <>
-                <View style={[styles.calendarBadge, { backgroundColor: color! }]}>
-                    <Text style={styles.calendarBadgeText}>{(entry.grade ?? "").replace("PRE_OP", "Pre").replace("FINALE", "Fin").replace("MAIDEN", "Mdn").replace("DEBUT", "Dbt")}</Text>
+                <View style={[calStyles.calendarBadge, { backgroundColor: color! }]}>
+                    <Text style={calStyles.calendarBadgeText}>{(entry.grade ?? "").replace("PRE_OP", "Pre").replace("FINALE", "Fin").replace("MAIDEN", "Mdn").replace("DEBUT", "Dbt")}</Text>
                 </View>
-                <Text style={styles.calendarRaceName} numberOfLines={2} ellipsizeMode="tail">
+                <Text style={calStyles.calendarRaceName} numberOfLines={2} ellipsizeMode="tail">
                     {shortRaceName}
                 </Text>
             </>
         ) : (
-            <Text style={styles.calendarCellEmpty}>{entry?.type === "Rest" ? "Rest" : "—"}</Text>
+            <Text style={calStyles.calendarCellEmpty}>{entry?.type === "Rest" ? "Rest" : "—"}</Text>
         )
 
         return (
-            <View key={turn} style={styles.calendarCellWrapper}>
+            <View key={turn} style={calStyles.calendarCellWrapper}>
                 <Popover>
                     <PopoverTrigger asChild>
                         <Pressable
                             style={[
-                                styles.calendarCell,
-                                isRace && styles.calendarCellRace,
-                                isMandatory && styles.calendarCellMandatory,
-                                isLocked && styles.calendarCellLocked,
-                                highlightHit && styles.calendarCellHighlighted,
+                                calStyles.calendarCell,
+                                isRace && calStyles.calendarCellRace,
+                                isMandatory && calStyles.calendarCellMandatory,
+                                isLocked && calStyles.calendarCellLocked,
+                                highlightHit && calStyles.calendarCellHighlighted,
                             ]}
                             android_ripple={{ color: colors.ripple, foreground: true }}
                         >
@@ -1158,7 +1076,7 @@ const SmartRaceSolverSettings = () => {
                         {renderPopoverBody(turn, entry)}
                     </PopoverContent>
                 </Popover>
-                <Text style={styles.calendarDateLabel}>
+                <Text style={calStyles.calendarDateLabel}>
                     {isMandatory ? "📌 " : isLocked ? "🔒 " : ""}
                     {dateLabel}
                 </Text>
@@ -1195,33 +1113,6 @@ const SmartRaceSolverSettings = () => {
         if (!ep) return new Set<number>()
         return turnsContributingToEpithet(ep, preview, racesByKey)
     }, [highlightedEpithet, preview, racesByKey])
-
-    /**
-     * Render one year's 4x6 calendar card.
-     *
-     * @param year The year descriptor (heading name and the absolute turn number of the
-     *   top-left cell).
-     * @returns The rendered year card.
-     */
-    const renderYearCard = (year: { name: string; startTurn: number }) => {
-        const rows: number[][] = []
-        for (let r = 0; r < 6; r++) rows.push([0, 1, 2, 3].map((c) => r * 4 + c))
-        return (
-            <View key={year.name} style={styles.yearCard}>
-                <Text style={styles.yearCardTitle}>{year.name} Year</Text>
-                {rows.map((row, ridx) => (
-                    <View key={`row-${ridx}`} style={styles.calendarRow}>
-                        {row.map((turnInYear) => renderCalendarCell(year.startTurn + turnInYear, turnInYear))}
-                    </View>
-                ))}
-            </View>
-        )
-    }
-
-    // Memoized 72-cell grid: rebuild only when the preview, locks, summer-blackout weight, or highlight change.
-    // Other settings refresh inside popovers when next opened.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    const calendarYearCards = useMemo(() => YEAR_LABELS.map(renderYearCard), [preview, manualLocks, weights.allowSummerRacing, highlightedEpithet, contributingTurnsForHighlight])
 
     // //////////////////////////////////////////////////////////////////////////////////////////////////
     // //////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1287,7 +1178,15 @@ const SmartRaceSolverSettings = () => {
 
                         {enableSmartRaceSolver && (
                             <Section label="General" collapsible defaultOpen={true}>
-                                <ToggleSetting id="disable-schedule-replan-on-race-loss" title="Disable Schedule Re-Plan Upon Race Loss" description="When a race is lost, keep the original schedule instead of re-planning the remaining turns. The loss is still recorded; epithets that depended on the lost race won't be re-routed." condition={enableSmartRaceSolver} parentId="enable-smart-race-solver" checked={disableScheduleReplanOnRaceLoss} onCheckedChange={(checked) => updateRacingSetting("disableScheduleReplanOnRaceLoss", checked)} />
+                                <ToggleSetting
+                                    id="disable-schedule-replan-on-race-loss"
+                                    title="Disable Schedule Re-Plan Upon Race Loss"
+                                    description="When a race is lost, keep the original schedule instead of re-planning the remaining turns. The loss is still recorded; epithets that depended on the lost race won't be re-routed."
+                                    condition={enableSmartRaceSolver}
+                                    parentId="enable-smart-race-solver"
+                                    checked={disableScheduleReplanOnRaceLoss}
+                                    onCheckedChange={(checked) => updateRacingSetting("disableScheduleReplanOnRaceLoss", checked)}
+                                />
 
                                 <View style={{ paddingHorizontal: SPACING.md, paddingVertical: SPACING.sm }}>
                                     <CustomSlider
@@ -1813,7 +1712,11 @@ const SmartRaceSolverSettings = () => {
                                                     </View>
                                                 </View>
                                             )}
-                                            {calendarYearCards}
+                                            <SeasonCalendar
+                                                allowSummer={weights.allowSummerRacing}
+                                                renderCell={renderCalendarCell}
+                                                deps={[preview, manualLocks, highlightedEpithet, contributingTurnsForHighlight]}
+                                            />
                                         </View>
                                     </SearchableItem>
                                 </Section>


### PR DESCRIPTION
## Description
- This PR resolves #386 by adding a support-card dating schedule to the Settings page: a turn-indexed `SeasonCalendar` picker pins recreation outings and an optional Pure Passion final date, and the bot holds the final outing for `purePassionTurn` so the buff lands on Senior Summer Training.
- Provides presets for `Team Sirius` and `Heirs to the Throne` schedules.
- On pinned turns the bot does the outing over scheduled and Smart Race Solver races (only mandatory career races win) and reads the live "Group Event Progress X/Y" via OCR; with `enableRecreationCatchUp` on it makes up a missed outing on the next available turn, and once the Pure Passion date passes with the chain unfinished it abandons the schedule back to regular recreation logic.

Original problem:

```
[RECREATION_DATE] Recreating with the trainee (normal recreation), leaving the date chain for the schedule.
[ENERGY] Successfully recovered energy via rest.
[RECREATION_DATE] Choose Recreation Partner dialog left open. Closing it.
```