### PR TITLE
Unify settings option pickers on the shared modal selector pattern

### DIFF
--- a/src/components/CustomSelect/index.tsx
+++ b/src/components/CustomSelect/index.tsx
@@ -14,6 +14,8 @@ interface SelectOption {
     value: string
     /** The display label for this option. */
     label: string
+    /** Optional muted description rendered below the label inside the dropdown. Use to explain an ambiguous option value. */
+    description?: string
     /** Whether this option is disabled. */
     disabled?: boolean
 }
@@ -27,6 +29,8 @@ interface CustomSelectProps {
     width?: string | number
     /** Optional label displayed above the options in the dropdown. */
     groupLabel?: string
+    /** Optional muted intro line rendered at the top of the dropdown, below the group label. Distinct from `description`, which renders outside the trigger. */
+    menuDescription?: string
     /** Callback fired when the selected value changes. */
     onValueChange?: (value: string | undefined) => void
     /** Optional state setter for two-way binding of the selected value. */
@@ -67,6 +71,7 @@ interface CustomSelectProps {
  * @param options The list of selectable options.
  * @param width The width of the select trigger.
  * @param groupLabel Optional label displayed above the options in the dropdown.
+ * @param menuDescription Optional muted intro line rendered at the top of the dropdown, below the group label.
  * @param onValueChange Callback fired when the selected value changes.
  * @param setValue Optional state setter for two-way binding of the selected value.
  * @param defaultValue The initial default value.
@@ -88,6 +93,7 @@ const CustomSelect: React.FC<CustomSelectProps> = ({
     options = [],
     width = "100%",
     groupLabel,
+    menuDescription,
     onValueChange,
     setValue,
     defaultValue,
@@ -148,7 +154,7 @@ const CustomSelect: React.FC<CustomSelectProps> = ({
                 )}
                 <Select onValueChange={handleValueChange} value={value as any} defaultValue={defaultValue as any} disabled={disabled}>
                     <View ref={triggerRef} style={[{ width: width as any }]} onLayout={onTriggerLayout}>
-                        <SelectTrigger disabled={disabled} style={{ backgroundColor: colors.bg, borderColor: colors.borderHair }}>
+                        <SelectTrigger disabled={disabled}>
                             <SelectValue placeholder={value || defaultValue ? (currentLabel ?? "ERROR") : placeholder} style={{ color: colors.text }} />
                         </SelectTrigger>
                     </View>
@@ -156,11 +162,12 @@ const CustomSelect: React.FC<CustomSelectProps> = ({
                         <NativeSelectScrollView>
                             <SelectGroup>
                                 {groupLabel && <SelectLabel>{groupLabel}</SelectLabel>}
+                                {menuDescription && <Text style={{ ...TYPE.caption, color: colors.textMuted, paddingHorizontal: SPACING.sm, paddingBottom: SPACING.xs }}>{menuDescription}</Text>}
                                 {options &&
                                     options.map((option, index) => (
                                         <React.Fragment key={option.value}>
                                             {index > 0 && <SelectSeparator />}
-                                            <SelectItem label={option.label} value={option.value} disabled={option.disabled}>
+                                            <SelectItem label={option.label} value={option.value} disabled={option.disabled} description={option.description}>
                                                 {option.label}
                                             </SelectItem>
                                         </React.Fragment>

--- a/src/components/ui/modal-header.tsx
+++ b/src/components/ui/modal-header.tsx
@@ -1,0 +1,35 @@
+import React from "react"
+import { View, Text, Pressable } from "react-native"
+import Ionicons from "@react-native-vector-icons/ionicons"
+import { useTheme } from "../../context/ThemeContext"
+import { useModalShellStyles } from "./modal-shell-styles"
+
+/** Props for `ModalHeader`. */
+export interface ModalHeaderProps {
+    /** The uppercase mono title shown on the left. */
+    title: string
+    /** Called when the close chip is tapped. */
+    onClose: () => void
+}
+
+/**
+ * The standard `SheetModal` header: a mono title on the left and a close chip on the right.
+ * @param title The uppercase mono title.
+ * @param onClose Tap handler for the close chip.
+ * @returns A header row for a `SheetModal`.
+ */
+const ModalHeaderImpl = ({ title, onClose }: ModalHeaderProps) => {
+    const { colors } = useTheme()
+    const modalShellStyles = useModalShellStyles()
+    return (
+        <View style={modalShellStyles.modalHeaderRow}>
+            <Text style={modalShellStyles.modalTitleMono}>{title}</Text>
+            <Pressable style={modalShellStyles.modalCloseChip} onPress={onClose} android_ripple={{ color: colors.ripple, foreground: true }} accessibilityLabel="Close">
+                <Ionicons name="close" size={18} color={colors.text} />
+            </Pressable>
+        </View>
+    )
+}
+
+export const ModalHeader = React.memo(ModalHeaderImpl)
+export default ModalHeader

--- a/src/components/ui/modal-list.tsx
+++ b/src/components/ui/modal-list.tsx
@@ -84,6 +84,8 @@ export interface ModalRadioRowProps {
     tag?: string
     /** The visible label (sole content if no tag, otherwise the second line). */
     label: string
+    /** Optional muted description rendered below the label. Use to explain an ambiguous option value. */
+    description?: string
     /** Whether the row is currently selected. */
     selected: boolean
     /** Called when the row is tapped. */
@@ -94,11 +96,12 @@ export interface ModalRadioRowProps {
  * A card-tile row with a circular radio indicator. Used by single-select auto-dismiss modals.
  * @param tag Optional uppercase mono tag rendered above the label.
  * @param label Primary label.
+ * @param description Optional muted line rendered below the label.
  * @param selected Whether selected.
  * @param onPress Tap handler.
  * @returns A Pressable card tile.
  */
-const ModalRadioRowImpl = ({ tag, label, selected, onPress }: ModalRadioRowProps) => {
+const ModalRadioRowImpl = ({ tag, label, description, selected, onPress }: ModalRadioRowProps) => {
     const { colors } = useTheme()
     const styles = useMemo(
         () =>
@@ -132,6 +135,7 @@ const ModalRadioRowImpl = ({ tag, label, selected, onPress }: ModalRadioRowProps
                 tagActive: { color: colors.brand },
                 label: { ...TYPE.body, color: colors.text },
                 labelActive: { color: colors.brand, fontWeight: "600" as const },
+                description: { ...TYPE.caption, color: colors.textMuted },
             }),
         [colors]
     )
@@ -147,6 +151,7 @@ const ModalRadioRowImpl = ({ tag, label, selected, onPress }: ModalRadioRowProps
             <View style={styles.textBlock}>
                 {tag ? <Text style={[styles.tag, selected && styles.tagActive]}>{tag}</Text> : null}
                 <Text style={[styles.label, selected && styles.labelActive]}>{label}</Text>
+                {description ? <Text style={styles.description}>{description}</Text> : null}
             </View>
         </Pressable>
     )

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,5 +1,7 @@
 import { Icon } from "@/src/components/ui/icon"
 import { useTheme } from "@/src/context/ThemeContext"
+import { RADII } from "@/src/lib/radii"
+import { TYPE } from "@/src/lib/type"
 // Removed the NativeOnlyAnimatedView import to fix the issue with this component not being properly scrollable on Android.
 // https://github.com/founded-labs/react-native-reusables/issues/424#issuecomment-3298693345
 import { TextClassContext } from "@/src/components/ui/text"
@@ -7,7 +9,7 @@ import { cn } from "@/src/lib/utils"
 import * as SelectPrimitive from "@rn-primitives/select"
 import { Check, ChevronDown, ChevronDownIcon, ChevronUpIcon } from "lucide-react-native"
 import * as React from "react"
-import { Platform, ScrollView, StyleSheet, View, StyleProp, TextStyle } from "react-native"
+import { Platform, ScrollView, StyleSheet, Text, View, StyleProp, TextStyle, ViewStyle } from "react-native"
 import { FullWindowOverlay as RNFullWindowOverlay } from "react-native-screens"
 
 type Option = SelectPrimitive.Option
@@ -33,6 +35,7 @@ function SelectTrigger({
     className,
     children,
     size = "default",
+    style,
     ...props
 }: SelectPrimitive.TriggerProps &
     React.RefAttributes<SelectPrimitive.TriggerRef> & {
@@ -44,7 +47,7 @@ function SelectTrigger({
         <SelectPrimitive.Trigger
             ref={ref}
             className={cn(
-                "border-input dark:bg-input/30 dark:active:bg-input/50 bg-background flex h-10 flex-row items-center justify-between gap-2 rounded-md border px-3 py-2 shadow-sm shadow-black/5 sm:h-9 overflow-hidden",
+                "flex h-10 flex-row items-center justify-between gap-2 px-3 py-2 sm:h-9 overflow-hidden",
                 Platform.select({
                     web: "focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:hover:bg-input/50 w-fit whitespace-nowrap text-sm outline-none transition-[color,box-shadow] focus-visible:ring-[3px] disabled:cursor-not-allowed [&_svg]:pointer-events-none [&_svg]:shrink-0",
                 }),
@@ -53,10 +56,11 @@ function SelectTrigger({
                 className
             )}
             android_ripple={{ color: colors.ripple, foreground: true }}
+            style={StyleSheet.flatten([{ backgroundColor: colors.surfaceRaised, borderRadius: RADII.lg }, style as StyleProp<ViewStyle>])}
             {...props}
         >
             <View style={{ flex: 1, minWidth: 0 }}>{children}</View>
-            <Icon as={ChevronDown} aria-hidden={true} className="text-muted-foreground size-4 shrink-0" />
+            <Icon as={ChevronDown} aria-hidden={true} color={colors.brand} className="size-4 shrink-0" />
         </SelectPrimitive.Trigger>
     )
 }
@@ -68,12 +72,14 @@ function SelectContent({
     children,
     position = "popper",
     portalHost,
+    style,
     ...props
 }: SelectPrimitive.ContentProps &
     React.RefAttributes<SelectPrimitive.ContentRef> & {
         className?: string
         portalHost?: string
     }) {
+    const { colors } = useTheme()
     return (
         <SelectPrimitive.Portal hostName={portalHost}>
             <FullWindowOverlay>
@@ -81,7 +87,7 @@ function SelectContent({
                     <TextClassContext.Provider value="text-popover-foreground">
                         <SelectPrimitive.Content
                             className={cn(
-                                "bg-popover border-border relative z-50 min-w-[8rem] rounded-md border shadow-md shadow-black/5",
+                                "relative z-50 min-w-[8rem] border",
                                 Platform.select({
                                     web: cn(
                                         "animate-in fade-in-0 zoom-in-95 origin-(--radix-select-content-transform-origin) max-h-52 overflow-y-auto overflow-x-hidden",
@@ -96,6 +102,7 @@ function SelectContent({
                                     }),
                                 className
                             )}
+                            style={StyleSheet.flatten([{ backgroundColor: colors.surface, borderColor: colors.brandBorder, borderRadius: RADII.lg }, style as StyleProp<ViewStyle>])}
                             position={position}
                             {...props}
                         >
@@ -124,10 +131,18 @@ function SelectContent({
 }
 
 function SelectLabel({ className, style, ...props }: SelectPrimitive.LabelProps & React.RefAttributes<SelectPrimitive.LabelRef>) {
-    return <SelectPrimitive.Label style={style} className={cn("text-muted-foreground px-2 py-2 text-xs sm:py-1.5", className)} {...props} />
+    const { colors } = useTheme()
+    return <SelectPrimitive.Label style={[{ ...TYPE.monoLabel, color: colors.textMuted }, style]} className={cn("px-2 py-2 sm:py-1.5", className)} {...props} />
 }
 
-function SelectItem({ className, children, textStyle, ...props }: SelectPrimitive.ItemProps & { textStyle?: StyleProp<TextStyle> } & React.RefAttributes<SelectPrimitive.ItemRef>) {
+function SelectItem({
+    className,
+    children,
+    textStyle,
+    description,
+    ...props
+}: SelectPrimitive.ItemProps & { textStyle?: StyleProp<TextStyle>; description?: string } & React.RefAttributes<SelectPrimitive.ItemRef>) {
+    const { colors } = useTheme()
     return (
         <SelectPrimitive.Item
             className={cn(
@@ -142,16 +157,20 @@ function SelectItem({ className, children, textStyle, ...props }: SelectPrimitiv
         >
             <View className="absolute right-2 flex size-3.5 items-center justify-center">
                 <SelectPrimitive.ItemIndicator>
-                    <Icon as={Check} className="text-muted-foreground size-4 shrink-0" />
+                    <Icon as={Check} color={colors.brand} className="size-4 shrink-0" />
                 </SelectPrimitive.ItemIndicator>
             </View>
-            <SelectPrimitive.ItemText style={textStyle} className="text-foreground group-active:text-accent-foreground select-none text-sm" />
+            <View className="min-w-0 flex-1">
+                <SelectPrimitive.ItemText style={textStyle} className="text-foreground group-active:text-accent-foreground select-none text-sm" />
+                {description ? <Text style={{ ...TYPE.caption, color: colors.textMuted }}>{description}</Text> : null}
+            </View>
         </SelectPrimitive.Item>
     )
 }
 
 function SelectSeparator({ className, ...props }: SelectPrimitive.SeparatorProps & React.RefAttributes<SelectPrimitive.SeparatorRef>) {
-    return <SelectPrimitive.Separator className={cn("bg-border -mx-1 my-1 h-px", Platform.select({ web: "pointer-events-none" }), className)} {...props} />
+    const { colors } = useTheme()
+    return <SelectPrimitive.Separator style={{ backgroundColor: colors.borderHair }} className={cn("-mx-1 my-1 h-px", Platform.select({ web: "pointer-events-none" }), className)} {...props} />
 }
 
 /**

--- a/src/components/ui/sheet-modal.tsx
+++ b/src/components/ui/sheet-modal.tsx
@@ -1,8 +1,9 @@
 import React, { useMemo } from "react"
-import { Dimensions, Modal, Pressable, ScrollView, StyleSheet, View } from "react-native"
+import { Dimensions, Modal, Pressable, ScrollView, StyleSheet, Text, View } from "react-native"
 import { useTheme } from "../../context/ThemeContext"
 import { SPACING } from "../../lib/spacing"
 import { RADII } from "../../lib/radii"
+import { TYPE } from "../../lib/type"
 
 /** Props for `SheetModal`. */
 export interface SheetModalProps {
@@ -12,6 +13,8 @@ export interface SheetModalProps {
     onRequestClose: () => void
     /** Header slot. Usually a title row + close chip. Rendered above a hairline divider. */
     header: React.ReactNode
+    /** Optional muted intro line rendered under the header, above the body. Use to frame what the modal's choices do. */
+    description?: string
     /** Optional sticky slot rendered between the header and the scrollable body. Use for search inputs, filter chips, or any controls that should remain visible while the body scrolls. */
     subHeader?: React.ReactNode
     /** Body slot. Rendered inside a flex-1 ScrollView so nested scroll regions resolve. */
@@ -36,6 +39,7 @@ export interface SheetModalProps {
  * @param visible Whether the sheet is visible.
  * @param onRequestClose Called on backdrop tap or Android back.
  * @param header Header slot rendered above a hairline divider.
+ * @param description Optional muted intro line rendered under the header.
  * @param subHeader Optional sticky slot rendered between the header and the scrollable body.
  * @param children Body slot rendered inside a flex-1 ScrollView.
  * @param footer Footer slot rendered below a hairline divider.
@@ -47,6 +51,7 @@ const SheetModalImpl = ({
     visible,
     onRequestClose,
     header,
+    description,
     subHeader,
     children,
     footer,
@@ -74,6 +79,7 @@ const SheetModalImpl = ({
                     overflow: "hidden",
                 },
                 header: { paddingHorizontal: SPACING.md, paddingTop: SPACING.md },
+                description: { ...TYPE.caption, color: colors.textMuted, paddingHorizontal: SPACING.md, paddingTop: SPACING.xs },
                 subHeader: { paddingHorizontal: SPACING.md },
                 body: { flex: 1 },
                 bodyContent: { paddingHorizontal: SPACING.md, paddingVertical: SPACING.md },
@@ -87,6 +93,7 @@ const SheetModalImpl = ({
                 <Pressable style={styles.backdrop} onPress={dismissOnBackdropPress ? onRequestClose : undefined} />
                 <View style={styles.card}>
                     <View style={styles.header}>{header}</View>
+                    {description != null ? <Text style={styles.description}>{description}</Text> : null}
                     {subHeader != null ? <View style={styles.subHeader}>{subHeader}</View> : null}
                     {scrollableBody ? (
                         <ScrollView style={styles.body} contentContainerStyle={styles.bodyContent} keyboardShouldPersistTaps="handled" nestedScrollEnabled>

--- a/src/components/ui/value-pill.tsx
+++ b/src/components/ui/value-pill.tsx
@@ -1,0 +1,29 @@
+import React from "react"
+import { Text } from "react-native"
+import { useTheme } from "../../context/ThemeContext"
+import { TYPE } from "../../lib/type"
+import { SPACING } from "../../lib/spacing"
+import { RADII } from "../../lib/radii"
+
+/** Props for `ValuePill`. */
+export interface ValuePillProps {
+    /** The current value to display inside the pill. */
+    label: string
+}
+
+/**
+ * A small cyan pill showing a picker's current value. Used in the `right` slot of a `Row` (or a `Pressable` cell) that opens a selector modal.
+ * @param label The value text rendered inside the pill.
+ * @returns A styled `Text` node sized to fit the value.
+ */
+const ValuePillImpl = ({ label }: ValuePillProps) => {
+    const { colors } = useTheme()
+    return (
+        <Text style={{ ...TYPE.monoLabel, color: colors.brand, paddingHorizontal: SPACING.sm, paddingVertical: 2, backgroundColor: colors.brandSubtle, borderRadius: RADII.pill, overflow: "hidden" }}>
+            {label}
+        </Text>
+    )
+}
+
+export const ValuePill = React.memo(ValuePillImpl)
+export default ValuePill

--- a/src/pages/Chat/index.tsx
+++ b/src/pages/Chat/index.tsx
@@ -6,7 +6,6 @@ import type { UserTheme } from "react-native-marked/dist/typescript/theme/types"
 import { KotlinCode, DARK_PALETTE, LIGHT_PALETTE } from "../../components/KotlinCode"
 import { useTheme } from "../../context/ThemeContext"
 import CustomButton from "../../components/CustomButton"
-import CustomSelect from "../../components/CustomSelect"
 import PageHeader from "../../components/PageHeader"
 import { MarkdownView } from "../../components/ChatMarkdown"
 import { databaseManager } from "../../lib/database"
@@ -16,6 +15,11 @@ import { loadChatTuning, trimToCap, type ChatTuning } from "../../lib/chat/chatS
 import { ACTIVE_MODEL_SETTING, resolveActiveModel } from "../../lib/chat/activeModel"
 import { isEmbedderReady } from "../../lib/chat/embedder"
 import { Section } from "../../components/ui/section"
+import { SheetModal } from "../../components/ui/sheet-modal"
+import { ModalRadioRow } from "../../components/ui/modal-list"
+import { useModalShellStyles } from "../../components/ui/modal-shell-styles"
+import { ValuePill } from "../../components/ui/value-pill"
+import { ModalHeader } from "../../components/ui/modal-header"
 import InfoCallout from "../../components/ui/info-callout"
 import { TYPE } from "../../lib/type"
 import { SPACING } from "../../lib/spacing"
@@ -74,6 +78,7 @@ const BlinkingCursor: React.FC<BlinkingCursorProps> = ({ color }) => {
 
 const Chat = () => {
     const { colors, isDark } = useTheme()
+    const modalShellStyles = useModalShellStyles()
     const [query, setQuery] = useState("")
     const [result, setResult] = useState<ChatResult | null>(null)
     const [partialAnswer, setPartialAnswer] = useState("")
@@ -86,6 +91,7 @@ const Chat = () => {
     const [tuning, setTuning] = useState<ChatTuning | null>(null)
     const [activeModelFilename, setActiveModelFilename] = useState<string | null | undefined>(undefined)
     const [downloadedModels, setDownloadedModels] = useState<string[]>([])
+    const [modelPickerOpen, setModelPickerOpen] = useState(false)
     const [embedderReady, setEmbedderReady] = useState<boolean | null>(null)
 
     const refreshActiveModel = useCallback(async () => {
@@ -417,13 +423,14 @@ const Chat = () => {
                                 <View style={styles.modelSelectorRow}>
                                     <Text style={styles.modelStatus}>Model:</Text>
                                     <View style={styles.modelSelectorControl}>
-                                        <CustomSelect
-                                            options={downloadedModels.map((f) => ({ value: f, label: f }))}
-                                            value={activeModelFilename ?? undefined}
-                                            onValueChange={handleSelectModel}
-                                            placeholder="Select a model"
-                                            groupLabel="Downloaded models"
-                                        />
+                                        <Pressable
+                                            onPress={() => setModelPickerOpen(true)}
+                                            android_ripple={{ color: colors.ripple, foreground: true }}
+                                            accessibilityRole="button"
+                                            style={{ alignSelf: "flex-start" }}
+                                        >
+                                            <ValuePill label={activeModelFilename ?? "Select a model"} />
+                                        </Pressable>
                                     </View>
                                 </View>
                             ) : (
@@ -543,6 +550,26 @@ const Chat = () => {
                 )}
                 {searched && !isSearching && !result && <Text style={styles.emptyText}>No matching documentation found.</Text>}
             </ScrollView>
+            <SheetModal
+                visible={modelPickerOpen}
+                onRequestClose={() => setModelPickerOpen(false)}
+                header={<ModalHeader title="DOWNLOADED MODELS" onClose={() => setModelPickerOpen(false)} />}
+                footer={null}
+            >
+                <View style={modalShellStyles.modalBodyList}>
+                    {downloadedModels.map((f) => (
+                        <ModalRadioRow
+                            key={f}
+                            label={f}
+                            selected={f === activeModelFilename}
+                            onPress={() => {
+                                handleSelectModel(f)
+                                setModelPickerOpen(false)
+                            }}
+                        />
+                    ))}
+                </View>
+            </SheetModal>
         </KeyboardAvoidingView>
     )
 }

--- a/src/pages/RacingSettings/index.tsx
+++ b/src/pages/RacingSettings/index.tsx
@@ -1,12 +1,10 @@
 import { useMemo, useContext, useRef, useCallback, useState } from "react"
 import { View, Text, TextInput, ScrollView, StyleSheet, Pressable } from "react-native"
 import { useNavigation } from "@react-navigation/native"
-import Ionicons from "@react-native-vector-icons/ionicons"
 import { Cpu, ChevronRight } from "lucide-react-native"
 import { useTheme } from "../../context/ThemeContext"
 import { RacingContext, defaultSettings, Settings } from "../../context/BotStateContext"
 import { SearchPageProvider } from "../../context/SearchPageContext"
-import CustomSelect from "../../components/CustomSelect"
 import CustomSlider from "../../components/CustomSlider"
 import PageHeader from "../../components/PageHeader"
 import InfoContainer from "../../components/InfoContainer"
@@ -20,6 +18,8 @@ import { SectionLabel } from "../../components/ui/section-label"
 import { GlassSurface } from "../../components/ui/glass-surface"
 import { SheetModal } from "../../components/ui/sheet-modal"
 import { ModalRadioRow } from "../../components/ui/modal-list"
+import { ValuePill } from "../../components/ui/value-pill"
+import { ModalHeader } from "../../components/ui/modal-header"
 import { useModalShellStyles } from "../../components/ui/modal-shell-styles"
 import { TYPE } from "../../lib/type"
 import { SPACING } from "../../lib/spacing"
@@ -29,6 +29,21 @@ import { RADII } from "../../lib/radii"
 const RACE_STRATEGY_OPTIONS = ["Default", "Auto", "Front", "Pace", "Late", "End"] as const
 
 type RaceStrategy = (typeof RACE_STRATEGY_OPTIONS)[number]
+
+/** Short explanations for the ambiguous strategy values. Front/Pace/Late/End are self-explanatory running styles and are intentionally left out. */
+const STRATEGY_OPTION_DESCRIPTIONS: Partial<Record<RaceStrategy, string>> = {
+    Default: "Keeps the running style already set in-game. The bot won't change it.",
+    Auto: "Picks the running style your trainee has the best aptitude for.",
+}
+
+/** Intro line shown at the top of the single-strategy picker modals. */
+const STRATEGY_PICKER_DESCRIPTION = "Pick the running style the bot uses for these races."
+
+/** In-game race agenda slots the user can select from. */
+const RACE_AGENDA_OPTIONS = ["Agenda 1", "Agenda 2", "Agenda 3", "Agenda 4", "Agenda 5", "Agenda 6", "Agenda 7", "Agenda 8"] as const
+
+/** Track distance keys shared by the Junior and Classic/Senior per-distance strategy grids. */
+type PerDistanceKey = "Short" | "Mile" | "Medium" | "Long"
 
 /**
  * The Racing Settings page.
@@ -45,6 +60,8 @@ const RacingSettings = () => {
     // Modal state for the Junior / Original strategy pickers (nav-row + chip pattern).
     const [juniorPickerOpen, setJuniorPickerOpen] = useState(false)
     const [originalPickerOpen, setOriginalPickerOpen] = useState(false)
+    const [agendaPickerOpen, setAgendaPickerOpen] = useState(false)
+    const [perDistancePicker, setPerDistancePicker] = useState<{ year: "junior" | "original"; distance: PerDistanceKey } | null>(null)
 
     // Merge current racing settings with defaults to handle missing properties.
     const racingSettings = { ...defaultSettings.racing, ...racing }
@@ -136,27 +153,6 @@ const RacingSettings = () => {
     )
 
     /**
-     * Render a small cyan pill displaying the current strategy value (for nav rows).
-     * @param label The strategy value to render inside the pill.
-     * @returns A styled `Text` node sized to fit the value.
-     */
-    const renderStrategyPill = (label: string) => (
-        <Text
-            style={{
-                ...TYPE.monoLabel,
-                color: colors.brand,
-                paddingHorizontal: SPACING.sm,
-                paddingVertical: 2,
-                backgroundColor: colors.brandSubtle,
-                borderRadius: RADII.pill,
-                overflow: "hidden",
-            }}
-        >
-            {label}
-        </Text>
-    )
-
-    /**
      * Render the modal contents for a strategy picker.
      * @param current The currently selected strategy.
      * @param onSelect Called when the user picks a new value (the modal close is handled by the caller).
@@ -166,7 +162,7 @@ const RacingSettings = () => {
     const renderStrategyOptions = (current: string, onSelect: (value: RaceStrategy) => void) => (
         <View style={modalShellStyles.modalBodyList}>
             {RACE_STRATEGY_OPTIONS.map((option) => (
-                <ModalRadioRow key={option} label={option} selected={option === current} onPress={() => onSelect(option)} />
+                <ModalRadioRow key={option} label={option} description={STRATEGY_OPTION_DESCRIPTIONS[option]} selected={option === current} onPress={() => onSelect(option)} />
             ))}
         </View>
     )
@@ -181,7 +177,13 @@ const RacingSettings = () => {
                             //////////////////////////////////////////////////////////////////////////////////////////////////
                             Race Behavior */}
                         <Section label="Race Behavior">
-                            <ToggleSetting id="enable-farming-fans" title="Enable Farming Fans" description="When enabled, the bot will start running extra races to gain fans." checked={enableFarmingFans} onCheckedChange={(checked) => updateRacingSetting("enableFarmingFans", checked)} />
+                            <ToggleSetting
+                                id="enable-farming-fans"
+                                title="Enable Farming Fans"
+                                description="When enabled, the bot will start running extra races to gain fans."
+                                checked={enableFarmingFans}
+                                onCheckedChange={(checked) => updateRacingSetting("enableFarmingFans", checked)}
+                            />
                             <View style={{ padding: SPACING.md }}>
                                 <CustomSlider
                                     searchId="days-to-run-extra-races"
@@ -197,13 +199,57 @@ const RacingSettings = () => {
                                     description="Extra races are eligible only on days where current day % value == 0. For example, 5 means days 5, 10, 15, etc. Has no effect when Smart Race Solver is enabled."
                                 />
                             </View>
-                            <ToggleSetting id="ignore-consecutive-race-warning" title="Ignore Consecutive Race Warning" description="When enabled, the bot will ignore the warning popup about consecutive races and continue racing." checked={ignoreConsecutiveRaceWarning} onCheckedChange={(checked) => updateRacingSetting("ignoreConsecutiveRaceWarning", checked)} />
-                            <ToggleSetting id="ignore-low-energy-racing-block" title="Ignore Low Energy Racing Block" description="When enabled, the Trackblazer bot will not block racing when energy is critically low (<=1%) with 3+ consecutive races." checked={ignoreLowEnergyRacingBlock} onCheckedChange={(checked) => updateRacingSetting("ignoreLowEnergyRacingBlock", checked)} />
-                            <ToggleSetting id="disable-race-retries" title="Disable Race Retries" description="When enabled, the bot will not retry mandatory races if they fail and will stop." checked={disableRaceRetries} onCheckedChange={(checked) => updateRacingSetting("disableRaceRetries", checked)} />
-                            <ToggleSetting id="enable-free-race-retry" title="Allow Daily Free Race Retry" description="When enabled, the bot will attempt to retry a failed mandatory race only if the daily free race retry is available." condition={disableRaceRetries} parentId="disable-race-retries" checked={enableFreeRaceRetry} onCheckedChange={(checked) => updateRacingSetting("enableFreeRaceRetry", checked)} />
-                            <ToggleSetting id="enable-complete-career-on-failure" title="Complete Career on Failure" description="When enabled, the bot will proceed to the career completion screen when a mandatory race fails and retries are exhausted." checked={enableCompleteCareerOnFailure} onCheckedChange={(checked) => updateRacingSetting("enableCompleteCareerOnFailure", checked)} />
-                            <ToggleSetting id="enable-stop-on-mandatory-races" title="Stop on Mandatory Races" description="When enabled, the bot will automatically stop when it encounters a mandatory race, allowing you to manually handle them." checked={enableStopOnMandatoryRaces} onCheckedChange={(checked) => updateRacingSetting("enableStopOnMandatoryRaces", checked)} />
-                            <ToggleSetting id="enable-force-racing" title="Force Racing" description="When enabled, the bot will skip all training, rest, and mood recovery activities and focus exclusively on racing every day." checked={enableForceRacing} onCheckedChange={(checked) => updateRacingSetting("enableForceRacing", checked)} />
+                            <ToggleSetting
+                                id="ignore-consecutive-race-warning"
+                                title="Ignore Consecutive Race Warning"
+                                description="When enabled, the bot will ignore the warning popup about consecutive races and continue racing."
+                                checked={ignoreConsecutiveRaceWarning}
+                                onCheckedChange={(checked) => updateRacingSetting("ignoreConsecutiveRaceWarning", checked)}
+                            />
+                            <ToggleSetting
+                                id="ignore-low-energy-racing-block"
+                                title="Ignore Low Energy Racing Block"
+                                description="When enabled, the Trackblazer bot will not block racing when energy is critically low (<=1%) with 3+ consecutive races."
+                                checked={ignoreLowEnergyRacingBlock}
+                                onCheckedChange={(checked) => updateRacingSetting("ignoreLowEnergyRacingBlock", checked)}
+                            />
+                            <ToggleSetting
+                                id="disable-race-retries"
+                                title="Disable Race Retries"
+                                description="When enabled, the bot will not retry mandatory races if they fail and will stop."
+                                checked={disableRaceRetries}
+                                onCheckedChange={(checked) => updateRacingSetting("disableRaceRetries", checked)}
+                            />
+                            <ToggleSetting
+                                id="enable-free-race-retry"
+                                title="Allow Daily Free Race Retry"
+                                description="When enabled, the bot will attempt to retry a failed mandatory race only if the daily free race retry is available."
+                                condition={disableRaceRetries}
+                                parentId="disable-race-retries"
+                                checked={enableFreeRaceRetry}
+                                onCheckedChange={(checked) => updateRacingSetting("enableFreeRaceRetry", checked)}
+                            />
+                            <ToggleSetting
+                                id="enable-complete-career-on-failure"
+                                title="Complete Career on Failure"
+                                description="When enabled, the bot will proceed to the career completion screen when a mandatory race fails and retries are exhausted."
+                                checked={enableCompleteCareerOnFailure}
+                                onCheckedChange={(checked) => updateRacingSetting("enableCompleteCareerOnFailure", checked)}
+                            />
+                            <ToggleSetting
+                                id="enable-stop-on-mandatory-races"
+                                title="Stop on Mandatory Races"
+                                description="When enabled, the bot will automatically stop when it encounters a mandatory race, allowing you to manually handle them."
+                                checked={enableStopOnMandatoryRaces}
+                                onCheckedChange={(checked) => updateRacingSetting("enableStopOnMandatoryRaces", checked)}
+                            />
+                            <ToggleSetting
+                                id="enable-force-racing"
+                                title="Force Racing"
+                                description="When enabled, the bot will skip all training, rest, and mood recovery activities and focus exclusively on racing every day."
+                                checked={enableForceRacing}
+                                onCheckedChange={(checked) => updateRacingSetting("enableForceRacing", checked)}
+                            />
                             {enableForceRacing && <WarningContainer>Warning: Enabling this will override all other racing settings and they will be ignored.</WarningContainer>}
                         </Section>
 
@@ -211,7 +257,13 @@ const RacingSettings = () => {
                             //////////////////////////////////////////////////////////////////////////////////////////////////
                             Strategy */}
                         <Section label="Strategy">
-                            <ToggleSetting id="enable-per-distance-strategy" title="Per-Distance Strategy" description="When enabled, allows setting different race strategies for each track distance." checked={enablePerDistanceStrategy} onCheckedChange={(checked) => updateRacingSetting("enablePerDistanceStrategy", checked)} />
+                            <ToggleSetting
+                                id="enable-per-distance-strategy"
+                                title="Per-Distance Strategy"
+                                description="When enabled, allows setting different race strategies for each track distance."
+                                checked={enablePerDistanceStrategy}
+                                onCheckedChange={(checked) => updateRacingSetting("enablePerDistanceStrategy", checked)}
+                            />
 
                             {!enablePerDistanceStrategy ? (
                                 <>
@@ -220,7 +272,7 @@ const RacingSettings = () => {
                                             title="Junior Year Strategy"
                                             description="The race strategy to use for all races during Junior Year."
                                             onPress={() => setJuniorPickerOpen(true)}
-                                            right={renderStrategyPill(juniorYearRaceStrategy)}
+                                            right={<ValuePill label={juniorYearRaceStrategy} />}
                                         />
                                     </SearchableItem>
                                     <SearchableItem
@@ -232,7 +284,7 @@ const RacingSettings = () => {
                                             title="Original Strategy"
                                             description="The race strategy to reset to after Junior Year. The bot will use this strategy for races in Year 2 and beyond."
                                             onPress={() => setOriginalPickerOpen(true)}
-                                            right={renderStrategyPill(originalRaceStrategy)}
+                                            right={<ValuePill label={originalRaceStrategy} />}
                                         />
                                     </SearchableItem>
                                 </>
@@ -247,22 +299,23 @@ const RacingSettings = () => {
                                         <Text style={styles.perDistanceGroupLabel}>JUNIOR YEAR</Text>
                                         <View style={styles.perDistanceBody}>
                                             {(["Short", "Mile", "Medium", "Long"] as const).map((distance) => (
-                                                <View key={`junior-${distance}`} style={styles.perDistanceItem}>
-                                                    <Text style={[TYPE.body, { color: colors.text, flex: 1 }]}>{distance}</Text>
-                                                    <CustomSelect
-                                                        searchId={`junior-strategy-${distance.toLowerCase()}`}
-                                                        searchTitle={`Junior Year ${distance} Distance Strategy`}
-                                                        searchDescription={`The race strategy to use for ${distance.toLowerCase()} distance races during Junior Year.`}
-                                                        width={140}
-                                                        options={RACE_STRATEGY_OPTIONS.map((value) => ({ value, label: value }))}
-                                                        value={juniorYearPerDistanceStrategies?.[distance] ?? "Default"}
-                                                        onValueChange={(value) => {
-                                                            const updated = { ...juniorYearPerDistanceStrategies, [distance]: value }
-                                                            updateRacingSetting("juniorYearPerDistanceStrategies", updated)
-                                                        }}
-                                                        placeholder="Default"
-                                                    />
-                                                </View>
+                                                <SearchableItem
+                                                    key={`junior-${distance}`}
+                                                    id={`junior-strategy-${distance.toLowerCase()}`}
+                                                    title={`Junior Year ${distance} Distance Strategy`}
+                                                    description={`The race strategy to use for ${distance.toLowerCase()} distance races during Junior Year.`}
+                                                >
+                                                    <View style={styles.perDistanceItem}>
+                                                        <Text style={[TYPE.body, { color: colors.text, flex: 1 }]}>{distance}</Text>
+                                                        <Pressable
+                                                            onPress={() => setPerDistancePicker({ year: "junior", distance })}
+                                                            android_ripple={{ color: colors.ripple, foreground: true }}
+                                                            accessibilityRole="button"
+                                                        >
+                                                            <ValuePill label={juniorYearPerDistanceStrategies?.[distance] ?? "Default"} />
+                                                        </Pressable>
+                                                    </View>
+                                                </SearchableItem>
                                             ))}
                                         </View>
                                     </View>
@@ -270,22 +323,23 @@ const RacingSettings = () => {
                                         <Text style={[styles.perDistanceGroupLabel, { paddingTop: 0 }]}>CLASSIC AND SENIOR YEAR</Text>
                                         <View style={styles.perDistanceBody}>
                                             {(["Short", "Mile", "Medium", "Long"] as const).map((distance) => (
-                                                <View key={`original-${distance}`} style={styles.perDistanceItem}>
-                                                    <Text style={[TYPE.body, { color: colors.text, flex: 1 }]}>{distance}</Text>
-                                                    <CustomSelect
-                                                        searchId={`original-strategy-${distance.toLowerCase()}`}
-                                                        searchTitle={`Original ${distance} Distance Strategy`}
-                                                        searchDescription={`The race strategy to use for ${distance.toLowerCase()} distance races in Year 2 and beyond.`}
-                                                        width={140}
-                                                        options={RACE_STRATEGY_OPTIONS.map((value) => ({ value, label: value }))}
-                                                        value={originalPerDistanceStrategies?.[distance] ?? "Default"}
-                                                        onValueChange={(value) => {
-                                                            const updated = { ...originalPerDistanceStrategies, [distance]: value }
-                                                            updateRacingSetting("originalPerDistanceStrategies", updated)
-                                                        }}
-                                                        placeholder="Default"
-                                                    />
-                                                </View>
+                                                <SearchableItem
+                                                    key={`original-${distance}`}
+                                                    id={`original-strategy-${distance.toLowerCase()}`}
+                                                    title={`Original ${distance} Distance Strategy`}
+                                                    description={`The race strategy to use for ${distance.toLowerCase()} distance races in Year 2 and beyond.`}
+                                                >
+                                                    <View style={styles.perDistanceItem}>
+                                                        <Text style={[TYPE.body, { color: colors.text, flex: 1 }]}>{distance}</Text>
+                                                        <Pressable
+                                                            onPress={() => setPerDistancePicker({ year: "original", distance })}
+                                                            android_ripple={{ color: colors.ripple, foreground: true }}
+                                                            accessibilityRole="button"
+                                                        >
+                                                            <ValuePill label={originalPerDistanceStrategies?.[distance] ?? "Default"} />
+                                                        </Pressable>
+                                                    </View>
+                                                </SearchableItem>
                                             ))}
                                         </View>
                                     </View>
@@ -297,7 +351,13 @@ const RacingSettings = () => {
                             //////////////////////////////////////////////////////////////////////////////////////////////////
                             In-Game Race Agenda */}
                         <Section label="In-Game Race Agenda">
-                            <ToggleSetting id="enable-user-in-game-race-agenda" title="Enable User In-Game Race Agenda" description="When enabled, the bot will load your selected in-game race agenda instead of using the racing plan settings. Note that this will disable the farming fans and racing plan settings." checked={enableUserInGameRaceAgenda} onCheckedChange={(checked) => updateRacingSetting("enableUserInGameRaceAgenda", checked)} />
+                            <ToggleSetting
+                                id="enable-user-in-game-race-agenda"
+                                title="Enable User In-Game Race Agenda"
+                                description="When enabled, the bot will load your selected in-game race agenda instead of using the racing plan settings. Note that this will disable the farming fans and racing plan settings."
+                                checked={enableUserInGameRaceAgenda}
+                                onCheckedChange={(checked) => updateRacingSetting("enableUserInGameRaceAgenda", checked)}
+                            />
                             {enableUserInGameRaceAgenda && (
                                 <>
                                     <InfoContainer style={{ marginHorizontal: SPACING.md }}>
@@ -312,24 +372,8 @@ const RacingSettings = () => {
                                         <Row
                                             title="Select Agenda"
                                             description="The in-game race agenda the bot loads when the toggle above is enabled."
-                                            right={
-                                                <CustomSelect
-                                                    placeholder="Agenda 1"
-                                                    width={140}
-                                                    options={[
-                                                        { value: "Agenda 1", label: "Agenda 1" },
-                                                        { value: "Agenda 2", label: "Agenda 2" },
-                                                        { value: "Agenda 3", label: "Agenda 3" },
-                                                        { value: "Agenda 4", label: "Agenda 4" },
-                                                        { value: "Agenda 5", label: "Agenda 5" },
-                                                        { value: "Agenda 6", label: "Agenda 6" },
-                                                        { value: "Agenda 7", label: "Agenda 7" },
-                                                        { value: "Agenda 8", label: "Agenda 8" },
-                                                    ]}
-                                                    value={racingSettings.selectedUserAgenda}
-                                                    onValueChange={(value) => updateRacingSetting("selectedUserAgenda", value)}
-                                                />
-                                            }
+                                            onPress={() => setAgendaPickerOpen(true)}
+                                            right={<ValuePill label={racingSettings.selectedUserAgenda} />}
                                         />
                                     </SearchableItem>
                                     <SearchableItem
@@ -354,8 +398,22 @@ const RacingSettings = () => {
                                             />
                                         </View>
                                     </SearchableItem>
-                                    <ToggleSetting id="limit-races-to-in-game-agenda" title="Limit Extra Races to Agenda" description="When enabled, the bot will override the racing behavior of any scenario such that it will not run any extra races except for the ones scheduled by the selected user's in-game racing agenda." parentId="enable-user-in-game-race-agenda" checked={limitRacesToInGameAgenda} onCheckedChange={(checked) => updateRacingSetting("limitRacesToInGameAgenda", checked)} />
-                                    <ToggleSetting id="skip-summer-training-for-agenda" title="Skip Summer Training for Agenda" description="When enabled, the bot will perform scheduled races from the in-game racing agenda during Summer instead of prioritizing Summer training. Note that this requires 'Enable User In-Game Race Agenda' to be enabled." parentId="enable-user-in-game-race-agenda" checked={skipSummerTrainingForAgenda} onCheckedChange={(checked) => updateRacingSetting("skipSummerTrainingForAgenda", checked)} />
+                                    <ToggleSetting
+                                        id="limit-races-to-in-game-agenda"
+                                        title="Limit Extra Races to Agenda"
+                                        description="When enabled, the bot will override the racing behavior of any scenario such that it will not run any extra races except for the ones scheduled by the selected user's in-game racing agenda."
+                                        parentId="enable-user-in-game-race-agenda"
+                                        checked={limitRacesToInGameAgenda}
+                                        onCheckedChange={(checked) => updateRacingSetting("limitRacesToInGameAgenda", checked)}
+                                    />
+                                    <ToggleSetting
+                                        id="skip-summer-training-for-agenda"
+                                        title="Skip Summer Training for Agenda"
+                                        description="When enabled, the bot will perform scheduled races from the in-game racing agenda during Summer instead of prioritizing Summer training. Note that this requires 'Enable User In-Game Race Agenda' to be enabled."
+                                        parentId="enable-user-in-game-race-agenda"
+                                        checked={skipSummerTrainingForAgenda}
+                                        onCheckedChange={(checked) => updateRacingSetting("skipSummerTrainingForAgenda", checked)}
+                                    />
                                 </>
                             )}
                         </Section>
@@ -405,19 +463,8 @@ const RacingSettings = () => {
                 <SheetModal
                     visible={juniorPickerOpen}
                     onRequestClose={() => setJuniorPickerOpen(false)}
-                    header={
-                        <View style={modalShellStyles.modalHeaderRow}>
-                            <Text style={modalShellStyles.modalTitleMono}>JUNIOR YEAR STRATEGY</Text>
-                            <Pressable
-                                style={modalShellStyles.modalCloseChip}
-                                onPress={() => setJuniorPickerOpen(false)}
-                                android_ripple={{ color: colors.ripple, foreground: true }}
-                                accessibilityLabel="Close"
-                            >
-                                <Ionicons name="close" size={18} color={colors.text} />
-                            </Pressable>
-                        </View>
-                    }
+                    description={STRATEGY_PICKER_DESCRIPTION}
+                    header={<ModalHeader title="JUNIOR YEAR STRATEGY" onClose={() => setJuniorPickerOpen(false)} />}
                     footer={null}
                 >
                     {renderStrategyOptions(juniorYearRaceStrategy, (value) => {
@@ -429,25 +476,55 @@ const RacingSettings = () => {
                 <SheetModal
                     visible={originalPickerOpen}
                     onRequestClose={() => setOriginalPickerOpen(false)}
-                    header={
-                        <View style={modalShellStyles.modalHeaderRow}>
-                            <Text style={modalShellStyles.modalTitleMono}>ORIGINAL STRATEGY</Text>
-                            <Pressable
-                                style={modalShellStyles.modalCloseChip}
-                                onPress={() => setOriginalPickerOpen(false)}
-                                android_ripple={{ color: colors.ripple, foreground: true }}
-                                accessibilityLabel="Close"
-                            >
-                                <Ionicons name="close" size={18} color={colors.text} />
-                            </Pressable>
-                        </View>
-                    }
+                    description={STRATEGY_PICKER_DESCRIPTION}
+                    header={<ModalHeader title="ORIGINAL STRATEGY" onClose={() => setOriginalPickerOpen(false)} />}
                     footer={null}
                 >
                     {renderStrategyOptions(originalRaceStrategy, (value) => {
                         updateRacingSetting("originalRaceStrategy", value)
                         setOriginalPickerOpen(false)
                     })}
+                </SheetModal>
+
+                <SheetModal
+                    visible={agendaPickerOpen}
+                    onRequestClose={() => setAgendaPickerOpen(false)}
+                    header={<ModalHeader title="SELECT AGENDA" onClose={() => setAgendaPickerOpen(false)} />}
+                    footer={null}
+                >
+                    <View style={modalShellStyles.modalBodyList}>
+                        {RACE_AGENDA_OPTIONS.map((option) => (
+                            <ModalRadioRow
+                                key={option}
+                                label={option}
+                                selected={option === racingSettings.selectedUserAgenda}
+                                onPress={() => {
+                                    updateRacingSetting("selectedUserAgenda", option)
+                                    setAgendaPickerOpen(false)
+                                }}
+                            />
+                        ))}
+                    </View>
+                </SheetModal>
+
+                <SheetModal
+                    visible={perDistancePicker !== null}
+                    onRequestClose={() => setPerDistancePicker(null)}
+                    description={STRATEGY_PICKER_DESCRIPTION}
+                    header={<ModalHeader title={perDistancePicker ? `${perDistancePicker.distance.toUpperCase()} STRATEGY` : ""} onClose={() => setPerDistancePicker(null)} />}
+                    footer={null}
+                >
+                    {perDistancePicker &&
+                        renderStrategyOptions(
+                            (perDistancePicker.year === "junior" ? juniorYearPerDistanceStrategies : originalPerDistanceStrategies)?.[perDistancePicker.distance] ?? "Default",
+                            (value) => {
+                                const { year, distance } = perDistancePicker
+                                const key = year === "junior" ? "juniorYearPerDistanceStrategies" : "originalPerDistanceStrategies"
+                                const current = year === "junior" ? juniorYearPerDistanceStrategies : originalPerDistanceStrategies
+                                updateRacingSetting(key, { ...current, [distance]: value })
+                                setPerDistancePicker(null)
+                            }
+                        )}
                 </SheetModal>
             </SearchPageProvider>
         </View>

--- a/src/pages/Settings/index.tsx
+++ b/src/pages/Settings/index.tsx
@@ -14,6 +14,11 @@ import PageHeader from "../../components/PageHeader"
 import { Row } from "../../components/ui/row"
 import { Switch } from "../../components/ui/switch"
 import { Section } from "../../components/ui/section"
+import { SheetModal } from "../../components/ui/sheet-modal"
+import { ModalRadioRow } from "../../components/ui/modal-list"
+import { useModalShellStyles } from "../../components/ui/modal-shell-styles"
+import { ValuePill } from "../../components/ui/value-pill"
+import { ModalHeader } from "../../components/ui/modal-header"
 import WarningContainer from "../../components/WarningContainer"
 import InfoContainer from "../../components/InfoContainer"
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from "../../components/ui/alert-dialog"
@@ -93,6 +98,8 @@ const Settings = () => {
     const { general, misc, updateGeneral, updateMisc } = useContext(GeneralMiscContext)
     const calStyles = useSeasonCalendarStyles()
     const { colors } = useTheme()
+    const modalShellStyles = useModalShellStyles()
+    const [datingPresetPickerOpen, setDatingPresetPickerOpen] = useState(false)
     // Width for the recreation-cell popovers, computed once instead of per calendar cell.
     const recreationPopoverStyle = useMemo(() => ({ width: Math.min(280, Dimensions.get("window").width - 24) }), [])
     const navigation = useNavigation()
@@ -533,15 +540,12 @@ const Settings = () => {
                                 description="Pick an optimized preset (Pure Passion timed for a summer camp) or Custom to hand-pick turns on the calendar below."
                                 parentId="settings-dating-schedule"
                             >
-                                <View style={{ padding: SPACING.md, paddingBottom: 0 }}>
-                                    <CustomSelect
-                                        placeholder="Preset"
-                                        width="100%"
-                                        options={datingPresetOptions}
-                                        value={general.datingSchedulePreset}
-                                        onValueChange={(value) => handleDatingPresetChange(value || DATING_SCHEDULE_CUSTOM)}
-                                    />
-                                </View>
+                                <Row
+                                    title="Schedule Preset"
+                                    description="Pick an optimized preset (Pure Passion timed for a summer camp) or Custom to hand-pick turns on the calendar below."
+                                    onPress={() => setDatingPresetPickerOpen(true)}
+                                    right={<ValuePill label={datingPresetOptions.find((o) => o.value === general.datingSchedulePreset)?.label ?? "Custom"} />}
+                                />
                                 {general.purePassionTurn > 0 && (
                                     <View style={{ paddingHorizontal: SPACING.md }}>
                                         <InfoContainer>
@@ -739,6 +743,26 @@ const Settings = () => {
                 </AlertDialogContent>
             </AlertDialog>
 
+            <SheetModal
+                visible={datingPresetPickerOpen}
+                onRequestClose={() => setDatingPresetPickerOpen(false)}
+                header={<ModalHeader title="SCHEDULE PRESET" onClose={() => setDatingPresetPickerOpen(false)} />}
+                footer={null}
+            >
+                <View style={modalShellStyles.modalBodyList}>
+                    {datingPresetOptions.map((option) => (
+                        <ModalRadioRow
+                            key={option.value}
+                            label={option.label}
+                            selected={option.value === general.datingSchedulePreset}
+                            onPress={() => {
+                                handleDatingPresetChange(option.value)
+                                setDatingPresetPickerOpen(false)
+                            }}
+                        />
+                    ))}
+                </View>
+            </SheetModal>
             <Snackbar visible={snackbarMessage !== null} onDismiss={() => setSnackbarMessage(null)} style={{ backgroundColor: colors.surfaceRaised, borderRadius: 10 }}>
                 {snackbarMessage ?? ""}
             </Snackbar>

--- a/src/pages/Skills/PlanTab.tsx
+++ b/src/pages/Skills/PlanTab.tsx
@@ -13,7 +13,11 @@ import { Row } from "../../components/ui/row"
 import { Switch } from "../../components/ui/switch"
 import { Input } from "../../components/ui/input"
 import SearchableItem from "../../components/SearchableItem"
-import CustomSelect from "../../components/CustomSelect"
+import { SheetModal } from "../../components/ui/sheet-modal"
+import { ModalRadioRow } from "../../components/ui/modal-list"
+import { useModalShellStyles } from "../../components/ui/modal-shell-styles"
+import { ValuePill } from "../../components/ui/value-pill"
+import { ModalHeader } from "../../components/ui/modal-header"
 import CustomButton from "../../components/CustomButton"
 import CustomScrollView from "../../components/CustomScrollView"
 import WarningContainer from "../../components/WarningContainer"
@@ -50,6 +54,13 @@ interface Skill {
 
 const skillData: Skill[] = Object.values(skillsData)
 
+/** Automated skill-point spending strategies. `label` shows in the modal, `chipLabel` in the row chip, `description` explains each option in the modal. */
+const SKILL_STRATEGY_OPTIONS = [
+    { value: "default", label: "Do Not Spend Remaining Points", chipLabel: "Off", description: "Leaves any leftover skill points unspent." },
+    { value: "optimize_skills", label: "Best Skills First", chipLabel: "Best Skills First", description: "Buys from a community tier list, best skills first. Optimizes rank within each tier." },
+    { value: "optimize_rank", label: "Optimize Rank", chipLabel: "Optimize Rank", description: "Buys whatever maximizes trainee rank. Avoid for TT or CM." },
+] as const
+
 /** Props for `PlanTab`. */
 interface PlanTabProps {
     /** Which plan to render (matches a key in `skillPlanSettingsPages`). */
@@ -65,6 +76,8 @@ interface PlanTabProps {
  */
 const PlanTab: React.FC<PlanTabProps> = ({ planKey }) => {
     const { colors } = useTheme()
+    const modalShellStyles = useModalShellStyles()
+    const [strategyPickerOpen, setStrategyPickerOpen] = useState(false)
     const config = skillPlanSettingsPages[planKey]
     const { skills, updateSkills } = useContext(SkillsContext)
 
@@ -142,7 +155,6 @@ const PlanTab: React.FC<PlanTabProps> = ({ planKey }) => {
                 hostPad: { padding: SPACING.md },
                 sectionDescription: { ...TYPE.caption, color: colors.textMuted, lineHeight: 18 },
                 subsectionTitle: { ...TYPE.body, color: colors.text, fontWeight: "600", marginBottom: SPACING.xs },
-                strategyDescription: { ...TYPE.caption, color: colors.textMuted, lineHeight: 18, marginTop: SPACING.xs },
                 listHeader: { flexDirection: "row", alignItems: "center", marginBottom: SPACING.sm, gap: SPACING.sm },
                 listHelperText: { ...TYPE.caption, color: colors.textMuted, lineHeight: 18 },
                 modeTabsRow: { flexDirection: "row", marginBottom: SPACING.sm, gap: 8 },
@@ -224,8 +236,8 @@ const PlanTab: React.FC<PlanTabProps> = ({ planKey }) => {
         return null
     }
 
-    const strategyLabel: string =
-        strategy === "default" ? "Do Not Spend Remaining Points" : strategy === "optimize_skills" ? "Best Skills First" : strategy === "optimize_rank" ? "Optimize Rank" : strategy
+    const currentStrategy = SKILL_STRATEGY_OPTIONS.find((o) => o.value === strategy)
+    const strategyLabel: string = currentStrategy?.label ?? strategy
     const excludedCategories: string[] = []
     if (excludeGreenSkills) excludedCategories.push("Green")
     if (excludeRedSkills) excludedCategories.push("Red")
@@ -299,31 +311,18 @@ const PlanTab: React.FC<PlanTabProps> = ({ planKey }) => {
             </Section>
 
             <Section label="Strategy & Planned Skills">
-                <View style={styles.hostPad}>
-                    <Text style={styles.subsectionTitle}>Automated Skill Point Spending Strategy</Text>
-                    <CustomSelect
-                        options={[
-                            { value: "default", label: "Do Not Spend Remaining Points" },
-                            { value: "optimize_skills", label: "Best Skills First" },
-                            { value: "optimize_rank", label: "Optimize Rank" },
-                        ]}
-                        value={strategy}
-                        defaultValue={defaultSettings.skills.plans[planKey].strategy}
-                        onValueChange={(value) => updatePlanSetting("strategy", value)}
-                        placeholder="Select Strategy"
+                <View>
+                    <Row
+                        title="Automated Skill Point Spending Strategy"
+                        description="What the bot does with leftover skill points after buying your planned skills."
+                        onPress={() => setStrategyPickerOpen(true)}
+                        right={<ValuePill label={currentStrategy?.chipLabel ?? "Select Strategy"} />}
                     />
-                    {strategy == "optimize_rank" && <WarningContainer>Warning: Optimize Rank ignores any of the Skill Style Overrides set in the Skills page.</WarningContainer>}
-                    <Text style={styles.strategyDescription}>
-                        This option determines what the bot does with any remaining skill points after it has purchased all of the skills from the Planned Skills section and the other options on this
-                        page.
-                    </Text>
-                    <Text style={styles.strategyDescription}>
-                        Best Skills First will use a community skill tier list to purchase better skills first and then within each tier it will attempt to optimize rank since the skills within each
-                        tier are not ordered.
-                    </Text>
-                    <Text style={styles.strategyDescription}>
-                        Optimize Rank will purchase skills in a way which will result in the highest trainee rank. Avoid this option if you wish to train an uma up for TT or CM.
-                    </Text>
+                    {strategy === "optimize_rank" && (
+                        <WarningContainer style={{ marginHorizontal: SPACING.md, marginBottom: SPACING.md }}>
+                            Warning: Optimize Rank ignores any of the Skill Style Overrides set in the Skills page.
+                        </WarningContainer>
+                    )}
                 </View>
 
                 <View style={styles.hostPad}>
@@ -443,6 +442,27 @@ const PlanTab: React.FC<PlanTabProps> = ({ planKey }) => {
                     </View>
                 </View>
             </View>
+            <SheetModal
+                visible={strategyPickerOpen}
+                onRequestClose={() => setStrategyPickerOpen(false)}
+                header={<ModalHeader title="SKILL POINT STRATEGY" onClose={() => setStrategyPickerOpen(false)} />}
+                footer={null}
+            >
+                <View style={modalShellStyles.modalBodyList}>
+                    {SKILL_STRATEGY_OPTIONS.map((option) => (
+                        <ModalRadioRow
+                            key={option.value}
+                            label={option.label}
+                            description={option.description}
+                            selected={option.value === strategy}
+                            onPress={() => {
+                                updatePlanSetting("strategy", option.value)
+                                setStrategyPickerOpen(false)
+                            }}
+                        />
+                    ))}
+                </View>
+            </SheetModal>
         </View>
     )
 }

--- a/src/pages/TrainingSettings/index.tsx
+++ b/src/pages/TrainingSettings/index.tsx
@@ -1,14 +1,15 @@
 import React, { useMemo, useContext, useEffect, useState, useRef, useCallback } from "react"
 import { View, Text, ScrollView, StyleSheet, Pressable, InteractionManager, LayoutAnimation } from "react-native"
 import { SheetModal } from "../../components/ui/sheet-modal"
-import { ModalCheckRow, ModalFooterChip } from "../../components/ui/modal-list"
+import { ModalCheckRow, ModalFooterChip, ModalRadioRow } from "../../components/ui/modal-list"
+import { ValuePill } from "../../components/ui/value-pill"
+import { ModalHeader } from "../../components/ui/modal-header"
 import { useModalShellStyles } from "../../components/ui/modal-shell-styles"
 import { Snackbar } from "react-native-paper"
 import { useTheme } from "../../context/ThemeContext"
 import { TrainingContext, GeneralMiscContext, BotMetaContext, defaultSettings, Settings } from "../../context/BotStateContext"
 import CustomSlider from "../../components/CustomSlider"
 import DraggablePriorityList from "../../components/DraggablePriorityList"
-import CustomSelect from "../../components/CustomSelect"
 import ProfileSelector from "../../components/ProfileSelector"
 import { useSettings } from "../../context/SettingsContext"
 import { useProfileManager } from "../../hooks/useProfileManager"
@@ -34,6 +35,14 @@ import Ionicons from "@react-native-vector-icons/ionicons"
 import { TrainingScoringSandbox } from "../../components/TrainingScoringSandbox"
 import { TrainingScoringAdvanced } from "../../components/TrainingScoringAdvanced"
 import { StickySandboxButton } from "../../components/TrainingScoringAdvanced/StickySandboxButton"
+
+/** Preferred race distance options for the training-target distance picker. */
+const PREFERRED_DISTANCE_OPTIONS = ["Auto", "Sprint", "Mile", "Medium", "Long"] as const
+
+/** Explanation for the ambiguous "Auto" distance value. The concrete distances are self-explanatory and intentionally omitted. */
+const PREFERRED_DISTANCE_DESCRIPTIONS: Partial<Record<(typeof PREFERRED_DISTANCE_OPTIONS)[number], string>> = {
+    Auto: "Picks the distance based on your character's aptitudes.",
+}
 
 /**
  * The Training Settings page.
@@ -75,6 +84,7 @@ const TrainingSettings = () => {
     }, [])
     const [scoringSandboxOpen, setScoringSandboxOpen] = useState(false)
     const [advancedExpanded, setAdvancedExpanded] = useState(false)
+    const [distancePickerOpen, setDistancePickerOpen] = useState(false)
 
     // Initialize local state from settings, with fallback to defaults.
     const [statPrioritizationItems, setStatPrioritizationItems] = useState<string[]>(() =>
@@ -649,9 +659,21 @@ const TrainingSettings = () => {
                                         />
                                     </View>
 
-                                    <ToggleSetting id="disable-training-on-maxed-stats" title="Disable Training on Maxed Stats" description="When enabled, training will be skipped for stats that have reached their maximum value." checked={disableTrainingOnMaxedStat} onCheckedChange={(checked) => updateTrainingSetting("disableTrainingOnMaxedStat", checked)} />
+                                    <ToggleSetting
+                                        id="disable-training-on-maxed-stats"
+                                        title="Disable Training on Maxed Stats"
+                                        description="When enabled, training will be skipped for stats that have reached their maximum value."
+                                        checked={disableTrainingOnMaxedStat}
+                                        onCheckedChange={(checked) => updateTrainingSetting("disableTrainingOnMaxedStat", checked)}
+                                    />
 
-                                    <ToggleSetting id="enable-riskier-training" title="Enable Riskier Training" description="When enabled, trainings with high main stat gains will use a separate, higher maximum failure chance threshold." checked={enableRiskyTraining} onCheckedChange={(checked) => updateTrainingSetting("enableRiskyTraining", checked)} />
+                                    <ToggleSetting
+                                        id="enable-riskier-training"
+                                        title="Enable Riskier Training"
+                                        description="When enabled, trainings with high main stat gains will use a separate, higher maximum failure chance threshold."
+                                        checked={enableRiskyTraining}
+                                        onCheckedChange={(checked) => updateTrainingSetting("enableRiskyTraining", checked)}
+                                    />
                                     {enableRiskyTraining && (
                                         <View style={styles.sliderShell}>
                                             <CustomSlider
@@ -691,13 +713,37 @@ const TrainingSettings = () => {
                                         </View>
                                     )}
 
-                                    <ToggleSetting id="enable-prioritize-skill-hints" title="Prioritize Skill Hints" description="When enabled, the bot will prioritize acquiring skill hints, bypassing stat prioritization and blacklist, while still being constrained by the failure chance thresholds." checked={enablePrioritizeSkillHints} onCheckedChange={(checked) => updateTrainingSetting("enablePrioritizeSkillHints", checked)} />
-                                    <ToggleSetting id="must-rest-before-summer" title="Must Rest before Summer" description="Optimizes June Late Phase in Classic and Senior Years for Summer Training. If Energy < 70%, it will Rest. If Energy >= 70% and Mood < Great, it will recover Mood. If Energy >= 70% and Mood is Great, it will train Wit." checked={mustRestBeforeSummer} onCheckedChange={(checked) => updateTrainingSetting("mustRestBeforeSummer", checked)} />
-                                    <ToggleSetting id="train-wit-during-finale" title="Train Wit During Finale" description="When enabled, the bot will train Wit during URA finale turns (73, 74, 75) instead of recovering energy or mood, even if the failure chance is high." checked={trainWitDuringFinale} onCheckedChange={(checked) => updateTrainingSetting("trainWitDuringFinale", checked)} />
+                                    <ToggleSetting
+                                        id="enable-prioritize-skill-hints"
+                                        title="Prioritize Skill Hints"
+                                        description="When enabled, the bot will prioritize acquiring skill hints, bypassing stat prioritization and blacklist, while still being constrained by the failure chance thresholds."
+                                        checked={enablePrioritizeSkillHints}
+                                        onCheckedChange={(checked) => updateTrainingSetting("enablePrioritizeSkillHints", checked)}
+                                    />
+                                    <ToggleSetting
+                                        id="must-rest-before-summer"
+                                        title="Must Rest before Summer"
+                                        description="Optimizes June Late Phase in Classic and Senior Years for Summer Training. If Energy < 70%, it will Rest. If Energy >= 70% and Mood < Great, it will recover Mood. If Energy >= 70% and Mood is Great, it will train Wit."
+                                        checked={mustRestBeforeSummer}
+                                        onCheckedChange={(checked) => updateTrainingSetting("mustRestBeforeSummer", checked)}
+                                    />
+                                    <ToggleSetting
+                                        id="train-wit-during-finale"
+                                        title="Train Wit During Finale"
+                                        description="When enabled, the bot will train Wit during URA finale turns (73, 74, 75) instead of recovering energy or mood, even if the failure chance is high."
+                                        checked={trainWitDuringFinale}
+                                        onCheckedChange={(checked) => updateTrainingSetting("trainWitDuringFinale", checked)}
+                                    />
                                 </Section>
 
                                 <Section label="Scoring">
-                                    <ToggleSetting id="enable-training-level-weighting" title="Weight Score by Training Level" description="When enabled (Year 2+), the bot reads each training's level (1-5) via OCR and boosts the score for trainings whose stat sits in the top 3 of your Stat Prioritization list. Helps the bot stick with stats you've invested in. OCR is skipped during Pre-Debut, Junior, and Summer." checked={enableTrainingLevelWeighting} onCheckedChange={(checked) => updateTrainingSetting("enableTrainingLevelWeighting", checked)} />
+                                    <ToggleSetting
+                                        id="enable-training-level-weighting"
+                                        title="Weight Score by Training Level"
+                                        description="When enabled (Year 2+), the bot reads each training's level (1-5) via OCR and boosts the score for trainings whose stat sits in the top 3 of your Stat Prioritization list. Helps the bot stick with stats you've invested in. OCR is skipped during Pre-Debut, Junior, and Summer."
+                                        checked={enableTrainingLevelWeighting}
+                                        onCheckedChange={(checked) => updateTrainingSetting("enableTrainingLevelWeighting", checked)}
+                                    />
                                     <SearchableItem
                                         id="enable-rainbow-training-bonus"
                                         title="Enable Rainbow Training Bonus"
@@ -768,24 +814,17 @@ const TrainingSettings = () => {
                                         <Row
                                             title="Preferred Distance"
                                             description="Set the preferred race distance for training targets. Auto picks based on character aptitudes."
-                                            right={
-                                                <CustomSelect
-                                                    value={preferredDistanceOverride}
-                                                    onValueChange={(value) => updateTrainingSetting("preferredDistanceOverride", value)}
-                                                    options={[
-                                                        { label: "Auto", value: "Auto" },
-                                                        { label: "Sprint", value: "Sprint" },
-                                                        { label: "Mile", value: "Mile" },
-                                                        { label: "Medium", value: "Medium" },
-                                                        { label: "Long", value: "Long" },
-                                                    ]}
-                                                    placeholder="Select distance"
-                                                    width={140}
-                                                />
-                                            }
+                                            onPress={() => setDistancePickerOpen(true)}
+                                            right={<ValuePill label={preferredDistanceOverride} />}
                                         />
                                     </SearchableItem>
-                                    <ToggleSetting id="disable-stat-targets" title="Disable Stat Targets" description="When enabled, all per-distance stat targets below are ignored. Every stat is treated as having a target equal to the in-game stat cap (1200), so the bot will keep pushing your top priority stats even after they would normally be considered 'done.' Useful when you want strict adherence to your Stat Prioritization list." checked={disableStatTargets} onCheckedChange={(checked) => updateTrainingSetting("disableStatTargets", checked)} />
+                                    <ToggleSetting
+                                        id="disable-stat-targets"
+                                        title="Disable Stat Targets"
+                                        description="When enabled, all per-distance stat targets below are ignored. Every stat is treated as having a target equal to the in-game stat cap (1200), so the bot will keep pushing your top priority stats even after they would normally be considered 'done.' Useful when you want strict adherence to your Stat Prioritization list."
+                                        checked={disableStatTargets}
+                                        onCheckedChange={(checked) => updateTrainingSetting("disableStatTargets", checked)}
+                                    />
 
                                     {/* Per-distance stat targets stay nested inside the Distance section so the whole distance domain reads as one block. */}
                                     <View style={disableStatTargets ? { opacity: 0.5 } : undefined} pointerEvents={disableStatTargets ? "none" : "auto"}>
@@ -1182,6 +1221,27 @@ const TrainingSettings = () => {
             >
                 <Text style={{ color: "#000" }}>{snackbarMessage}</Text>
             </Snackbar>
+            <SheetModal
+                visible={distancePickerOpen}
+                onRequestClose={() => setDistancePickerOpen(false)}
+                header={<ModalHeader title="PREFERRED DISTANCE" onClose={() => setDistancePickerOpen(false)} />}
+                footer={null}
+            >
+                <View style={modalShellStyles.modalBodyList}>
+                    {PREFERRED_DISTANCE_OPTIONS.map((option) => (
+                        <ModalRadioRow
+                            key={option}
+                            label={option}
+                            description={PREFERRED_DISTANCE_DESCRIPTIONS[option]}
+                            selected={option === preferredDistanceOverride}
+                            onPress={() => {
+                                updateTrainingSetting("preferredDistanceOverride", option)
+                                setDistancePickerOpen(false)
+                            }}
+                        />
+                    ))}
+                </View>
+            </SheetModal>
         </View>
     )
 }


### PR DESCRIPTION
## Description

- This PR adds the shared `ValuePill` and `ModalHeader` components and restyles the `CustomSelect` dropdown so its closed trigger reads as a borderless soft chip that fits the app's flat rows.
- It migrates the option pickers on the Racing, Training, Chat, and Settings pages to the `Row` + `ValuePill` + `SheetModal` selector pattern, with optional per-option descriptions rendered inside the modal.
- It redesigns the `Automated Skill Point Spending Strategy` selector to match the Style section rows, moving each option's explanation into the modal.
