### PR TITLE
Fix and redesign the Event Log Visualizer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { LogBox } from "react-native"
 import { PortalHost } from "@rn-primitives/portal"
 import { StatusBar } from "expo-status-bar"
 import { SafeAreaView, SafeAreaProvider } from "react-native-safe-area-context"
+import { GestureHandlerRootView } from "react-native-gesture-handler"
 import { useFonts, Geist_400Regular, Geist_500Medium, Geist_600SemiBold, Geist_700Bold } from "@expo-google-fonts/geist"
 import { GeistMono_400Regular, GeistMono_500Medium } from "@expo-google-fonts/geist-mono"
 import { BotStateProvider } from "./context/BotStateContext"
@@ -146,11 +147,13 @@ function App() {
     if (!fontsLoaded) return null
 
     return (
-        <SafeAreaProvider>
-            <ThemeProvider>
-                <AppContent />
-            </ThemeProvider>
-        </SafeAreaProvider>
+        <GestureHandlerRootView style={{ flex: 1 }}>
+            <SafeAreaProvider>
+                <ThemeProvider>
+                    <AppContent />
+                </ThemeProvider>
+            </SafeAreaProvider>
+        </GestureHandlerRootView>
     )
 }
 

--- a/src/components/EventLog/ActionChip.tsx
+++ b/src/components/EventLog/ActionChip.tsx
@@ -1,0 +1,60 @@
+import React, { useMemo } from "react"
+import { StyleSheet, Text, View } from "react-native"
+import { useTheme } from "../../context/ThemeContext"
+import { TYPE } from "../../lib/type"
+import { SPACING } from "../../lib/spacing"
+import { RADII } from "../../lib/radii"
+import { ACTION_VISUALS, type ActionKey } from "./actionVisuals"
+
+/** Props for `ActionChip`. */
+interface ActionChipProps {
+    /** Which action this chip represents. */
+    action: ActionKey
+    /** Optional granular detail appended after the label (e.g. race grade "G3" or training type "Wit"). */
+    sublabel?: string
+}
+
+/**
+ * A small pill showing one action that happened on a day: a tinted Lucide icon plus an uppercase mono tag.
+ * The tint comes from the shared `ACTION_VISUALS` mapping so it matches the Year Summary stat bars.
+ * @param action The action this chip represents.
+ * @param sublabel Optional granular detail appended after the label.
+ * @returns A tinted icon-and-label pill.
+ */
+const ActionChipImpl = ({ action, sublabel }: ActionChipProps) => {
+    const { colors } = useTheme()
+    const visual = ACTION_VISUALS[action]
+    const tint = colors[visual.colorKey]
+
+    const styles = useMemo(
+        () =>
+            StyleSheet.create({
+                chip: {
+                    flexDirection: "row",
+                    alignItems: "center",
+                    gap: SPACING.xs,
+                    paddingHorizontal: SPACING.sm,
+                    paddingVertical: 3,
+                    borderRadius: RADII.pill,
+                    backgroundColor: colors.surfaceRaised,
+                    borderWidth: 1,
+                    borderColor: colors.borderHair,
+                },
+                label: { ...TYPE.monoLabel, color: tint },
+            }),
+        [colors, tint]
+    )
+
+    const Icon = visual.icon
+    const text = sublabel ? `${visual.label} ${sublabel}` : visual.label
+
+    return (
+        <View style={styles.chip}>
+            <Icon size={12} color={tint} />
+            <Text style={styles.label}>{text}</Text>
+        </View>
+    )
+}
+
+export const ActionChip = React.memo(ActionChipImpl)
+export default ActionChip

--- a/src/components/EventLog/DayRow.tsx
+++ b/src/components/EventLog/DayRow.tsx
@@ -2,6 +2,13 @@ import React, { useMemo } from "react"
 import { StyleSheet, Text, View } from "react-native"
 import type { DayRecord } from "../../lib/eventLogParser"
 import { useTheme } from "../../context/ThemeContext"
+import { TYPE } from "../../lib/type"
+import { SPACING } from "../../lib/spacing"
+import { RADII } from "../../lib/radii"
+import { ValuePill } from "../ui/value-pill"
+import { ActionChip } from "./ActionChip"
+import { ACTION_ORDER, type ActionKey } from "./actionVisuals"
+import { RAIL_WIDTH, NODE_SIZE, STATS } from "./constants"
 
 type Props = {
     /** The parsed day record data including actions, triggers, and summary. */
@@ -10,10 +17,51 @@ type Props = {
     showTriggers?: boolean
 }
 
+/** Titles rendered above each expanded trigger group, in action order. */
+const TRIGGER_GROUPS: { key: ActionKey; title: string }[] = [
+    { key: "training", title: "Training" },
+    { key: "race", title: "Race" },
+    { key: "energy", title: "Recover Energy" },
+    { key: "mood", title: "Recover Mood" },
+    { key: "injury", title: "Recover Injury" },
+]
+
 /**
- * Displays a single day's event log data as a styled card.
- * Shows a day number, date, summary text, and action flags (energy, mood, injury, training, race).
- * Optionally displays detailed trigger information for each action type.
+ * Title-cases a freeform date string for display so uppercase log dates read cleanly (e.g. "JUNIOR YEAR LATE AUGUST" -> "Junior Year Late August").
+ * @param text The raw date text.
+ * @returns The date text with each word title-cased.
+ */
+function toDisplayDate(text: string): string {
+    return text.replace(/\S+/g, (w) => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase())
+}
+
+/**
+ * Builds the short granular detail shown on an action chip (e.g. the race grade or a normalized energy type).
+ * @param key The action the chip represents.
+ * @param record The day record supplying the granular fields.
+ * @returns The sublabel string, or undefined when there is no useful detail.
+ */
+function chipSublabel(key: ActionKey, record: DayRecord): string | undefined {
+    if (key === "training") return record.trainingType ? toDisplayDate(record.trainingType) : undefined
+    if (key === "race") return record.raceGrade || undefined
+    if (key === "energy") {
+        const t = record.energyType?.toLowerCase() ?? ""
+        if (t.includes("summer")) return "Summer"
+        if (t.includes("date")) return "Date"
+        if (t.includes("rest")) return "Rest"
+        return record.energyType || undefined
+    }
+    if (key === "mood") {
+        const t = record.moodType?.toLowerCase() ?? ""
+        if (t.includes("date")) return "Date"
+        return record.moodType || undefined
+    }
+    return undefined
+}
+
+/**
+ * Displays a single day as a node on the timeline rail: a day-number badge on a connecting vertical line, the date, and a
+ * row of tinted action chips for whatever happened that turn. Optionally expands the raw trigger log lines below.
  * @param record The parsed day record data.
  * @param showTriggers Whether to show detailed trigger information.
  */
@@ -23,128 +71,98 @@ const DayRow: React.FC<Props> = ({ record, showTriggers }) => {
     const styles = useMemo(
         () =>
             StyleSheet.create({
-                container: {
-                    paddingVertical: 12,
-                    paddingHorizontal: 12,
-                    borderRadius: 8,
+                container: { flexDirection: "row", paddingRight: SPACING.sm },
+                rail: { width: RAIL_WIDTH, alignItems: "center" },
+                railLine: { position: "absolute", top: 0, bottom: 0, left: RAIL_WIDTH / 2 - 0.5, width: 1, backgroundColor: colors.borderHair },
+                node: {
+                    width: NODE_SIZE,
+                    height: NODE_SIZE,
+                    borderRadius: RADII.pill,
+                    marginTop: SPACING.sm,
+                    alignItems: "center",
+                    justifyContent: "center",
+                    backgroundColor: colors.surfaceRaised,
                     borderWidth: 1,
-                    marginBottom: 10,
-                    backgroundColor: colors.surface,
-                    borderColor: colors.borderHair,
+                    borderColor: colors.brandBorder,
                 },
-                headerRow: {
-                    flexDirection: "row",
-                    alignItems: "center",
-                    justifyContent: "space-between",
-                    marginBottom: 4,
-                },
-                title: {
-                    fontSize: 16,
-                    fontWeight: "600",
-                    color: colors.text,
-                },
-                date: {
-                    fontSize: 12,
-                    color: colors.textMuted,
-                },
-                summary: {
-                    fontSize: 14,
-                    marginBottom: 8,
-                    color: colors.text,
-                },
-                flagsRow: {
-                    flexDirection: "row",
-                    flexWrap: "wrap",
-                    gap: 10,
-                },
-                flag: {
-                    flexDirection: "row",
-                    alignItems: "center",
-                    marginRight: 8,
-                    marginBottom: 6,
-                },
-                flagDot: {
-                    marginRight: 6,
-                },
-                flagLabel: {
-                    fontSize: 12,
-                    color: colors.textMuted,
-                },
-                triggersContainer: {
-                    marginTop: 8,
-                },
-                triggerSection: {
-                    marginBottom: 6,
-                },
-                triggerTitle: {
-                    color: colors.textMuted,
-                    fontWeight: "600",
-                    marginBottom: 2,
-                },
-                triggerLine: {
-                    color: colors.textMuted,
-                    fontSize: 12,
-                },
+                nodeText: { ...TYPE.monoLabel, fontSize: 10, letterSpacing: 0, color: colors.brand },
+                content: { flex: 1, paddingTop: SPACING.sm, paddingBottom: SPACING.md, paddingLeft: SPACING.xs },
+                headerRow: { flexDirection: "row", alignItems: "center", justifyContent: "space-between", gap: SPACING.sm },
+                date: { ...TYPE.body, color: colors.text, flex: 1 },
+                chipsRow: { flexDirection: "row", flexWrap: "wrap", gap: SPACING.xs, marginTop: SPACING.sm },
+                detail: { ...TYPE.monoValue, color: colors.textMuted, marginTop: SPACING.sm },
+                triggers: { marginTop: SPACING.sm, gap: SPACING.xs },
+                triggerTitle: { ...TYPE.monoLabel, color: colors.textMuted },
+                triggerLine: { ...TYPE.caption, color: colors.textMuted },
             }),
         [colors]
     )
 
-    /**
-     * Renders the trigger information for a specific action type.
-     * @param title The title of the trigger section (e.g., `Training`).
-     * @param lines An array of trigger description strings.
-     * @returns The rendered trigger section, or null if no triggers are present.
-     */
-    const renderTriggers = (title: string, lines: string[]) => {
-        if (!lines || lines.length === 0) return null
-        return (
-            <View style={styles.triggerSection}>
-                <Text style={styles.triggerTitle}>{title} Triggers:</Text>
-                {lines.map((l, idx) => (
-                    <Text key={idx} style={styles.triggerLine}>
-                        • {l}
-                    </Text>
-                ))}
-            </View>
-        )
-    }
+    const activeActions = ACTION_ORDER.filter((key) => record.actions[key])
+
+    // Compose the non-zero training stat gains into a compact line, e.g. "SPD +5   WIT +8".
+    const detailText = useMemo(() => {
+        if (!record.actions.training || !record.trainingStatGains) return ""
+        return record.trainingStatGains
+            .map((gain, i) => (gain !== 0 ? `${STATS[i].abbr} ${gain > 0 ? "+" : ""}${gain}` : null))
+            .filter(Boolean)
+            .join("   ")
+    }, [record.actions.training, record.trainingStatGains])
 
     return (
-        <View style={styles.container}>
-            <View style={styles.headerRow}>
-                <Text style={styles.title}>Day {record.dayNumber}</Text>
-                {!!record.dateText && <Text style={styles.date}>{record.dateText}</Text>}
-            </View>
-            <Text style={styles.summary}>{record.summary}</Text>
-            <View style={styles.flagsRow}>
-                {[
-                    { label: "Recover Energy", active: record.actions.energy },
-                    { label: "Recover Mood", active: record.actions.mood },
-                    { label: "Recover Injury", active: record.actions.injury },
-                    { label: "Training", active: record.actions.training },
-                    { label: "Race", active: record.actions.race },
-                ].map(({ label, active }) => {
-                    const flagColor = active ? colors.activeFlag : colors.textMuted
-                    return (
-                        <View key={label} style={[styles.flag, { opacity: active ? 1 : 0.35 }]}>
-                            <Text style={[styles.flagDot, { color: flagColor }]}>{active ? "●" : "○"}</Text>
-                            <Text style={styles.flagLabel}>{label}</Text>
-                        </View>
-                    )
-                })}
+        <View style={styles.container} accessibilityLabel={`Day ${record.dayNumber}: ${record.summary}`}>
+            <View style={styles.rail}>
+                <View style={styles.railLine} />
+                <View style={styles.node}>
+                    <Text style={styles.nodeText}>{record.dayNumber}</Text>
+                </View>
             </View>
 
-            {showTriggers && record.triggers && (
-                <View style={styles.triggersContainer}>
-                    {renderTriggers("Training", record.triggers.training)}
-                    {renderTriggers("Race", record.triggers.race)}
-                    {renderTriggers("Recover Energy", record.triggers.energy)}
-                    {renderTriggers("Recover Mood", record.triggers.mood)}
-                    {renderTriggers("Recover Injury", record.triggers.injury)}
+            <View style={styles.content}>
+                <View style={styles.headerRow}>
+                    <Text style={styles.date}>{record.dateText ? toDisplayDate(record.dateText) : `Day ${record.dayNumber}`}</Text>
+                    {!!record.year && <ValuePill label={record.year} />}
                 </View>
-            )}
+
+                {activeActions.length > 0 && (
+                    <View style={styles.chipsRow}>
+                        {activeActions.map((key) => (
+                            <ActionChip key={key} action={key} sublabel={chipSublabel(key, record)} />
+                        ))}
+                    </View>
+                )}
+
+                {!!detailText && <Text style={styles.detail}>{detailText}</Text>}
+
+                {record.actions.race && !!record.raceName && (
+                    <Text style={styles.detail}>
+                        {record.raceName}
+                        {record.racePlace ? `  ·  ${record.racePlace}` : ""}
+                        {record.raceWon !== undefined && <Text style={{ color: record.raceWon ? colors.activeFlag : colors.warning }}>{`  ·  ${record.raceWon ? "Won" : "Lost"}`}</Text>}
+                    </Text>
+                )}
+
+                {showTriggers && record.triggers && (
+                    <View style={styles.triggers}>
+                        {TRIGGER_GROUPS.map(({ key, title }) => {
+                            const lines = record.triggers![key]
+                            if (!lines || lines.length === 0) return null
+                            return (
+                                <View key={key}>
+                                    <Text style={styles.triggerTitle}>{title}</Text>
+                                    {lines.map((l, idx) => (
+                                        <Text key={idx} style={styles.triggerLine}>
+                                            {l}
+                                        </Text>
+                                    ))}
+                                </View>
+                            )
+                        })}
+                    </View>
+                )}
+            </View>
         </View>
     )
 }
 
-export default DayRow
+export default React.memo(DayRow)

--- a/src/components/EventLog/FileDivider.tsx
+++ b/src/components/EventLog/FileDivider.tsx
@@ -2,6 +2,9 @@ import React, { useMemo } from "react"
 import { StyleSheet, Text, View } from "react-native"
 import type { FileDividerRecord } from "../../lib/eventLogParser"
 import { useTheme } from "../../context/ThemeContext"
+import { TYPE } from "../../lib/type"
+import { SPACING } from "../../lib/spacing"
+import { ValuePill } from "../ui/value-pill"
 
 type Props = {
     /** The file divider record containing the filename to display. */
@@ -9,9 +12,9 @@ type Props = {
 }
 
 /**
- * Renders a horizontal line divider with a centered filename label.
- * Used to visually separate log entries originating from different files.
- * @param divider The file divider record containing the filename.
+ * Renders a labeled break in the timeline where the source log file changes: a hairline on each side with the filename and,
+ * when detected, the trainee name and scenario as pills.
+ * @param divider The file divider record containing the filename and optional trainee name and scenario.
  */
 const FileDivider: React.FC<Props> = ({ divider }) => {
     const { colors } = useTheme()
@@ -19,23 +22,11 @@ const FileDivider: React.FC<Props> = ({ divider }) => {
     const styles = useMemo(
         () =>
             StyleSheet.create({
-                container: {
-                    flexDirection: "row",
-                    alignItems: "center",
-                    marginVertical: 12,
-                    marginHorizontal: 12,
-                },
-                line: {
-                    flex: 1,
-                    height: 1,
-                    backgroundColor: colors.borderHair,
-                },
-                text: {
-                    marginHorizontal: 12,
-                    fontSize: 12,
-                    fontWeight: "500",
-                    color: colors.textMuted,
-                },
+                container: { flexDirection: "row", alignItems: "center", gap: SPACING.md, marginVertical: SPACING.md, marginHorizontal: SPACING.md },
+                line: { flex: 1, height: 1, backgroundColor: colors.borderHair },
+                center: { alignItems: "center", gap: SPACING.xs },
+                pillRow: { flexDirection: "row", flexWrap: "wrap", justifyContent: "center", gap: SPACING.xs },
+                fileName: { ...TYPE.monoValue, color: colors.textMuted },
             }),
         [colors]
     )
@@ -43,11 +34,12 @@ const FileDivider: React.FC<Props> = ({ divider }) => {
     return (
         <View style={styles.container}>
             <View style={styles.line} />
-            <View style={{ alignItems: "center" }}>
-                <Text style={[styles.text, { marginBottom: 2 }]}>{divider.fileName}</Text>
-                {divider.traineeName && (
-                    <View style={{ backgroundColor: colors.brand, paddingHorizontal: 6, paddingVertical: 2, borderRadius: 4 }}>
-                        <Text style={{ fontSize: 10, fontWeight: "bold", color: colors.onBrand }}>{divider.traineeName}</Text>
+            <View style={styles.center}>
+                <Text style={styles.fileName}>{divider.fileName}</Text>
+                {(divider.traineeName || divider.scenario) && (
+                    <View style={styles.pillRow}>
+                        {divider.traineeName && <ValuePill label={divider.traineeName} />}
+                        {divider.scenario && <ValuePill label={divider.scenario} />}
                     </View>
                 )}
             </View>
@@ -56,4 +48,4 @@ const FileDivider: React.FC<Props> = ({ divider }) => {
     )
 }
 
-export default FileDivider
+export default React.memo(FileDivider)

--- a/src/components/EventLog/GapsNotice.tsx
+++ b/src/components/EventLog/GapsNotice.tsx
@@ -1,6 +1,11 @@
-import React from "react"
-import type { GapRecord } from "../../lib/eventLogParser"
-import WarningContainer from "../WarningContainer"
+import React, { useMemo } from "react"
+import { StyleSheet, Text, View } from "react-native"
+import { type GapRecord, formatGapText } from "../../lib/eventLogParser"
+import { useTheme } from "../../context/ThemeContext"
+import { TYPE } from "../../lib/type"
+import { SPACING } from "../../lib/spacing"
+import { RADII } from "../../lib/radii"
+import { RAIL_WIDTH, NODE_SIZE } from "./constants"
 
 type Props = {
     /** The gap record indicating missing day(s) in the event log. */
@@ -8,12 +13,54 @@ type Props = {
 }
 
 /**
- * Displays a warning notice for missing days in the event log data.
- * Formats the message based on whether a single day or a range of days is missing.
+ * Marks missing day(s) as a greyed-out node on the timeline rail that mirrors a real day row: a dashed node plus a muted
+ * "Day N missing" line, so a gap reads as an absent day in the sequence rather than a warning banner.
  * @param gap The gap record indicating the missing day range.
  */
 const GapsNotice: React.FC<Props> = ({ gap }) => {
-    return <WarningContainer style={{ marginBottom: 10, marginTop: 0 }}>⚠️ {gap.from === gap.to ? `Day ${gap.from} missing.` : `Days ${gap.from}-${gap.to} missing.`}</WarningContainer>
+    const { colors } = useTheme()
+
+    const styles = useMemo(
+        () =>
+            StyleSheet.create({
+                container: { flexDirection: "row", paddingRight: SPACING.sm, opacity: 0.6 },
+                rail: { width: RAIL_WIDTH, alignItems: "center" },
+                railLine: { position: "absolute", top: 0, bottom: 0, left: RAIL_WIDTH / 2 - 0.5, width: 1, backgroundColor: colors.borderHair },
+                node: {
+                    width: NODE_SIZE,
+                    height: NODE_SIZE,
+                    borderRadius: RADII.pill,
+                    marginTop: SPACING.sm,
+                    alignItems: "center",
+                    justifyContent: "center",
+                    backgroundColor: colors.surface,
+                    borderWidth: 1,
+                    borderStyle: "dashed",
+                    borderColor: colors.borderStrong,
+                },
+                nodeText: { ...TYPE.monoLabel, fontSize: 10, letterSpacing: 0, color: colors.textMuted },
+                content: { flex: 1, justifyContent: "center", paddingTop: SPACING.sm, paddingBottom: SPACING.md, paddingLeft: SPACING.xs },
+                text: { ...TYPE.body, color: colors.textMuted, fontStyle: "italic" },
+            }),
+        [colors]
+    )
+
+    // Single missing day shows its number. A range shows an ellipsis since the label already spells out the span.
+    const nodeLabel = gap.from === gap.to ? String(gap.from) : "…"
+
+    return (
+        <View style={styles.container}>
+            <View style={styles.rail}>
+                <View style={styles.railLine} />
+                <View style={styles.node}>
+                    <Text style={styles.nodeText}>{nodeLabel}</Text>
+                </View>
+            </View>
+            <View style={styles.content}>
+                <Text style={styles.text}>{formatGapText(gap)}</Text>
+            </View>
+        </View>
+    )
 }
 
-export default GapsNotice
+export default React.memo(GapsNotice)

--- a/src/components/EventLog/StatBar.tsx
+++ b/src/components/EventLog/StatBar.tsx
@@ -1,0 +1,70 @@
+import React, { useMemo } from "react"
+import { StyleSheet, Text, View } from "react-native"
+import { useTheme } from "../../context/ThemeContext"
+import { TYPE } from "../../lib/type"
+import { SPACING } from "../../lib/spacing"
+import { RADII } from "../../lib/radii"
+
+/** Props for `StatBar`. */
+interface StatBarProps {
+    /** Short label shown at the left of the bar. */
+    label: string
+    /** Optional leading icon node (e.g. a tinted Lucide icon). */
+    iconLeft?: React.ReactNode
+    /** The value this bar represents, also shown right-aligned. */
+    value: number
+    /** The maximum value across sibling bars, used to scale the fill width. */
+    max: number
+    /** Fill color (an already-resolved theme color string). */
+    color: string
+    /** Optional caption appended after the value (e.g. "x3" training count). */
+    caption?: string
+}
+
+/**
+ * A labeled horizontal bar: a fixed-width label on the left, a proportional fill in the middle, and the value on the right.
+ * The fill width is `value / max`; a zero value renders an empty track dimmed so it still reads as "none".
+ * @param label Short label shown at the left of the bar.
+ * @param iconLeft Optional leading icon node.
+ * @param value The value this bar represents.
+ * @param max The maximum value across sibling bars, used to scale the fill width.
+ * @param color Fill color (an already-resolved theme color string).
+ * @param caption Optional caption appended after the value.
+ * @returns A single labeled proportional bar row.
+ */
+const StatBarImpl = ({ label, iconLeft, value, max, color, caption }: StatBarProps) => {
+    const { colors } = useTheme()
+    const pct = max > 0 ? Math.max(0, Math.min(1, value / max)) : 0
+    const isZero = value === 0
+
+    const styles = useMemo(
+        () =>
+            StyleSheet.create({
+                row: { flexDirection: "row", alignItems: "center", gap: SPACING.sm, marginBottom: SPACING.xs, opacity: isZero ? 0.45 : 1 },
+                labelWrap: { flexDirection: "row", alignItems: "center", gap: SPACING.xs, width: 82 },
+                label: { ...TYPE.monoLabel, color: colors.textMuted },
+                track: { flex: 1, height: 6, borderRadius: RADII.pill, backgroundColor: colors.surfaceRaised, overflow: "hidden" },
+                fill: { height: "100%", borderRadius: RADII.pill, backgroundColor: color },
+                value: { ...TYPE.monoValue, color: colors.text, minWidth: 28, textAlign: "right" },
+                caption: { ...TYPE.caption, color: colors.textMuted, minWidth: 26 },
+            }),
+        [colors, color, isZero]
+    )
+
+    return (
+        <View style={styles.row}>
+            <View style={styles.labelWrap}>
+                {iconLeft}
+                <Text style={styles.label}>{label}</Text>
+            </View>
+            <View style={styles.track}>
+                <View style={[styles.fill, { width: `${pct * 100}%` }]} />
+            </View>
+            <Text style={styles.value}>{value}</Text>
+            {caption ? <Text style={styles.caption}>{caption}</Text> : null}
+        </View>
+    )
+}
+
+export const StatBar = React.memo(StatBarImpl)
+export default StatBar

--- a/src/components/EventLog/YearSummaryCard.tsx
+++ b/src/components/EventLog/YearSummaryCard.tsx
@@ -2,6 +2,13 @@ import React, { useMemo } from "react"
 import { StyleSheet, Text, View } from "react-native"
 import type { YearSummary } from "../../lib/eventLogParser"
 import { useTheme } from "../../context/ThemeContext"
+import { TYPE } from "../../lib/type"
+import { SPACING } from "../../lib/spacing"
+import { RADII } from "../../lib/radii"
+import { ValuePill } from "../ui/value-pill"
+import { StatBar } from "./StatBar"
+import { ACTION_ORDER, ACTION_VISUALS, type ActionKey } from "./actionVisuals"
+import { STATS } from "./constants"
 
 type Props = {
     /** The year summary data including action counts, stat gains, and elapsed time. */
@@ -9,9 +16,8 @@ type Props = {
 }
 
 /**
- * Displays a summary card for a single year's event log data.
- * Shows total actions (energy, mood, injury, race, training), stat gains per training type,
- * and elapsed time. Appends "+ Finals" to the title for Senior Year if finals data is present.
+ * Displays a summary card for a single year: action counts as tinted proportional bars and per-stat training gains as a
+ * five-column strip, with the trainee names and elapsed time in the header. Shows a "Finals" pill for years covering turns 73-75.
  * @param summary The year summary data.
  */
 const YearSummaryCard: React.FC<Props> = ({ summary }) => {
@@ -20,108 +26,44 @@ const YearSummaryCard: React.FC<Props> = ({ summary }) => {
     const styles = useMemo(
         () =>
             StyleSheet.create({
-                container: {
-                    paddingVertical: 16,
-                    paddingHorizontal: 16,
-                    borderRadius: 8,
-                    borderWidth: 1,
-                    marginBottom: 12,
-                    backgroundColor: colors.surface,
-                    borderColor: colors.borderHair,
-                },
-                headerRow: {
-                    flexDirection: "row",
-                    justifyContent: "space-between",
-                    alignItems: "flex-start",
-                    marginBottom: 12,
-                },
-                title: {
-                    fontSize: 20,
-                    fontWeight: "bold",
-                    flex: 1,
-                    color: colors.text,
-                },
-                timeContainer: {
-                    alignItems: "flex-end",
-                },
-                timeFormatted: {
-                    fontSize: 18,
-                    fontWeight: "600",
-                    marginBottom: 2,
-                    color: colors.text,
-                },
-                timeHuman: {
-                    fontSize: 12,
-                    color: colors.textMuted,
-                },
-                section: {
-                    marginBottom: 12,
-                },
-                sectionTitle: {
-                    fontSize: 16,
-                    fontWeight: "600",
-                    marginBottom: 8,
-                    color: colors.text,
-                },
-                actionRow: {
-                    gap: 8,
-                },
-                actionItem: {
-                    flexDirection: "row",
-                    alignItems: "center",
-                    marginBottom: 4,
-                },
-                actionLabel: {
-                    fontSize: 14,
-                    marginRight: 8,
-                    minWidth: 120,
-                    color: colors.textMuted,
-                },
-                actionValue: {
-                    fontSize: 14,
-                    fontWeight: "600",
-                    color: colors.text,
-                },
-                statRow: {
-                    gap: 8,
-                },
-                statItem: {
-                    flexDirection: "row",
-                    alignItems: "center",
-                    marginBottom: 4,
-                },
-                statLabel: {
-                    fontSize: 14,
-                    marginRight: 8,
-                    minWidth: 110,
-                    color: colors.textMuted,
-                },
-                statValue: {
-                    fontSize: 14,
-                    fontWeight: "600",
-                    color: colors.text,
-                },
+                container: { padding: SPACING.lg, borderRadius: RADII.lg, borderWidth: 1, marginBottom: SPACING.md, backgroundColor: colors.surface, borderColor: colors.borderHair },
+                headerRow: { flexDirection: "row", justifyContent: "space-between", alignItems: "flex-start", marginBottom: SPACING.md },
+                titleRow: { flexDirection: "row", alignItems: "center", gap: SPACING.sm, flexWrap: "wrap", flex: 1 },
+                title: { ...TYPE.h1, color: colors.text },
+                timeContainer: { alignItems: "flex-end" },
+                timeFormatted: { ...TYPE.monoValue, fontSize: 15, color: colors.text },
+                timeHuman: { ...TYPE.caption, color: colors.textMuted, marginTop: 1 },
+                sectionLabel: { ...TYPE.monoLabel, color: colors.textMuted, marginBottom: SPACING.sm },
+                section: { marginTop: SPACING.md },
+                statStrip: { flexDirection: "row", gap: SPACING.sm },
+                statCol: { flex: 1, alignItems: "center", gap: 2 },
+                statAbbr: { ...TYPE.monoLabel, color: colors.textMuted },
+                statValue: { ...TYPE.monoValue, color: colors.text },
+                statTrack: { width: "100%", height: 4, borderRadius: RADII.pill, backgroundColor: colors.surfaceRaised, overflow: "hidden" },
+                statFill: { height: "100%", borderRadius: RADII.pill, backgroundColor: colors.brand },
+                statCount: { ...TYPE.caption, color: colors.textMuted },
             }),
         [colors]
     )
 
-    // Build the title string, including "+ Finals" for Senior Year if the logs covered the Finals days (turns 73-75).
-    const titleText = summary.hasFinals ? `${summary.year} Year + Finals` : `${summary.year} Year`
+    const countFor: Record<ActionKey, number> = {
+        training: summary.trainingCount,
+        race: summary.raceCount,
+        energy: summary.energyCount,
+        mood: summary.moodCount,
+        injury: summary.injuryCount,
+    }
+    const maxCount = Math.max(1, ...ACTION_ORDER.map((k) => countFor[k]))
+    const maxStat = Math.max(1, ...STATS.map((s) => summary.totalStatGains[s.key]))
 
     return (
         <View style={styles.container}>
             <View style={styles.headerRow}>
                 <View style={{ flex: 1 }}>
-                    <Text style={styles.title}>{titleText}</Text>
-                    {summary.traineeNames && summary.traineeNames.length > 0 && (
-                        <View style={{ flexDirection: "row", flexWrap: "wrap", gap: 4, marginTop: 4 }}>
-                            {summary.traineeNames.map((name, idx) => (
-                                <View key={idx} style={{ backgroundColor: colors.brand, paddingHorizontal: 6, paddingVertical: 2, borderRadius: 4 }}>
-                                    <Text style={{ fontSize: 10, fontWeight: "bold", color: colors.onBrand }}>{name}</Text>
-                                </View>
-                            ))}
-                        </View>
-                    )}
+                    <View style={styles.titleRow}>
+                        <Text style={styles.title}>{summary.year} Year</Text>
+                        {summary.hasFinals && <ValuePill label="Finals" />}
+                    </View>
                 </View>
                 {summary.elapsedTimeFormatted && (
                     <View style={styles.timeContainer}>
@@ -132,44 +74,36 @@ const YearSummaryCard: React.FC<Props> = ({ summary }) => {
             </View>
 
             <View style={styles.section}>
-                <Text style={styles.sectionTitle}>Actions</Text>
-                <View style={styles.actionRow}>
-                    {[
-                        { label: "Recover Energy", count: summary.energyCount },
-                        { label: "Recover Mood", count: summary.moodCount },
-                        { label: "Recover Injury", count: summary.injuryCount },
-                        { label: "Race", count: summary.raceCount },
-                        { label: "Training", count: summary.trainingCount },
-                    ].map(({ label, count }) => (
-                        <View key={label} style={styles.actionItem}>
-                            <Text style={styles.actionLabel}>{label}:</Text>
-                            <Text style={styles.actionValue}>{count}</Text>
-                        </View>
-                    ))}
-                </View>
+                <Text style={styles.sectionLabel}>Actions</Text>
+                {ACTION_ORDER.map((key) => {
+                    const visual = ACTION_VISUALS[key]
+                    const Icon = visual.icon
+                    const tint = colors[visual.colorKey]
+                    return <StatBar key={key} label={visual.label} iconLeft={<Icon size={12} color={tint} />} value={countFor[key]} max={maxCount} color={tint} />
+                })}
             </View>
 
             <View style={styles.section}>
-                <Text style={styles.sectionTitle}>Total Stat Gains</Text>
-                <View style={styles.statRow}>
-                    {[
-                        { label: "Speed", value: summary.totalStatGains.speed, count: summary.trainingCounts.speed },
-                        { label: "Stamina", value: summary.totalStatGains.stamina, count: summary.trainingCounts.stamina },
-                        { label: "Power", value: summary.totalStatGains.power, count: summary.trainingCounts.power },
-                        { label: "Guts", value: summary.totalStatGains.guts, count: summary.trainingCounts.guts },
-                        { label: "Wit", value: summary.totalStatGains.wit, count: summary.trainingCounts.wit },
-                    ].map(({ label, value, count }) => (
-                        <View key={label} style={styles.statItem}>
-                            <Text style={styles.statLabel}>
-                                {label} ({count}):
-                            </Text>
-                            <Text style={styles.statValue}>{value}</Text>
-                        </View>
-                    ))}
+                <Text style={styles.sectionLabel}>Stat Gains</Text>
+                <View style={styles.statStrip}>
+                    {STATS.map(({ abbr, key }) => {
+                        const value = summary.totalStatGains[key]
+                        const count = summary.trainingCounts[key]
+                        return (
+                            <View key={abbr} style={styles.statCol}>
+                                <Text style={styles.statAbbr}>{abbr}</Text>
+                                <Text style={styles.statValue}>{value}</Text>
+                                <View style={styles.statTrack}>
+                                    <View style={[styles.statFill, { width: `${(value / maxStat) * 100}%` }]} />
+                                </View>
+                                <Text style={styles.statCount}>x{count}</Text>
+                            </View>
+                        )
+                    })}
                 </View>
             </View>
         </View>
     )
 }
 
-export default YearSummaryCard
+export default React.memo(YearSummaryCard)

--- a/src/components/EventLog/actionVisuals.ts
+++ b/src/components/EventLog/actionVisuals.ts
@@ -1,0 +1,37 @@
+import { Dumbbell, Flag, Zap, Smile, Bandage, type LucideIcon } from "lucide-react-native"
+import type { DayActions } from "../../lib/eventLogParser"
+
+// //////////////////////////////////////////////////////////////////////////////////////////////////
+// //////////////////////////////////////////////////////////////////////////////////////////////////
+// Action visuals
+//
+// Single source of truth for how each of the five tracked actions is drawn. Both DayRow (Timeline chips) and
+// YearSummaryCard (stat bars) read from here so their colors and icons never drift apart.
+
+/** One of the five tracked per-day actions. */
+export type ActionKey = keyof DayActions
+
+/** The theme color token names used to tint actions (each exists on the palette returned by `useTheme`). */
+export type ActionColorKey = "brand" | "info" | "warning" | "activeFlag" | "error"
+
+/** Visual metadata for an action: its short label, Lucide icon, and the theme color token that tints it. */
+export interface ActionVisual {
+    /** Short human label shown on chips and stat bars. */
+    label: string
+    /** Lucide icon representing the action. */
+    icon: LucideIcon
+    /** Theme color token name resolved against `useTheme().colors`. */
+    colorKey: ActionColorKey
+}
+
+/** Per-action visual mapping: Train=cyan, Race=blue, Energy=amber, Mood=green, Injury=red. */
+export const ACTION_VISUALS: Record<ActionKey, ActionVisual> = {
+    training: { label: "Train", icon: Dumbbell, colorKey: "brand" },
+    race: { label: "Race", icon: Flag, colorKey: "info" },
+    energy: { label: "Energy", icon: Zap, colorKey: "warning" },
+    mood: { label: "Mood", icon: Smile, colorKey: "activeFlag" },
+    injury: { label: "Injury", icon: Bandage, colorKey: "error" },
+}
+
+/** The order actions are listed everywhere (chips, stat bars). */
+export const ACTION_ORDER: ActionKey[] = ["training", "race", "energy", "mood", "injury"]

--- a/src/components/EventLog/constants.ts
+++ b/src/components/EventLog/constants.ts
@@ -1,0 +1,21 @@
+// //////////////////////////////////////////////////////////////////////////////////////////////////
+// //////////////////////////////////////////////////////////////////////////////////////////////////
+// EventLog presentational constants
+//
+// Shared geometry and taxonomy for the timeline cards so the same values are not redeclared across DayRow,
+// GapsNotice, and YearSummaryCard.
+
+/** Width of the left rail column, shared by DayRow (the rail) and GapsNotice (the aligned break marker). */
+export const RAIL_WIDTH = 34
+
+/** Diameter of the day-number node drawn on the rail. */
+export const NODE_SIZE = 26
+
+/** The five trainee stats in the fixed order used by `trainingStatGains` and the `YearSummary` stat fields. */
+export const STATS: { abbr: string; key: "speed" | "stamina" | "power" | "guts" | "wit" }[] = [
+    { abbr: "SPD", key: "speed" },
+    { abbr: "STA", key: "stamina" },
+    { abbr: "PWR", key: "power" },
+    { abbr: "GUT", key: "guts" },
+    { abbr: "WIT", key: "wit" },
+]

--- a/src/hooks/useSettingsManager.tsx
+++ b/src/hooks/useSettingsManager.tsx
@@ -7,6 +7,7 @@ import { databaseManager } from "../lib/database"
 import { startTiming } from "../lib/performanceLogger"
 import { logWithTimestamp, logErrorWithTimestamp } from "../lib/logger"
 import { deepMerge, convertSettingsToBatch, applyMigrations, stripDbOwnedKeys } from "../lib/settingsUtils"
+import { storageBridge, folderDocumentUriFromTreeUri } from "../lib/storageBridge"
 
 export { deepMerge, convertSettingsToBatch, applyMigrations }
 
@@ -429,30 +430,39 @@ export const useSettingsManager = () => {
         const packageName = "com.steve1316.uma_android_automation"
 
         try {
-            // Try Storage Access Framework first (recommended for Android 11+).
+            // Prefer the folder the user chose for the bot's logs/recordings so the button lands on their actual data
+            // location, not the app's internal storage. Only fall back to internal when no folder has been configured.
+            let chosenUri: string | null = null
             try {
-                await startActivityAsync("android.intent.action.OPEN_DOCUMENT_TREE", {
-                    data: `content://com.android.externalstorage.documents/tree/primary%3AAndroid%2Fdata%2F${packageName}/files`,
-                    flags: 1, // FLAG_GRANT_READ_URI_PERMISSION
-                })
-
-                endTiming({ status: "success", method: "saf" })
-                return
-            } catch (safError) {
-                console.warn("SAF approach failed, trying fallback:", safError)
+                chosenUri = (await storageBridge.getCurrentFolder())?.uri || null
+            } catch (folderReadError) {
+                console.warn("Could not read the chosen storage folder, falling back to internal:", folderReadError)
             }
 
-            // Fallback: Try to open the data folder with the android.intent.action.VIEW Intent.
-            try {
-                await startActivityAsync("android.intent.action.VIEW", {
-                    data: `/storage/emulated/0/Android/data/${packageName}/files`,
-                    type: "resource/folder",
-                })
+            // Ordered open attempts; the first that launches wins. When the user picked a folder we view it directly in
+            // the system Files app; otherwise we keep the legacy internal-storage behavior (SAF picker, then a path view).
+            const attempts: { action: string; params: Parameters<typeof startActivityAsync>[1]; method: string }[] = chosenUri
+                ? [
+                      { action: "android.intent.action.VIEW", params: { data: folderDocumentUriFromTreeUri(chosenUri), type: "vnd.android.document/directory", flags: 1 }, method: "view-chosen" },
+                      { action: "android.intent.action.OPEN_DOCUMENT_TREE", params: { flags: 1 }, method: "saf-chosen" },
+                  ]
+                : [
+                      {
+                          action: "android.intent.action.OPEN_DOCUMENT_TREE",
+                          params: { data: `content://com.android.externalstorage.documents/tree/primary%3AAndroid%2Fdata%2F${packageName}/files`, flags: 1 },
+                          method: "saf",
+                      },
+                      { action: "android.intent.action.VIEW", params: { data: `/storage/emulated/0/Android/data/${packageName}/files`, type: "resource/folder" }, method: "intent" },
+                  ]
 
-                endTiming({ status: "success", method: "intent" })
-                return
-            } catch (folderError) {
-                console.warn("Folder approach failed, trying file sharing:", folderError)
+            for (const { action, params, method } of attempts) {
+                try {
+                    await startActivityAsync(action, params)
+                    endTiming({ status: "success", method })
+                    return
+                } catch (attemptError) {
+                    console.warn(`Open data directory attempt "${method}" failed, trying next:`, attemptError)
+                }
             }
 
             // Final fallback: Share the settings file directly.

--- a/src/lib/__tests__/eventLogParser.test.ts
+++ b/src/lib/__tests__/eventLogParser.test.ts
@@ -1,4 +1,6 @@
-import { parseLogs, formatGapText, aggregateYearSummaries, LogFileInput, DayRecord, GapRecord } from "../eventLogParser"
+import { readFileSync } from "fs"
+import { join } from "path"
+import { parseLogs, formatGapText, aggregateYearSummaries, LogFileInput, DayRecord, GapRecord, FileDividerRecord } from "../eventLogParser"
 
 // ---------------------------------------------------------------------------
 // Helper: builds a minimal log file content string for a single day.
@@ -282,8 +284,8 @@ describe("parseLogs", () => {
         const result = parseLogs([file("a.txt", content)])
         const days = dayRecords(result)
         expect(days[0].dateText).toBe("JUNIOR YEAR LATE JANUARY")
-        // yearExtract regex captures the case as-is from the text.
-        expect(days[0].year).toBe("JUNIOR")
+        // dateText is kept verbatim, but the year is normalized to canonical title case so year grouping works.
+        expect(days[0].year).toBe("Junior")
     })
 
     it("extracts detected date from INFO line", () => {
@@ -503,12 +505,7 @@ describe("parseLogs", () => {
     it("updates existing day's dateText when same day appears again in same file", () => {
         // Day 5 first appears without dateText (bare Turn Number line without [DATE] prefix),
         // then appears again with proper dateText.
-        const content = [
-            "Current Turn Number 5",
-            "some log line",
-            "[INFO] Detected date: Junior Year Early Mar",
-            "[DATE] It is currently Junior Year Early Mar / Turn Number 5.",
-        ].join("\n")
+        const content = ["Current Turn Number 5", "some log line", "[INFO] Detected date: Junior Year Early Mar", "[DATE] It is currently Junior Year Early Mar / Turn Number 5."].join("\n")
         const result = parseLogs([file("a.txt", content)])
         const days = dayRecords(result)
         const day5 = days.find((d) => d.dayNumber === 5)!
@@ -600,11 +597,7 @@ describe("aggregateYearSummaries", () => {
     })
 
     it("produces summaries in order [Junior, Classic, Senior]", () => {
-        const records = [
-            makeDayRecord({ dayNumber: 25, year: "Classic" }),
-            makeDayRecord({ dayNumber: 1, year: "Junior" }),
-            makeDayRecord({ dayNumber: 49, year: "Senior" }),
-        ]
+        const records = [makeDayRecord({ dayNumber: 25, year: "Classic" }), makeDayRecord({ dayNumber: 1, year: "Junior" }), makeDayRecord({ dayNumber: 49, year: "Senior" })]
         const result = aggregateYearSummaries(records)
         expect(result.summaries.map((s) => s.year)).toEqual(["Junior", "Classic", "Senior"])
     })
@@ -704,10 +697,7 @@ describe("aggregateYearSummaries", () => {
     })
 
     it("marks hasFinals for Senior year when turns 73-75 are present", () => {
-        const records = [
-            makeDayRecord({ dayNumber: 72, year: "Senior" }),
-            makeDayRecord({ dayNumber: 73, year: "Senior" }),
-        ]
+        const records = [makeDayRecord({ dayNumber: 72, year: "Senior" }), makeDayRecord({ dayNumber: 73, year: "Senior" })]
         const result = aggregateYearSummaries(records)
         const senior = result.summaries.find((s) => s.year === "Senior")!
         expect(senior.hasFinals).toBe(true)
@@ -741,5 +731,86 @@ describe("aggregateYearSummaries", () => {
         const result = aggregateYearSummaries(records)
         // Junior: 100000, Classic: 150000, total: 250000
         expect(result.totalElapsedTimeMs).toBe(250000)
+    })
+})
+
+// ===========================================================================
+// Regression: trimmed slice of a real bot run
+// ===========================================================================
+
+describe("real-run slice regression", () => {
+    // A trimmed slice of an actual Oguri Cap Trackblazer run. It keeps the Smart Race Solver preview schedule
+    // (34 "Turn N (...)" lines) so we lock in that those future-turn lines never create phantom day records, plus
+    // representative Junior/Classic/Senior turns covering training, racing, energy, mood, injury, and the Finale.
+    const content = readFileSync(join(__dirname, "fixtures", "oguri-run-slice.log"), "utf8")
+    const result = parseLogs([file("Oguri_CapP_2026-06-30 00_50_29.txt", content)])
+    const days = dayRecords(result)
+    const byDay = (n: number) => days.find((d) => d.dayNumber === n)
+
+    it("does not create phantom days from the solver preview schedule", () => {
+        expect(result.meta.firstDay).toBe(1)
+        expect(result.meta.lastDay).toBe(75)
+        // The schedule lists turns 16, 50, 65, ... but the slice has no real per-turn content for them.
+        expect(byDay(16)).toBeUndefined()
+        expect(byDay(50)).toBeUndefined()
+        expect(byDay(65)).toBeUndefined()
+        expect(days.map((d) => d.dayNumber)).toEqual([1, 2, 31, 58, 73, 74, 75])
+    })
+
+    it("normalizes uppercase year text into the three canonical year buckets", () => {
+        // Day 2 logs its date as "JUNIOR YEAR ...", day 31 as "CLASSIC YEAR ...", day 58 as "SENIOR YEAR ...".
+        expect(byDay(2)!.year).toBe("Junior")
+        expect(byDay(31)!.year).toBe("Classic")
+        expect(byDay(58)!.year).toBe("Senior")
+    })
+
+    it("title-cases the uppercase training type in the summary", () => {
+        expect(byDay(1)!.trainingType).toBe("WIT")
+        expect(byDay(1)!.summary).toContain("Wit Training")
+        expect(byDay(1)!.summary).not.toContain("WIT Training")
+    })
+
+    it("detects the reworded injury line and the mood recovery", () => {
+        expect(byDay(58)!.actions.injury).toBe(true)
+        expect(byDay(58)!.summary).toContain("Recover Injury")
+        expect(byDay(2)!.actions.mood).toBe(true)
+    })
+
+    it("builds correct year summaries with the Finale folded into Senior", () => {
+        const summary = aggregateYearSummaries(days)
+        expect(summary.summaries.map((s) => s.year)).toEqual(["Junior", "Classic", "Senior"])
+        const junior = summary.summaries.find((s) => s.year === "Junior")!
+        const classic = summary.summaries.find((s) => s.year === "Classic")!
+        const senior = summary.summaries.find((s) => s.year === "Senior")!
+        expect(junior.moodCount).toBe(1)
+        expect(classic.raceCount).toBe(1)
+        expect(senior.injuryCount).toBe(1)
+        expect(senior.hasFinals).toBe(true)
+        // Year-summary action counts reconcile with the timeline: 3 training days and 3 race days total.
+        expect(summary.summaries.reduce((n, s) => n + s.trainingCount, 0)).toBe(3)
+        expect(summary.summaries.reduce((n, s) => n + s.raceCount, 0)).toBe(3)
+    })
+
+    it("captures the race name, grade, finishing place, and win result", () => {
+        const race = byDay(31)!
+        expect(race.actions.race).toBe(true)
+        expect(race.raceName).toBe("Satsuki Sho")
+        expect(race.raceGrade).toBe("G1")
+        expect(race.racePlace).toBe("1st")
+        expect(race.raceWon).toBe(true)
+        // The race name flows into the summary used as the row's accessibility label.
+        expect(race.summary).toContain("Satsuki Sho")
+        // The lines behind the detected name/place/result are also surfaced as expandable race trigger lines.
+        const raceTriggers = race.triggers!.race.join("\n")
+        expect(raceTriggers).toContain("Selected Race: Satsuki Sho")
+        expect(raceTriggers).toContain("confirmed 1st")
+        expect(raceTriggers).toContain("Race result detected")
+    })
+
+    it("captures the scenario/campaign and surfaces it on the file divider and year summaries", () => {
+        const divider = result.records.find((r) => r.kind === "fileDivider") as FileDividerRecord
+        expect(divider.scenario).toBe("Trackblazer")
+        expect(byDay(31)!.scenario).toBe("Trackblazer")
+        expect(aggregateYearSummaries(days).scenario).toBe("Trackblazer")
     })
 })

--- a/src/lib/__tests__/fixtures/oguri-run-slice.log
+++ b/src/lib/__tests__/fixtures/oguri-run-slice.log
@@ -1,0 +1,1619 @@
+
+00:00:00.423 [INFO] [INFO] Device Information: 1080x1920, DPI 240
+00:00:00.423 [WARN] [WARN] ⚠️ Note that certain Android notification styles (like banners) are big enough that they cover the area that contains the Mood which will interfere with mood recovery logic in the beginning.
+00:00:00.423 [INFO] [INFO] Bot version: 5.8.0 (78)
+00:00:00.415 [INFO] 🏁 Campaign Selected: Trackblazer
+
+
+00:00:00.448 [INFO] [ANALYTICS] Run start: persistence enabled; saved run found (scenario=Trackblazer, lastTurn=75, name=Oguri CapP, 74 turns).
+00:00:03.995 [VERBOSE] [INFO] Detected date: Junior Year Pre-Debut
+00:00:04.128 [INFO] [INFO] Detected day for extra racing: 11
+00:00:04.262 [INFO] Smart Race Solver Preview Schedule (34 races, score=1021.30, projected epithets: [Breakneck Miler, Dirt G1 Achiever, Dirt G1 Powerhouse, Dirt G1 Star, Dirty Work, Fall Champion, Globe-Trotter, Incredible, Junior Jewel, Kanto Conqueror, Legendary, Phenomenal, Pro Racer, Shield Bearer, Spring Champion, Standard Distance Leader, Stunning, Tohoku Top Dog, West Japan Whiz]):
+  Turn 16 (Junior Class August, Second Half - Niigata Junior Stakes, G3)
+  Turn 17 (Junior Class September, First Half - Sapporo Junior Stakes, G3)
+  Turn 19 (Junior Class October, First Half - Saudi Arabia Royal Cup, G3)
+  Turn 20 (Junior Class October, Second Half - Artemis Stakes, G3)
+  Turn 22 (Junior Class November, Second Half - Tokyo Sports Hai Junior Stakes, G3)
+  Turn 23 (Junior Class December, First Half - Asahi Hai Futurity Stakes, G1)
+  Turn 24 (Junior Class December, Second Half - Hopeful Stakes, G1)
+  Turn 27 (Classic Class February, First Half - Kyodo News Hai, G3)
+  Turn 29 (Classic Class March, First Half - Yayoi Sho, G2)
+  Turn 30 (Classic Class March, Second Half - Spring Stakes, G2)
+  Turn 31 (Classic Class April, First Half - Satsuki Sho, G1)
+  Turn 33 (Classic Class May, First Half - NHK Mile Cup, G1)
+  Turn 34 (Classic Class May, Second Half - Tokyo Yushun (Japanese Derby), G1)
+  Turn 36 (Classic Class June, Second Half - Takarazuka Kinen, G1)
+  Turn 41 (Classic Class September, First Half - Niigata Kinen, G3)
+  Turn 43 (Classic Class October, First Half - Mainichi Okan, G2)
+  Turn 44 (Classic Class October, Second Half - Kikuka Sho, G1)
+  Turn 46 (Classic Class November, Second Half - Mile Championship, G1)
+  Turn 47 (Classic Class December, First Half - Champions Cup, G1)
+  Turn 48 (Classic Class December, Second Half - Arima Kinen, G1)
+  Turn 50 (Senior Class January, Second Half - American JCC, G2)
+  Turn 52 (Senior Class February, Second Half - February Stakes, G1)
+  Turn 53 (Senior Class March, First Half - Kinko Sho, G2)
+  Turn 54 (Senior Class March, Second Half - Osaka Hai, G1)
+  Turn 56 (Senior Class April, Second Half - Tenno Sho (Spring), G1)
+  Turn 57 (Senior Class May, First Half - Victoria Mile, G1)
+  Turn 59 (Senior Class June, First Half - Yasuda Kinen, G1)
+  Turn 60 (Senior Class June, Second Half - Teio Sho, G1)
+  Turn 65 (Senior Class September, First Half - Niigata Kinen, G3)
+  Turn 67 (Senior Class October, First Half - Mainichi Okan, G2)
+  Turn 68 (Senior Class October, Second Half - Tenno Sho (Autumn), G1)
+  Turn 70 (Senior Class November, Second Half - Japan Cup, G1)
+  Turn 71 (Senior Class December, First Half - Champions Cup, G1)
+  Turn 72 (Senior Class December, Second Half - Tokyo Daishoten, G1)
+00:00:06.508 [INFO] [TRAINEE] Name: Oguri CapP
+00:00:07.741 [VERBOSE] [INFO] Detected date: Junior Year Pre-Debut
+00:00:07.850 [INFO] [INFO] Detected day for extra racing: 11
+00:00:09.941 [VERBOSE] [INFO] Detected date: Junior Year Pre-Debut
+00:00:10.153 [INFO] [INFO] Detected day for extra racing: 11
+00:00:10.208 [VERBOSE] [TRAINEE] Name: Oguri CapP
+00:00:10.208 [VERBOSE] [TRAINEE] Stats: Spd=192, Sta=101, Pow=219, Gut=85, Wit=145
+00:00:10.208 [VERBOSE] [TRAINEE] Energy: 100%
+00:00:10.208 [VERBOSE] [TRAINEE] Mood: NORMAL
+00:00:10.208 [VERBOSE] [TRAINEE] Fans: 1
+00:00:10.208 [VERBOSE] [TRAINEE] Skill Points: 120
+00:00:10.208 [VERBOSE] [TRAINEE] Track: Turf=A, Dirt=B
+00:00:10.208 [VERBOSE] [TRAINEE] Distance: Sprint=B, Mile=A, Medium=A, Long=B
+00:00:10.208 [VERBOSE] [TRAINEE] Style: Front=F, Pace=A, Late=A, End=B
+00:00:10.208 [INFO] [ANALYTICS] Saved analytics did not match the current run; starting fresh. saved(scenario=Trackblazer, turn=75, name=Oguri CapP) vs current(scenario=Trackblazer, turn=1, name=Oguri CapP).
+
+00:00:10.267 [INFO] [INJURY] Checking if there is an injury that needs healing on JUNIOR YEAR EARLY JANUARY (Turn 1).
+00:00:10.295 [INFO] [INJURY] No injury detected.
+00:00:10.321 [INFO] [MOOD] Current mood is Normal. Not recovering mood due to firstTrainingCheck flag being active. Will need to complete a training first before being allowed to recover mood.
+
+00:00:10.441 [INFO] [INFO] Detected day for extra racing: 11
+00:00:10.441 [INFO] [RACE] Current remaining number of days before the next mandatory race: 11.
+00:00:10.442 [INFO] [RACE] Smart Race Solver has no race planned for turn 1. Skipping the extra-race fallback.
+00:00:10.473 [INFO] [TRACKBLAZER] Decision made to train.
+00:00:10.474 [INFO] [TRACKBLAZER] Starting specialized Training process.
+
+00:00:11.168 [VERBOSE] [TRAINING] Now starting process to analyze all 5 Trainings.
+00:00:11.587 [INFO] [TRAINING] 0% within acceptable range of 20%. Proceeding to acquire all other percentages and total stat increases...
+00:00:11.700 [INFO] [TRAINING] Skipping STAMINA training due to being blacklisted.
+00:00:12.385 [INFO] [TRAINING] Skipping GUTS training due to being blacklisted.
+00:00:13.460 [VERBOSE] [TRAINING] Process to analyze all 5 Trainings complete.
+
+00:00:13.488 [VERBOSE] [TRAINING] Starting process to score SPEED Training with a focus on building relationship bars.
+00:00:13.490 [INFO] [TRAINING] SPEED Training has a score of 2.50 with a focus on building 1 relationship bars.
+
+00:00:13.491 [VERBOSE] [TRAINING] Starting process to score POWER Training with a focus on building relationship bars.
+00:00:13.492 [INFO] [TRAINING] POWER Training has a score of 5.00 with a focus on building 2 relationship bars.
+
+00:00:13.492 [VERBOSE] [TRAINING] Starting process to score WIT Training with a focus on building relationship bars.
+00:00:13.492 [INFO] [TRAINING] WIT Training has a score of 7.50 with a focus on building 3 relationship bars.
+
+00:00:13.495 [VERBOSE] ========== Training Analysis Results ==========
+Scoring Mode: Friendship (Pre-Debut/Junior)
+Current Date: JUNIOR YEAR EARLY JANUARY (Turn 1)
+Current Stats: Speed=192, Stamina=101, Power=219, Guts=85, Wit=145
+Stat Targets: Disabled (treating cap=1200 as the target for all stats)
+Completion: SPEED=16%, STAMINA=8%, POWER=18%, GUTS=7%, WIT=12%
+
+--- Training Details ---
+SPEED Training: stats={SPEED=11, STAMINA=0, POWER=6, GUTS=0, WIT=0}, fail=0%, rainbows=0
+  -> Relationship bars: #1:blue(31%)
+[STAMINA] BLACKLISTED
+POWER Training: stats={SPEED=0, STAMINA=5, POWER=8, GUTS=0, WIT=0}, fail=0%, rainbows=0
+  -> Relationship bars: #1:blue(19%), #2:blue(20%)
+  -> Skill hints: 1
+[GUTS] BLACKLISTED
+WIT Training: stats={SPEED=5, STAMINA=0, POWER=0, GUTS=0, WIT=8}, fail=0%, rainbows=0 <---- SELECTED
+  -> Relationship bars: #1:blue(31%), #2:blue(19%), #3:blue(13%)
+
+--- Selection Explanation ---
+WIT beat POWER by 2.50 points (50.0% higher)
+Key factor: 3 near-max friendship bar(s) (anticipatory rainbow multiplier applied).
+Key factor: WIT stat is at 12% of target (behind, higher priority).
+Key factor: Multiple relationship bars present (3).
+================================================
+
+00:00:13.496 [VERBOSE] [TRAINING] Now starting process to execute WIT training...
+00:00:13.497 [VERBOSE] [TRAINING] Executing the WIT Training.
+
+00:00:14.489 [VERBOSE] [TRAINING] Process to execute training completed.
+
+00:00:14.490 [INFO] ============== Turn 1 (JUNIOR EARLY JANUARY) Decision Report ==============
+State:
+  Energy = 100%
+  Mood = NORMAL
+  Negative Statuses = []
+  Megaphone Turns = 0
+  Consecutive Races = 0
+  Used Charm Today = false
+  Used Whistle Today = false
+Inventory (decision-relevant):
+  [Charms & Whistles]
+  Good-Luck Charm = 0
+  Reset Whistle = 0
+  [Megaphones]
+  Coaching Megaphone = 0
+  Empowering Megaphone = 0
+  Motivating Megaphone = 0
+  [Cupcakes & Heals]
+  Berry Sweet Cupcake = 0
+  Plain Cupcake = 0
+  Royal Kale Juice = 0
+  [Race Items]
+  Artisan Cleat Hammer = 0
+  Glow Sticks = 0
+  Master Cleat Hammer = 0
+Settings (decision-relevant):
+  Trackblazer Energy Threshold = 40
+  Force-Train Energy Floor = 20
+  Skip Risky Charm Training Below Gain = 30
+  Consecutive Races Limit = 5
+  Skip Bad-Mood Items Below Gain = 15
+  Skip Empowering Megaphone Below Gain = 0
+  Skip Motivating Megaphone Below Gain = 0
+  Skip Coaching Megaphone Below Gain = 0
+  Whistle Forces Training = true
+  Irregular Training = on (min main 30)
+  Enable In-Game Race Agenda = false
+  Max Failure Chance = 20%
+  Riskier Training = on (max fail 30%, min main 30)
+  Energy Item Reserve = 1
+  Cupcake Reserve = 1
+  Race Item Conservation Start Turn = 65
+  Master Hammer Finale Reserve = 2
+  Artisan Hammer Min Stock G3 = 3
+  Artisan Hammer Min Stock G2 = 2
+  Glow Stick Final-Day Reserve = 1
+  Glow Stick Min Fans = 20000
+Items Used: None
+
+Race eligibility: NOT ELIGIBLE
+  Reason: Smart Race Solver has no race planned for this turn
+
+Action: TRAIN
+  Reason: Default fallback after racing/mood/injury checks did not trigger
+
+Training selected: WIT (source=ANALYSIS)
+  Reason: Final pick selected by initial analyzer pass (no Reset Whistle used)
+  Pick: fail=0%, gains=[SPD:5 STA:0 PWR:0 GUTS:0 WIT:8]
+  Runner-ups:
+    - SPEED (considered): fail=0%, gains=[SPD:11 STA:0 PWR:6 GUTS:0 WIT:0], considered by analyzer but lost to selection
+    - POWER (considered): fail=0%, gains=[SPD:0 STA:5 PWR:8 GUTS:0 WIT:0], considered by analyzer but lost to selection
+==============================================================
+
+
+
+
+
+
+
+
+
+
+00:00:16.416 [INFO] [LOADING] Detected that the game is awaiting a response from the server from the "Connecting" text at the top of the screen. Waiting...
+
+
+
+
+
+
+
+
+
+
+00:00:18.565 [INFO] [LOADING] Detected that the game is awaiting a response from the server from the "Connecting" text at the top of the screen. Waiting...
+
+
+
+
+
+
+
+
+
+
+
+00:00:20.968 [INFO] [TRACKBLAZER] Tutorial must have already been dismissed.
+
+00:00:20.968 [VERBOSE] ********************
+00:00:20.968 [VERBOSE] [TRAINING_EVENT] Starting Training Event process on JUNIOR YEAR EARLY JANUARY (Turn 1).
+
+
+00:00:21.161 [VERBOSE] ========== Training Event Summary ==========
+Event: "Field Workout" (Oguri Cap) [Confidence: 1]
+Current Date: JUNIOR YEAR EARLY JANUARY (Turn 1)
+
+Options:
+  Option 1 [Weight: 10]: Guts +10
+  Option 2 [Weight: 50]: Power +10 <---- SELECTED
+
+Selected: Option 2
+============================================
+
+00:00:21.441 [VERBOSE] [TRAINING_EVENT] Process to handle detected Training Event completed.
+00:00:21.441 [VERBOSE] ********************
+
+
+00:00:21.643 [VERBOSE] ********************
+00:00:21.643 [VERBOSE] [TRAINING_EVENT] Starting Training Event process on JUNIOR YEAR EARLY JANUARY (Turn 1).
+
+
+00:00:21.813 [VERBOSE] ========== Training Event Summary ==========
+Event: "Field Workout" (Oguri Cap) [Confidence: 1]
+Current Date: JUNIOR YEAR EARLY JANUARY (Turn 1)
+
+Options:
+  Option 1 [Weight: 10]: Guts +10
+  Option 2 [Weight: 50]: Power +10 <---- SELECTED
+
+Selected: Option 2
+============================================
+
+00:00:22.435 [VERBOSE] [TRAINING_EVENT] Process to handle detected Training Event completed.
+00:00:22.435 [VERBOSE] ********************
+
+
+
+
+
+00:00:23.787 [VERBOSE] [INFO] Detected date: Junior Year Pre-Debut
+00:00:23.888 [INFO] [INFO] Detected day for extra racing: 10
+00:00:23.888 [VERBOSE] [DATE] New date: JUNIOR YEAR LATE JANUARY (Turn 2)
+00:00:24.765 [VERBOSE] [TRAINEE] Name: Oguri CapP
+00:00:24.766 [VERBOSE] [TRAINEE] Stats: Spd=197, Sta=101, Pow=229, Gut=85, Wit=171
+00:00:24.766 [VERBOSE] [TRAINEE] Energy: 100%
+00:00:24.766 [VERBOSE] [TRAINEE] Mood: NORMAL
+00:00:24.766 [VERBOSE] [TRAINEE] Fans: 1
+00:00:24.769 [VERBOSE] [TRAINEE] Skill Points: 123
+00:00:24.769 [VERBOSE] [TRAINEE] Track: Turf=A, Dirt=B
+00:00:24.769 [VERBOSE] [TRAINEE] Distance: Sprint=B, Mile=A, Medium=A, Long=B
+00:00:24.769 [VERBOSE] [TRAINEE] Style: Front=F, Pace=A, Late=A, End=B
+
+00:00:24.838 [INFO] [INJURY] Checking if there is an injury that needs healing on JUNIOR YEAR LATE JANUARY (Turn 2).
+00:00:24.867 [INFO] [INJURY] No injury detected.
+00:00:24.867 [INFO] [TRACKBLAZER] Mood is NORMAL and energy is 100% (>= 70%). Attempting to recover mood via rest/recreation (saving items).
+00:00:24.906 [INFO] [TRACKBLAZER] Resetting 0 consecutive race counts due to mood recovery.
+
+00:00:24.907 [VERBOSE] [MOOD] Detecting current mood on JUNIOR YEAR LATE JANUARY (Turn 2).
+00:00:24.987 [VERBOSE] [MOOD] Detected mood to be NORMAL.
+00:00:25.015 [VERBOSE] [MOOD] Current mood is not good (NORMAL). Recovering mood now.
+00:00:25.893 [VERBOSE] [MOOD] Successfully recovered mood.
+
+00:00:25.894 [INFO] ============== Turn 2 (JUNIOR LATE JANUARY) Decision Report ==============
+State:
+  Energy = 100%
+  Mood = NORMAL
+  Negative Statuses = []
+  Megaphone Turns = 0
+  Consecutive Races = 0
+  Used Charm Today = false
+  Used Whistle Today = false
+Inventory (decision-relevant):
+  [Charms & Whistles]
+  Good-Luck Charm = 0
+  Reset Whistle = 0
+  [Megaphones]
+  Coaching Megaphone = 0
+  Empowering Megaphone = 0
+  Motivating Megaphone = 0
+  [Cupcakes & Heals]
+  Berry Sweet Cupcake = 0
+  Plain Cupcake = 0
+  Royal Kale Juice = 0
+  [Race Items]
+  Artisan Cleat Hammer = 0
+  Glow Sticks = 0
+  Master Cleat Hammer = 0
+Settings (decision-relevant):
+  Trackblazer Energy Threshold = 40
+  Force-Train Energy Floor = 20
+  Skip Risky Charm Training Below Gain = 30
+  Consecutive Races Limit = 5
+  Skip Bad-Mood Items Below Gain = 15
+  Skip Empowering Megaphone Below Gain = 0
+  Skip Motivating Megaphone Below Gain = 0
+  Skip Coaching Megaphone Below Gain = 0
+  Whistle Forces Training = true
+  Irregular Training = on (min main 30)
+  Enable In-Game Race Agenda = false
+  Max Failure Chance = 20%
+  Riskier Training = on (max fail 30%, min main 30)
+  Energy Item Reserve = 1
+  Cupcake Reserve = 1
+  Race Item Conservation Start Turn = 65
+  Master Hammer Finale Reserve = 2
+  Artisan Hammer Min Stock G3 = 3
+  Artisan Hammer Min Stock G2 = 2
+  Glow Stick Final-Day Reserve = 1
+  Glow Stick Min Fans = 20000
+Items Used: None
+
+Action: RECOVER_MOOD
+  Reason: shouldRecoverMood returned true (mood NORMAL)
+==============================================================
+
+
+
+
+
+
+
+
+
+
+
+
+00:00:27.988 [VERBOSE] ********************
+00:00:27.988 [VERBOSE] [TRAINING_EVENT] Starting Training Event process on JUNIOR YEAR LATE JANUARY (Turn 2).
+
+
+00:00:28.195 [VERBOSE] ========== Training Event Summary ==========
+Event: "Something Smells Good!" (Oguri Cap) [Confidence: 1]
+Current Date: JUNIOR YEAR LATE JANUARY (Turn 2)
+
+Options:
+  Option 1 [Weight: 40]: Speed +10 <---- SELECTED
+  Option 2 [Weight: 10]: Guts +10
+
+Selected: Option 1
+============================================
+
+00:00:28.838 [VERBOSE] [TRAINING_EVENT] Process to handle detected Training Event completed.
+00:00:28.838 [VERBOSE] ********************
+
+
+
+
+
+
+
+00:00:30.028 [VERBOSE] ********************
+00:00:30.028 [VERBOSE] [TRAINING_EVENT] Starting Training Event process on JUNIOR YEAR LATE JANUARY (Turn 2).
+00:00:30.240 [VERBOSE] [TRAINING_EVENT] Tutorial event detected for Unity Cup. Found 2 option(s) on screen.
+00:00:30.240 [VERBOSE] [TRAINING_EVENT] Selecting last option (option 2) to dismiss Tutorial.
+00:00:30.864 [INFO] [TRAINING_EVENT] Selected option 2 for Tutorial.
+00:00:30.864 [VERBOSE] [TRAINING_EVENT] Process to handle detected Training Event completed.
+00:00:30.864 [VERBOSE] ********************
+00:00:31.262 [VERBOSE] [INFO] Detected date: Junior Year Pre-Debut
+00:00:31.413 [INFO] [INFO] Detected day for extra racing: 9
+00:18:53.566 [VERBOSE] [DATE] New date: CLASSIC YEAR EARLY APRIL (Turn 31)
+00:18:55.524 [VERBOSE] [TRAINEE] Positive Statuses: Charming
+00:18:56.171 [WARN] [WARN] updateStats:: New GUTS stat value has changed too much since last update (old=192, new=1) via sequential processing. Consecutive mismatch count: 1
+00:18:57.281 [VERBOSE] [INFO] Detected date: Classic Year Early Apr
+00:18:59.362 [VERBOSE] [INFO] Detected date: Classic Year Early Apr
+00:18:59.425 [VERBOSE] [TRAINEE] Name: Oguri CapP
+00:18:59.425 [VERBOSE] [TRAINEE] Stats: Spd=466, Sta=211, Pow=465, Gut=192, Wit=529
+00:18:59.426 [VERBOSE] [TRAINEE] Energy: 52%
+00:18:59.426 [VERBOSE] [TRAINEE] Mood: GREAT
+00:18:59.426 [VERBOSE] [TRAINEE] Fans: 99253
+00:18:59.426 [VERBOSE] [TRAINEE] Skill Points: 292
+00:18:59.426 [VERBOSE] [TRAINEE] Track: Turf=A, Dirt=B
+00:18:59.426 [VERBOSE] [TRAINEE] Distance: Sprint=B, Mile=A, Medium=A, Long=B
+00:18:59.426 [VERBOSE] [TRAINEE] Style: Front=F, Pace=A, Late=A, End=B
+00:18:59.426 [VERBOSE] [TRAINEE] Positive Statuses: Charming
+00:18:59.426 [INFO] [TRACKBLAZER] Skipping Training Items dialog as no relevant items are in the cached inventory.
+00:18:59.427 [INFO] [TRACKBLAZER] Smart Race Solver has "Satsuki Sho (Classic Class April, First Half)" planned for turn 31; deferring to racing flow.
+00:18:59.465 [INFO] [INFO] All checks are cleared for racing.
+00:18:59.532 [INFO] [TRACKBLAZER] Checking for suitable races.
+00:19:01.095 [INFO] [TRACKBLAZER] Current consecutive race count: 3.
+00:19:01.095 [WARN] [WARN] shouldAllowConsecutiveRace:: Current consecutive race count is 3. Note that a -30 stat penalty can apply starting from 3 consecutive races!
+00:19:01.131 [INFO] [TRACKBLAZER] Consecutive race count 3 < 6. Continuing.
+00:19:01.131 [INFO] [RACE] Consecutive race warning! Racing anyway...
+00:19:03.951 [INFO] [RACE] Scanning the whole race list for suitable races...
+00:19:08.266 [INFO] [INFO] Extracted race name: "Hanshin Turf 160Om (Mile) Right / Outer"
+00:19:08.267 [INFO] [RACE] Looking up race for turn 31 with detected name: "Hanshin Turf 160Om (Mile) Right / Outer".
+00:19:08.267 [INFO] [RACE] Found 2 fuzzy matches with similarity 0.94 but different fan counts:
+00:19:08.267 [INFO] [RACE]     - "Arlington Cup" (Fans: 3800)
+00:19:08.267 [INFO] [RACE]     - "Oka Sho" (Fans: 10500)
+00:19:08.491 [INFO] [INFO] Extracted race name: "Nakayama Turf 2000m (Med) Right / Inner"
+00:19:08.492 [INFO] [RACE] Looking up race for turn 31 with detected name: "Nakayama Turf 2000m (Med) Right / Inner".
+00:19:08.492 [INFO] [RACE] Found exact match: "Satsuki Sho" AKA "Nakayama Turf 2000m (Med) Right / Inner" (Fans: 11000).
+
+00:19:08.492 [VERBOSE] ========== Trackblazer Race Selection Analysis ==========
+Current Date: CLASSIC YEAR EARLY APRIL (Turn 31)
+Consecutive Race Count: 3
+
+- Found Suitable Race: "Arlington Cup" (G3) Rival: true
+
+- Found Suitable Race: "Oka Sho" (G1) Rival: true
+
+- Found Suitable Race: "Satsuki Sho" (G1) Rival: true [Smart Race Solver override]
+
+Selected Race: Satsuki Sho (G1) Rival: true [Smart Race Solver pick]
+================================================
+
+00:19:08.492 [INFO] [RACE] Smart Race Solver match "Satsuki Sho" found during scan. Skipping the rest of the scan.
+00:19:08.492 [INFO] [TRACKBLAZER] Found suitable race: Satsuki Sho (G1). Processing items.
+00:19:08.492 [INFO] [TRACKBLAZER] Suitable race items found in inventory (Hammer: Master Cleat Hammer, Glow Sticks: false). Opening Training Items dialog.
+00:19:09.828 [INFO] [TRACKBLAZER] Queuing specific item for use: "Master Cleat Hammer". (Reason: Race bonus for G1.)
+
+00:19:10.520 [VERBOSE] ============== Item Usage Summary ==============
+
+[Current Inventory]
+
+Energy and Motivation
+- Plain Cupcake: 2
+
+Training Effects
+- Coaching Megaphone: 1
+- Good-Luck Charm: 1
+- Motivating Megaphone: 1
+- Power Ankle Weights: 1
+- Reset Whistle: 1
+
+Races
+- Master Cleat Hammer: 1
+
+------------------------------------------------
+
+Items Used:
+
+- 1x Master Cleat Hammer: Race bonus for G1.
+================================================
+
+00:19:10.521 [INFO] [TRACKBLAZER] Decremented Master Cleat Hammer. Remaining: 0.
+00:19:10.521 [INFO] [TRACKBLAZER] Queued 1 race items for G1 (11000 fans). Confirming usage.
+00:19:10.521 [INFO] [TRACKBLAZER] Confirming usage of 1 items.
+00:19:11.368 [INFO] [TRACKBLAZER] Waiting for animation to finish (Delay: 4.0 seconds).
+00:19:15.438 [INFO] [TRACKBLAZER] Closing training items dialog.
+
+00:19:18.533 [VERBOSE] ********************
+00:19:18.533 [VERBOSE] [RACE] Starting Racing process on CLASSIC YEAR EARLY APRIL (Turn 31).
+00:19:18.750 [VERBOSE] [RACE] The bot is already at the Race List screen and a race has already been selected.
+00:19:18.750 [VERBOSE] [RACE] Starting process for a race that is already selected.
+00:19:22.227 [INFO] [RACE] Proceeding to handle the race...
+00:19:23.607 [INFO] [LOADING] Detected that the game is still loading from the "Now Loading" text at the bottom of the screen. Waiting...
+00:19:25.220 [INFO] [RACE] Detected ButtonChangeRunningStyle. Handling race prep screen...
+00:19:25.375 [INFO] [RACE] Clicked ViewResults button to skip race.
+00:19:25.425 [INFO] [LOADING] Detected that the game is awaiting a response from the server from the "Connecting" text at the top of the screen. Waiting...
+00:19:31.215 [INFO] [RACE] Closed post-race popup.
+00:19:31.215 [INFO] [TRACKBLAZER] Rival Race win detected via post-race popup.
+00:19:31.215 [INFO] [TRACKBLAZER] Rival Race win detected. Starting shop check counter at 1. Frequency: 2.
+00:19:32.342 [INFO] [RACE] No retries remaining or eligible race conditions not met.
+00:19:32.678 [INFO] [RACE] Reached race results screen. Exiting race retry loop...
+00:19:32.679 [INFO] [RACE] Now performing cleanup and finishing the race.
+00:19:32.756 [INFO] [RACE] Race result detected - 1st place: true.
+00:19:32.756 [INFO] Race "Satsuki Sho" on turn 31 confirmed 1st; added to history.
+00:19:32.772 [INFO] Race "Satsuki Sho" updated 14 epithet(s):
+  - "All-Rounder" -> IN_PROGRESS (1/6) -> (2/6)
+      * Win 3 turf G1 races
+  - "Epoch Pioneer" -> IN_PROGRESS (1/10) -> (2/10)
+      * Win 10 G1 races
+  - "First Step to Glory" -> IN_PROGRESS (1/15) -> (2/15)
+      * Win at least 15 G1 races
+  - "G1 Hunter" -> IN_PROGRESS (1/7) -> (2/7)
+      * Win 7 G1 races
+  - "Legendary Diva" -> IN_PROGRESS (1/6) -> (2/6)
+      * Win at least 5 G1 races
+  - "Pro Racer" -> IN_PROGRESS (8/10) -> (9/10)
+      * Win 10 OP+ races
+  - "Satsuki Spirit" -> COMPLETED (0/1) -> (1/1)
+      * Win the Satsuki Sho
+  - "Standard Distance Leader" -> IN_PROGRESS (8/10) -> (9/10)
+      * Win 10 Mile/Medium races
+  - "Stunning" -> IN_PROGRESS (0/3) -> (1/3)
+      * Win the Satsuki Sho
+  - "The GOAT" -> IN_PROGRESS (1/7) -> (2/7)
+      * Win at least 7 G1 races
+  - "Triple Crown" -> IN_PROGRESS (0/3) -> (1/3)
+      * Win the Satsuki Sho
+  - "Turf Terror" -> IN_PROGRESS (8/15) -> (9/15)
+      * Win 15 turf races
+  - "Victorious" -> IN_PROGRESS (1/20) -> (2/20)
+      * Win at least 20 G1 races
+  - "Way of Kings" -> IN_PROGRESS (0/3) -> (1/3)
+      * Win the Satsuki Sho
+00:19:32.986 [INFO] [RACE] Clicked on Next (race results) button.
+00:19:34.409 [INFO] [RACE] Clicked on Next (race end) button.
+00:19:34.497 [VERBOSE] [RACE] Racing process for already selected race is completed. Grade: G1
+00:19:34.497 [VERBOSE] ********************
+00:19:34.497 [INFO] [TRACKBLAZER] Consecutive race count was already updated by OCR: 3.
+
+00:19:34.498 [INFO] ============== Turn 31 (CLASSIC EARLY APRIL) Decision Report ==============
+State:
+  Energy = 52%
+  Mood = GREAT
+  Negative Statuses = []
+  Megaphone Turns = 0
+  Consecutive Races = 3
+  Used Charm Today = false
+  Used Whistle Today = false
+Inventory (decision-relevant):
+  [Charms & Whistles]
+  Good-Luck Charm = 1
+  Reset Whistle = 1
+  [Megaphones]
+  Coaching Megaphone = 1
+  Empowering Megaphone = 0
+  Motivating Megaphone = 1
+  [Cupcakes & Heals]
+  Berry Sweet Cupcake = 0
+  Plain Cupcake = 2
+  Royal Kale Juice = 0
+  [Race Items]
+  Artisan Cleat Hammer = 0
+  Glow Sticks = 0
+  Master Cleat Hammer = 1
+Settings (decision-relevant):
+  Trackblazer Energy Threshold = 40
+  Force-Train Energy Floor = 20
+  Skip Risky Charm Training Below Gain = 30
+  Consecutive Races Limit = 5
+  Skip Bad-Mood Items Below Gain = 15
+  Skip Empowering Megaphone Below Gain = 0
+  Skip Motivating Megaphone Below Gain = 0
+  Skip Coaching Megaphone Below Gain = 0
+  Whistle Forces Training = true
+  Irregular Training = on (min main 30)
+  Enable In-Game Race Agenda = false
+  Max Failure Chance = 20%
+  Riskier Training = on (max fail 30%, min main 30)
+  Energy Item Reserve = 1
+  Cupcake Reserve = 1
+  Race Item Conservation Start Turn = 65
+  Master Hammer Finale Reserve = 2
+  Artisan Hammer Min Stock G3 = 3
+  Artisan Hammer Min Stock G2 = 2
+  Glow Stick Final-Day Reserve = 1
+  Glow Stick Min Fans = 20000
+Items Used: None
+
+Action: RACE
+  Reason: Smart Race Solver planned race "Satsuki Sho (Classic Class April, First Half)" for this turn
+
+Race eligibility: ELIGIBLE
+  Reason: Consecutive-race check: Under consecutive-race limit (3 < 6)
+==============================================================
+00:19:34.498 [INFO] [TRACKBLAZER] Shop check frequency reached (2 / 2). Shop check will be performed on main screen.
+
+
+
+
+
+
+
+00:19:35.724 [VERBOSE] ********************
+00:19:35.724 [VERBOSE] [TRAINING_EVENT] Starting Training Event process on CLASSIC YEAR EARLY APRIL (Turn 31).
+00:19:35.884 [VERBOSE] [TRAINING_EVENT] Detected special event: Victory!
+00:19:35.884 [VERBOSE] [TRAINING_EVENT] Using setting: Option 2: Energy -5 and random stat gain (Option 2)
+00:19:35.884 [VERBOSE] [TRAINING_EVENT] Special event override applied: option 2
+00:19:36.521 [VERBOSE] [TRAINING_EVENT] Process to handle detected Training Event completed.
+00:19:36.521 [VERBOSE] ********************
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+00:19:41.692 [INFO] [LOADING] Detected that the game is awaiting a response from the server from the "Connecting" text at the top of the screen. Waiting...
+
+
+
+
+
+
+
+
+
+
+
+
+00:19:44.287 [VERBOSE] ********************
+00:19:44.287 [VERBOSE] [TRAINING_EVENT] Starting Training Event process on CLASSIC YEAR EARLY APRIL (Turn 31).
+
+We Walk Together with confidence = 1
+
+00:19:44.479 [VERBOSE] ========== Training Event Summary ==========
+Event: "(❯❯❯) We Walk Together" (Kitasan Black) [Confidence: 1]
+Current Date: CLASSIC YEAR EARLY APRIL (Turn 31)
+
+Options:
+  Option 1 [Weight: 310]: Randomly either, Speed +5, Power +5... <---- SELECTED
+
+Selected: Option 1
+============================================
+
+00:19:45.103 [VERBOSE] [TRAINING_EVENT] Process to handle detected Training Event completed.
+00:19:45.104 [VERBOSE] ********************
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+00:19:48.557 [INFO] [TRACKBLAZER] Pending shop check detected! Checking Shop for new items...
+00:19:49.807 [INFO] [TRACKBLAZER] Buying extra items after participating in a race...
+00:19:49.807 [INFO] [TRACKBLAZER] Initiating buying process.
+00:19:49.807 [INFO] [TRACKBLAZER] Updating current amount of Shop Coins...
+00:19:53.091 [INFO] [INFO] Current Shop Coins: 228 (Raw OCR text: "228")
+00:19:53.091 [INFO] [TRACKBLAZER] Initial Shop Coins: 228
+00:19:53.091 [INFO] [INFO] Beginning process of scanning shop items...
+00:19:56.106 [WARN] [WARN] getShopItemPrice:: Parsed empty string for Shop Item Price.
+00:19:56.106 [INFO] 	Energy Drink MAX: 30 coins at index 0
+00:19:56.418 [WARN] [WARN] getShopItemPrice:: Parsed empty string for Shop Item Price.
+00:19:56.419 [INFO] 	Power Scroll: 30 coins at index 1
+00:19:56.652 [WARN] [WARN] getShopItemPrice:: Parsed empty string for Shop Item Price.
+00:19:56.652 [INFO] 	Guts Ankle Weights: 50 coins at index 2
+00:19:58.306 [WARN] [WARN] getShopItemPrice:: Parsed empty string for Shop Item Price.
+00:19:58.306 [INFO] 	Empowering Megaphone: 70 coins at index 3
+00:19:58.652 [INFO] 	Guts Ankle Weights: 45 coins at index 4
+00:19:58.899 [INFO] 	Stamina Ankle Weights: 45 coins at index 5
+00:20:00.799 [INFO] 	Stamina Training Application: 135 coins at index 6
+
+00:20:05.503 [VERBOSE] ============== Shop Evaluation Summary ==============
+
+[Current Inventory]
+
+Energy and Motivation
+- Plain Cupcake: 2
+
+Training Effects
+- Coaching Megaphone: 1
+- Good-Luck Charm: 1
+- Motivating Megaphone: 1
+- Power Ankle Weights: 1
+- Reset Whistle: 1
+
+------------------------------------------------
+Current coins: 228.
+Items found:
+
+  - Energy Drink MAX
+  - Power Scroll
+  - Guts Ankle Weights
+  - Empowering Megaphone
+  - Guts Ankle Weights
+  - Stamina Ankle Weights
+  - Stamina Training Application
+  - Guts Manual (Purchased)
+  - Stamina Manual (Purchased)
+  - Grilled Carrots (Purchased)
+  - Master Cleat Hammer (Purchased)
+  - Motivating Megaphone (Purchased)
+  - Power Scroll (Purchased)
+  - Guts Scroll (Purchased)
+
+Items to buy:
+
+  - Power Scroll: 30 coins (Reason: Power +15)
+  - Empowering Megaphone: 70 coins (Reason: Training bonus +60% for 2 turns)
+  - Energy Drink MAX: 30 coins (Reason: Maximum energy +4, Energy +5)
+
+TOTAL: 130 / 228 coins with 98 left over coins
+==========================================
+00:20:08.457 [INFO] [INFO] Selecting "Energy Drink MAX" for 30 coins at index 0. (Reason: Maximum energy +4, Energy +5)
+00:20:09.187 [INFO] [INFO] Selecting "Power Scroll" for 30 coins at index 1. (Reason: Power +15)
+00:20:11.505 [INFO] [INFO] Selecting "Empowering Megaphone" for 70 coins at index 3. (Reason: Training bonus +60% for 2 turns)
+00:20:11.959 [INFO] [INFO] Successfully selected and purchased 3 item(s).
+00:20:13.251 [INFO] [TRACKBLAZER] Quick-use items were purchased. Navigating and queuing for usage...
+00:20:13.559 [INFO] [TRACKBLAZER] Queuing item for use (copy 1): "Power Scroll". (Reason: Quick-use after purchase.)
+00:20:14.255 [INFO] [TRACKBLAZER] Queuing item for use (copy 2): "Power Scroll". (Reason: Quick-use after purchase.)
+
+00:20:14.265 [VERBOSE] ============== Item Usage Summary ==============
+
+[Current Inventory]
+
+Stats
+- Power Scroll: 1
+
+Energy and Motivation
+- Energy Drink MAX: 1
+- Plain Cupcake: 2
+
+Training Effects
+- Coaching Megaphone: 1
+- Empowering Megaphone: 1
+- Good-Luck Charm: 1
+- Motivating Megaphone: 1
+- Power Ankle Weights: 1
+- Reset Whistle: 1
+
+------------------------------------------------
+
+Items Used:
+
+- 1x Power Scroll: Quick-use after purchase.
+================================================
+
+00:20:14.265 [INFO] [TRACKBLAZER] Decremented Power Scroll. Remaining: 0.
+00:20:16.260 [INFO] [TRACKBLAZER] Successfully handled "Exchange Complete" dialog.
+00:20:16.260 [INFO] [TRACKBLAZER] Updating current amount of Shop Coins...
+00:20:19.576 [INFO] [INFO] Current Shop Coins: 98 (Raw OCR text: "98")
+00:20:19.576 [INFO] [TRACKBLAZER] Remaining Shop Coins: 98
+00:20:21.783 [INFO] [TRACKBLAZER] Shop process complete. Returning up to the previous screen.
+00:20:23.103 [VERBOSE] [INFO] Detected date: Classic Year Late Apr
+00:43:42.870 [VERBOSE] [DATE] New date: SENIOR YEAR LATE MAY (Turn 58)
+00:43:46.545 [VERBOSE] [INFO] Detected date: Senior Year Late May
+00:43:46.597 [VERBOSE] [TRAINEE] Name: Oguri CapP
+00:43:46.597 [VERBOSE] [TRAINEE] Stats: Spd=812, Sta=321, Pow=812, Gut=349, Wit=719
+00:43:46.597 [VERBOSE] [TRAINEE] Energy: 0%
+00:43:46.597 [VERBOSE] [TRAINEE] Mood: GOOD
+00:43:46.597 [VERBOSE] [TRAINEE] Fans: 394709
+00:43:46.597 [VERBOSE] [TRAINEE] Skill Points: 351
+00:43:46.597 [VERBOSE] [TRAINEE] Track: Turf=A, Dirt=B
+00:43:46.597 [VERBOSE] [TRAINEE] Distance: Sprint=B, Mile=A, Medium=A, Long=B
+00:43:46.597 [VERBOSE] [TRAINEE] Style: Front=F, Pace=A, Late=A, End=B
+00:43:46.597 [VERBOSE] [TRAINEE] Positive Statuses: Charming
+00:43:46.597 [INFO] [TRACKBLAZER] Skipping Training Items dialog as no relevant items are in the cached inventory.
+00:43:46.692 [INFO] [TRACKBLAZER] Skipping Irregular Training evaluation as energy is 0%.
+
+00:43:46.753 [INFO] [INJURY] Checking if there is an injury that needs healing on SENIOR YEAR LATE MAY (Turn 58).
+00:43:46.777 [VERBOSE] [INJURY] Injury detected. Attempting to heal...
+00:43:47.444 [INFO] [LOADING] Detected that the game is awaiting a response from the server from the "Connecting" text at the top of the screen. Waiting...
+00:43:48.358 [VERBOSE] [INJURY] Injury detected and no follow-up Infirmary event appeared.
+
+
+
+
+
+
+
+00:43:49.450 [VERBOSE] ********************
+00:43:49.450 [VERBOSE] [TRAINING_EVENT] Starting Training Event process on SENIOR YEAR LATE MAY (Turn 58).
+00:43:49.765 [WARN] [WARN] handleTrainingEvent:: First option will be selected since OCR failed to match the event title and no event rewards were found.
+00:43:50.389 [VERBOSE] [TRAINING_EVENT] Process to handle detected Training Event completed.
+00:43:50.389 [VERBOSE] ********************
+00:43:50.628 [VERBOSE] [TRAINEE] Name: Oguri CapP
+00:43:50.628 [VERBOSE] [TRAINEE] Stats: Spd=812, Sta=321, Pow=812, Gut=349, Wit=719
+00:43:50.628 [VERBOSE] [TRAINEE] Energy: 0%
+00:43:50.628 [VERBOSE] [TRAINEE] Mood: GOOD
+00:43:50.628 [VERBOSE] [TRAINEE] Fans: 394709
+00:43:50.628 [VERBOSE] [TRAINEE] Skill Points: 351
+00:43:50.628 [VERBOSE] [TRAINEE] Track: Turf=A, Dirt=B
+00:43:50.628 [VERBOSE] [TRAINEE] Distance: Sprint=B, Mile=A, Medium=A, Long=B
+00:43:50.628 [VERBOSE] [TRAINEE] Style: Front=F, Pace=A, Late=A, End=B
+00:43:50.628 [VERBOSE] [TRAINEE] Positive Statuses: Charming
+00:43:50.629 [INFO] [TRACKBLAZER] Skipping Training Items dialog as no relevant items are in the cached inventory.
+
+00:43:50.690 [INFO] [INJURY] Checking if there is an injury that needs healing on SENIOR YEAR LATE MAY (Turn 58).
+00:43:50.715 [INFO] [INJURY] No injury detected.
+
+00:43:50.920 [INFO] [INFO] Detected day for extra racing: 14
+00:43:50.920 [INFO] [RACE] Current remaining number of days before the next mandatory race: 14.
+00:43:50.920 [INFO] [RACE] Smart Race Solver has no race planned for turn 58. Skipping the extra-race fallback.
+00:43:50.949 [INFO] [TRACKBLAZER] Decision made to train.
+00:43:50.949 [INFO] [TRACKBLAZER] Starting specialized Training process.
+
+00:43:51.651 [VERBOSE] [TRAINING] Now starting process to analyze all 5 Trainings.
+00:43:52.653 [INFO] [TRAINING] Flag set to ignore failure chance. Proceeding to acquire all other percentages and total stat increases...
+00:43:53.074 [INFO] [TRAINING] SPEED training level detected as Lvl 2.
+00:43:53.074 [INFO] [TRAINING] Skipping STAMINA training due to being blacklisted.
+00:43:53.821 [INFO] [TRAINING] POWER training level detected as Lvl 1.
+00:43:53.822 [INFO] [TRAINING] Skipping GUTS training due to being blacklisted.
+00:43:54.616 [INFO] [TRAINING] WIT training level detected as Lvl 3.
+00:43:55.215 [INFO] [TRAINING] Skipping SPEED training with Good-Luck Charm because main stat gain (21) is less than 30 and failure chance (65%) is risky.
+00:43:55.235 [INFO] [TRAINING] Skipping POWER training with Good-Luck Charm because main stat gain (12) is less than 30 and failure chance (64%) is risky.
+00:43:55.235 [INFO] [TRAINING] Skipping WIT training with Good-Luck Charm because main stat gain (13) is less than 30 and failure chance (25%) is risky.
+00:43:55.236 [VERBOSE] [TRAINING] Process to analyze all 5 Trainings complete.
+
+00:43:55.243 [VERBOSE] ========== Training Analysis Results ==========
+Scoring Mode: Stat Efficiency (Year 2+)
+Current Date: SENIOR YEAR LATE MAY (Turn 58)
+Current Stats: Speed=812, Stamina=321, Power=812, Guts=349, Wit=719
+Stat Targets: Disabled (treating cap=1200 as the target for all stats)
+Completion: SPEED=68%, STAMINA=27%, POWER=68%, GUTS=29%, WIT=60%
+
+--- Training Details ---
+SPEED Training: stats={SPEED=21, STAMINA=0, POWER=9, GUTS=0, WIT=0}, fail=65%, rainbows=1, level=Lvl 2 (SKIPPED)
+  -> Relationship bars: #1:orange(100%), #2:orange(100%)
+[STAMINA] BLACKLISTED
+POWER Training: stats={SPEED=0, STAMINA=5, POWER=12*, GUTS=0, WIT=0}, fail=64%, rainbows=0, level=Lvl 1 (SKIPPED)
+  -> Relationship bars: #1:orange(100%)
+[GUTS] BLACKLISTED
+WIT Training: stats={SPEED=2, STAMINA=0, POWER=0, GUTS=0, WIT=13*}, fail=25%, rainbows=0, level=Lvl 3 (SKIPPED)
+  -> Relationship bars: #1:orange(100%)[Yayoi Akikawa]
+
+--- Selection Explanation ---
+No training was selected (3 skipped due to: low gain with charm, 2 blacklisted).
+* means manual stat correction
+================================================
+
+00:43:55.243 [INFO] [TRAINING] Analysis returned no winning training. forceSelection=false → returning first non-blacklisted training: none available. Caller decides whether to execute.
+00:43:55.244 [INFO] [TRACKBLAZER] Skipping Training Items dialog as no relevant items are in the cached inventory.
+00:43:55.244 [INFO] [TRACKBLAZER] Still no suitable training found. Backing out for recovery.
+00:43:56.626 [INFO] [TRACKBLAZER] Energy is 0%. Attempting to recover energy.
+00:43:56.626 [INFO] [TRACKBLAZER] Resetting 2 consecutive race counts due to energy recovery.
+
+00:43:56.626 [VERBOSE] [ENERGY] Now starting attempt to recover energy on SENIOR YEAR LATE MAY (Turn 58).
+00:43:57.479 [VERBOSE] [ENERGY] Successfully recovered energy via rest.
+
+00:43:57.479 [INFO] ============== Turn 58 (SENIOR LATE MAY) Decision Report ==============
+State:
+  Energy = 0%
+  Mood = GOOD
+  Negative Statuses = []
+  Megaphone Turns = 0
+  Consecutive Races = 2
+  Used Charm Today = false
+  Used Whistle Today = false
+Inventory (decision-relevant):
+  [Charms & Whistles]
+  Good-Luck Charm = 1
+  Reset Whistle = 2
+  [Megaphones]
+  Coaching Megaphone = 1
+  Empowering Megaphone = 0
+  Motivating Megaphone = 3
+  [Cupcakes & Heals]
+  Berry Sweet Cupcake = 0
+  Plain Cupcake = 5
+  Royal Kale Juice = 0
+  [Race Items]
+  Artisan Cleat Hammer = 0
+  Glow Sticks = 0
+  Master Cleat Hammer = 0
+Settings (decision-relevant):
+  Trackblazer Energy Threshold = 40
+  Force-Train Energy Floor = 20
+  Skip Risky Charm Training Below Gain = 30
+  Consecutive Races Limit = 5
+  Skip Bad-Mood Items Below Gain = 15
+  Skip Empowering Megaphone Below Gain = 0
+  Skip Motivating Megaphone Below Gain = 0
+  Skip Coaching Megaphone Below Gain = 0
+  Whistle Forces Training = true
+  Irregular Training = on (min main 30)
+  Enable In-Game Race Agenda = false
+  Max Failure Chance = 20%
+  Riskier Training = on (max fail 30%, min main 30)
+  Energy Item Reserve = 1
+  Cupcake Reserve = 1
+  Race Item Conservation Start Turn = 65
+  Master Hammer Finale Reserve = 2
+  Artisan Hammer Min Stock G3 = 3
+  Artisan Hammer Min Stock G2 = 2
+  Glow Stick Final-Day Reserve = 1
+  Glow Stick Min Fans = 20000
+Items Used: None
+
+Race eligibility: NOT ELIGIBLE
+  Reason: Smart Race Solver has no race planned for this turn
+
+Action: TRAIN
+  Reason: Default fallback after racing/mood/injury checks did not trigger
+
+Whistle: NOT_ELIGIBLE
+  Reason: Outside Whistle window (day=58, allowed: 37..40 or > 60)
+
+Training selected: NONE (source=UNFORCED_DEFAULT)
+  Reason: No training selected; mood GOOD <= NORMAL or energy 0% <= 50 - backing out for recovery
+  Runner-ups:
+    - SPEED (REJECTED): fail=65%, gains=[SPD:21 STA:0 PWR:9 GUTS:0 WIT:0], low gain with charm
+    - POWER (REJECTED): fail=64%, gains=[SPD:0 STA:5 PWR:12 GUTS:0 WIT:0], low gain with charm
+    - WIT (REJECTED): fail=25%, gains=[SPD:2 STA:0 PWR:0 GUTS:0 WIT:13], low gain with charm
+
+Recovery executed: RECOVER_ENERGY
+  Reason: Mood GOOD > NORMAL or energy 0% < 20%
+==============================================================
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+00:44:02.149 [VERBOSE] [INFO] Detected date: Senior Year Late Jun
+00:56:28.678 [VERBOSE] [DATE] New date: Finale Qualifier (Turn 73)
+00:56:29.661 [VERBOSE] [TRAINEE] Name: Oguri CapP
+00:56:29.662 [VERBOSE] [TRAINEE] Stats: Spd=1039, Sta=422, Pow=1012, Gut=408, Wit=796
+00:56:29.662 [VERBOSE] [TRAINEE] Energy: 95%
+00:56:29.662 [VERBOSE] [TRAINEE] Mood: GREAT
+00:56:29.662 [VERBOSE] [TRAINEE] Fans: 559427
+00:56:29.662 [VERBOSE] [TRAINEE] Skill Points: 1
+00:56:29.662 [VERBOSE] [TRAINEE] Track: Turf=A, Dirt=B
+00:56:29.662 [VERBOSE] [TRAINEE] Distance: Sprint=B, Mile=A, Medium=A, Long=B
+00:56:29.662 [VERBOSE] [TRAINEE] Style: Front=F, Pace=A, Late=A, End=B
+00:56:29.662 [VERBOSE] [TRAINEE] Positive Statuses: Charming
+00:56:29.663 [INFO] [TRACKBLAZER] Skipping Training Items dialog as no relevant items are in the cached inventory.
+00:56:29.665 [INFO] [TRACKBLAZER] It is the Finale. Prioritizing training.
+00:56:29.697 [INFO] [TRACKBLAZER] Decision made to train.
+00:56:29.697 [INFO] [TRACKBLAZER] Starting specialized Training process.
+
+00:56:30.407 [VERBOSE] [TRAINING] Now starting process to analyze all 5 Trainings.
+00:56:32.441 [INFO] [TRAINING] 0% within acceptable range of 20%. Proceeding to acquire all other percentages and total stat increases...
+00:56:32.762 [INFO] [TRAINING] SPEED training level detected as Lvl 2.
+00:56:32.762 [INFO] [TRAINING] Skipping STAMINA training due to being blacklisted.
+00:56:33.549 [INFO] [TRAINING] POWER training level detected as Lvl 1.
+00:56:33.551 [INFO] [TRAINING] Skipping GUTS training due to being blacklisted.
+00:56:34.607 [INFO] [TRAINING] WIT training level detected as Lvl 3.
+00:56:35.133 [VERBOSE] [TRAINING] Process to analyze all 5 Trainings complete.
+
+00:56:35.189 [VERBOSE] ========== Training Analysis Results ==========
+Scoring Mode: Stat Efficiency (Year 2+)
+Current Date: Finale Qualifier (Turn 73)
+Current Stats: Speed=1039, Stamina=422, Power=1012, Guts=408, Wit=796
+Stat Targets: Disabled (treating cap=1200 as the target for all stats)
+Completion: SPEED=87%, STAMINA=35%, POWER=84%, GUTS=34%, WIT=66%
+
+--- Training Details ---
+SPEED Training: stats={SPEED=26, STAMINA=0, POWER=8, GUTS=0, WIT=0}, fail=0%, rainbows=1, level=Lvl 2
+  -> Relationship bars: #1:orange(100%), #2:orange(100%)
+[STAMINA] BLACKLISTED
+POWER Training: stats={SPEED=0, STAMINA=5, POWER=7, GUTS=0, WIT=0}, fail=0%, rainbows=0, level=Lvl 1
+[GUTS] BLACKLISTED
+WIT Training: stats={SPEED=5, STAMINA=0, POWER=0, GUTS=0, WIT=21}, fail=0%, rainbows=1, level=Lvl 3 <---- SELECTED
+  -> Relationship bars: #1:orange(100%)[Yayoi Akikawa], #2:orange(100%), #3:orange(100%), #4:orange(100%)
+
+--- Selection Explanation ---
+WIT beat SPEED by 144.17 points (226.7% higher)
+Key factor: Rainbow training detected (multiplier applied).
+Key factor: WIT stat is at 66% of target (behind, higher priority).
+Key factor: Yayoi Akikawa is present (special trainer bonus).
+Key factor: Multiple relationship bars present (4).
+================================================
+
+00:56:35.189 [INFO] [TRACKBLAZER] Opening Training Items dialog (Megaphone available)...
+00:56:35.848 [INFO] [TRACKBLAZER] Starting inventory management pass.
+00:56:35.848 [INFO] [TRACKBLAZER] Items of interest for this pass: Coaching Megaphone, Vita 20, Plain Cupcake, Motivating Megaphone, Energy Drink MAX, Miracle Cure.
+00:56:39.341 [VERBOSE] [TRACKBLAZER] Item "Plain Cupcake" read as disabled in dialog, so skipping its usage.
+00:56:39.820 [VERBOSE] [TRACKBLAZER] Item "Miracle Cure" read as disabled in dialog, so skipping its usage.
+00:56:40.678 [INFO] [TRACKBLAZER] Holding Coaching Megaphone: a better eligible megaphone (Motivating Megaphone) is available this turn.
+00:56:41.127 [INFO] [TRACKBLAZER] Queuing best eligible megaphone: "Motivating Megaphone" (main gain 21 >= threshold 0).
+00:56:41.553 [INFO] [TRACKBLAZER] Decremented Motivating Megaphone. Remaining: 1.
+00:56:41.554 [INFO] [TRACKBLAZER] All items of interest processed. Exiting scan early.
+
+00:56:41.554 [VERBOSE] ============== Item Usage Summary ==============
+
+[Current Inventory]
+
+Energy and Motivation
+- Energy Drink MAX: 1
+- Plain Cupcake: 3
+- Vita 20: 1
+
+Heal Bad Conditions
+- Miracle Cure: 2
+
+Training Effects
+- Coaching Megaphone: 1
+- Good-Luck Charm: 2
+- Motivating Megaphone: 1
+- Power Ankle Weights: 2
+- Reset Whistle: 2
+
+Races
+- Artisan Cleat Hammer: 2
+- Glow Sticks: 1
+
+------------------------------------------------
+Current State: Energy=95%, Mood=GREAT, Megaphone Turn=0, Coins=27
+Selected Training: WIT
+
+Items Used:
+
+- 1x Motivating Megaphone: Increasing training gains for the next few turns.
+================================================
+
+00:56:41.554 [INFO] [TRACKBLAZER] Confirming usage of 1 items.
+00:56:42.420 [INFO] [TRACKBLAZER] Waiting for animation to finish (Delay: 4.0 seconds).
+00:56:46.502 [INFO] [TRACKBLAZER] Closing training items dialog.
+00:56:48.946 [VERBOSE] [TRAINING] Now starting process to execute WIT training...
+00:56:48.946 [VERBOSE] [TRAINING] Executing the WIT Training.
+
+00:56:49.946 [VERBOSE] [TRAINING] Process to execute training completed.
+00:56:49.946 [INFO] [TRACKBLAZER] Megaphone duration reduced. Turns remaining: 2.
+
+00:56:49.947 [INFO] ============== Turn 73 (SENIOR LATE DECEMBER) Decision Report ==============
+State:
+  Energy = 95%
+  Mood = GREAT
+  Negative Statuses = []
+  Megaphone Turns = 0
+  Consecutive Races = 3
+  Used Charm Today = false
+  Used Whistle Today = false
+Inventory (decision-relevant):
+  [Charms & Whistles]
+  Good-Luck Charm = 2
+  Reset Whistle = 2
+  [Megaphones]
+  Coaching Megaphone = 1
+  Empowering Megaphone = 0
+  Motivating Megaphone = 2
+  [Cupcakes & Heals]
+  Berry Sweet Cupcake = 0
+  Plain Cupcake = 4
+  Royal Kale Juice = 0
+  [Race Items]
+  Artisan Cleat Hammer = 2
+  Glow Sticks = 1
+  Master Cleat Hammer = 0
+Settings (decision-relevant):
+  Trackblazer Energy Threshold = 40
+  Force-Train Energy Floor = 20
+  Skip Risky Charm Training Below Gain = 30
+  Consecutive Races Limit = 5
+  Skip Bad-Mood Items Below Gain = 15
+  Skip Empowering Megaphone Below Gain = 0
+  Skip Motivating Megaphone Below Gain = 0
+  Skip Coaching Megaphone Below Gain = 0
+  Whistle Forces Training = true
+  Irregular Training = on (min main 30)
+  Enable In-Game Race Agenda = false
+  Max Failure Chance = 20%
+  Riskier Training = on (max fail 30%, min main 30)
+  Energy Item Reserve = 1
+  Cupcake Reserve = 1
+  Race Item Conservation Start Turn = 65
+  Master Hammer Finale Reserve = 2
+  Artisan Hammer Min Stock G3 = 3
+  Artisan Hammer Min Stock G2 = 2
+  Glow Stick Final-Day Reserve = 1
+  Glow Stick Min Fans = 20000
+Items Used:
+  - Motivating Megaphone: Best eligible megaphone (main gain 21 >= threshold 0); setting megaphone turn duration to 3
+
+Action: TRAIN
+  Reason: Trackblazer: Finale (day >= 73) prioritizes training
+
+Item: Coaching Megaphone -> CONSERVED
+  Reason: Better eligible megaphone available this turn: Motivating Megaphone
+
+Training selected: WIT (source=ANALYSIS)
+  Reason: Final pick selected by initial analyzer pass (no Reset Whistle used)
+  Pick: fail=0%, gains=[SPD:5 STA:0 PWR:0 GUTS:0 WIT:21]
+  Runner-ups:
+    - SPEED (considered): fail=0%, gains=[SPD:26 STA:0 PWR:8 GUTS:0 WIT:0], considered by analyzer but lost to selection
+    - POWER (considered): fail=0%, gains=[SPD:0 STA:5 PWR:7 GUTS:0 WIT:0], considered by analyzer but lost to selection
+==============================================================
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+00:56:56.129 [INFO] [TRACKBLAZER] Mandatory race ribbon detected. Processing as mandatory race.
+
+00:56:56.182 [VERBOSE] ********************
+00:56:56.183 [VERBOSE] [RACE] Starting Racing process on Finale Qualifier (Turn 73).
+00:56:56.979 [VERBOSE] [RACE] Starting process for handling a mandatory race.
+00:56:56.980 [INFO] [TRACKBLAZER] Executing scheduled race item logic on Race Prep screen.
+00:56:56.980 [INFO] [TRACKBLAZER] Suitable race items found in inventory (Hammer: Artisan Cleat Hammer, Glow Sticks: false). Opening Training Items dialog.
+00:57:02.856 [INFO] [TRACKBLAZER] Queuing specific item for use: "Artisan Cleat Hammer". (Reason: Race bonus for G1.)
+
+00:57:03.539 [VERBOSE] ============== Item Usage Summary ==============
+
+[Current Inventory]
+
+Energy and Motivation
+- Energy Drink MAX: 1
+- Plain Cupcake: 3
+- Vita 20: 1
+
+Heal Bad Conditions
+- Miracle Cure: 2
+
+Training Effects
+- Coaching Megaphone: 1
+- Good-Luck Charm: 2
+- Motivating Megaphone: 1
+- Power Ankle Weights: 2
+- Reset Whistle: 2
+
+Races
+- Artisan Cleat Hammer: 2
+- Glow Sticks: 1
+
+------------------------------------------------
+
+Items Used:
+
+- 1x Artisan Cleat Hammer: Race bonus for G1.
+================================================
+
+00:57:03.539 [INFO] [TRACKBLAZER] Decremented Artisan Cleat Hammer. Remaining: 1.
+00:57:03.539 [INFO] [TRACKBLAZER] Queued 1 race items for G1 (20000 fans). Confirming usage.
+00:57:03.539 [INFO] [TRACKBLAZER] Confirming usage of 1 items.
+00:57:04.366 [INFO] [TRACKBLAZER] Waiting for animation to finish (Delay: 4.0 seconds).
+00:57:08.439 [INFO] [TRACKBLAZER] Closing training items dialog.
+00:57:10.926 [VERBOSE] [RACE] Confirming the mandatory race selection.
+00:57:12.133 [INFO] [RACE] Confirming any popup from the mandatory race selection.
+00:57:14.345 [INFO] [LOADING] Detected that the game is still loading from the "Now Loading" text at the bottom of the screen. Waiting...
+00:57:15.670 [INFO] [RACE] Proceeding to handle the race...
+00:57:16.280 [INFO] [RACE] Detected ButtonChangeRunningStyle. Handling race prep screen...
+00:57:16.437 [INFO] [RACE] Clicked ViewResults button to skip race.
+00:57:16.470 [INFO] [LOADING] Detected that the game is awaiting a response from the server from the "Connecting" text at the top of the screen. Waiting...
+00:57:20.276 [INFO] [RACE] Reached race results screen. Exiting race retry loop...
+00:57:20.276 [INFO] [RACE] Now performing cleanup and finishing the race.
+00:57:20.344 [INFO] [RACE] Race result detected - 1st place: true.
+00:57:20.548 [INFO] [RACE] Clicked on Next (race results) button.
+00:57:21.948 [INFO] [RACE] Clicked on Next (race end) button.
+00:57:22.031 [VERBOSE] [RACE] Racing process for Mandatory Race is completed. Grade: FINALE
+00:57:22.031 [VERBOSE] ********************
+00:57:22.031 [INFO] [TRACKBLAZER] Megaphone duration reduced. Turns remaining: 1.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+00:57:32.630 [INFO] [INFO] Misc checks complete.
+00:57:33.162 [VERBOSE] [INFO] Detected date: TS Climax Races Underway
+00:57:33.295 [INFO] [DATE] Trackblazer Finale Semi-Final (Turn 74).
+00:57:33.295 [VERBOSE] [DATE] New date: Finale Semi-Final (Turn 74)
+00:57:34.369 [VERBOSE] [TRAINEE] Name: Oguri CapP
+00:57:34.369 [VERBOSE] [TRAINEE] Stats: Spd=1065, Sta=441, Pow=1031, Gut=427, Wit=844
+00:57:34.370 [VERBOSE] [TRAINEE] Energy: 100%
+00:57:34.370 [VERBOSE] [TRAINEE] Mood: GREAT
+00:57:34.370 [VERBOSE] [TRAINEE] Fans: 559427
+00:57:34.370 [VERBOSE] [TRAINEE] Skill Points: 269
+00:57:34.370 [VERBOSE] [TRAINEE] Track: Turf=A, Dirt=B
+00:57:34.370 [VERBOSE] [TRAINEE] Distance: Sprint=B, Mile=A, Medium=A, Long=B
+00:57:34.370 [VERBOSE] [TRAINEE] Style: Front=F, Pace=A, Late=A, End=B
+00:57:34.370 [VERBOSE] [TRAINEE] Positive Statuses: Charming
+00:57:34.372 [INFO] [TRACKBLAZER] Skipping Training Items dialog as no relevant items are in the cached inventory.
+00:57:34.373 [INFO] [TRACKBLAZER] It is the Finale. Prioritizing training.
+00:57:34.403 [INFO] [TRACKBLAZER] Decision made to train.
+00:57:34.403 [INFO] [TRACKBLAZER] Starting specialized Training process.
+
+00:57:35.097 [VERBOSE] [TRAINING] Now starting process to analyze all 5 Trainings.
+00:57:36.895 [INFO] [TRAINING] 0% within acceptable range of 20%. Proceeding to acquire all other percentages and total stat increases...
+00:57:37.345 [INFO] [TRAINING] SPEED training level detected as Lvl 2.
+00:57:37.345 [INFO] [TRAINING] Skipping STAMINA training due to being blacklisted.
+00:57:38.232 [INFO] [TRAINING] POWER training level detected as Lvl 1.
+00:57:38.233 [INFO] [TRAINING] Skipping GUTS training due to being blacklisted.
+00:57:39.219 [INFO] [TRAINING] WIT training level detected as Lvl 4.
+00:57:39.670 [VERBOSE] [TRAINING] Process to analyze all 5 Trainings complete.
+
+00:57:39.734 [VERBOSE] ========== Training Analysis Results ==========
+Scoring Mode: Stat Efficiency (Year 2+)
+Current Date: Finale Semi-Final (Turn 74)
+Current Stats: Speed=1065, Stamina=441, Power=1031, Guts=427, Wit=844
+Stat Targets: Disabled (treating cap=1200 as the target for all stats)
+Completion: SPEED=89%, STAMINA=37%, POWER=86%, GUTS=36%, WIT=70%
+
+--- Training Details ---
+SPEED Training: stats={SPEED=19, STAMINA=0, POWER=7, GUTS=0, WIT=0}, fail=0%, rainbows=0, level=Lvl 2
+  -> Relationship bars: #1:orange(100%)
+[STAMINA] BLACKLISTED
+POWER Training: stats={SPEED=0, STAMINA=11, POWER=18, GUTS=0, WIT=0}, fail=0%, rainbows=1, level=Lvl 1 <---- SELECTED
+  -> Relationship bars: #1:orange(100%)[Etsuko Otonashi], #2:orange(100%), #3:orange(100%)
+[GUTS] BLACKLISTED
+WIT Training: stats={SPEED=5, STAMINA=0, POWER=0, GUTS=0, WIT=14}, fail=0%, rainbows=0, level=Lvl 4
+
+--- Selection Explanation ---
+POWER beat WIT by 35.29 points (63.1% higher)
+Key factor: Rainbow training detected (multiplier applied).
+Key factor: Etsuko Otonashi is present (special trainer bonus).
+Key factor: Multiple relationship bars present (3).
+================================================
+
+00:57:39.736 [INFO] [TRACKBLAZER] Opening Training Items dialog (Ankle weights available)...
+00:57:40.393 [INFO] [TRACKBLAZER] Starting inventory management pass.
+00:57:40.393 [INFO] [TRACKBLAZER] Items of interest for this pass: Vita 20, Plain Cupcake, Power Ankle Weights, Energy Drink MAX, Miracle Cure.
+00:57:43.732 [VERBOSE] [TRACKBLAZER] Item "Plain Cupcake" read as disabled in dialog, so skipping its usage.
+00:57:44.303 [VERBOSE] [TRACKBLAZER] Item "Miracle Cure" read as disabled in dialog, so skipping its usage.
+00:57:44.903 [VERBOSE] [TRACKBLAZER] Item "Coaching Megaphone" read as disabled in dialog, so skipping its usage.
+00:57:45.344 [VERBOSE] [TRACKBLAZER] Item "Motivating Megaphone" read as disabled in dialog, so skipping its usage.
+00:57:48.019 [INFO] [TRACKBLAZER] Queuing Power Ankle Weights via inline pass.
+00:57:48.433 [INFO] [TRACKBLAZER] Decremented Power Ankle Weights. Remaining: 1.
+00:57:48.433 [INFO] [TRACKBLAZER] All items of interest processed. Exiting scan early.
+
+00:57:48.433 [VERBOSE] ============== Item Usage Summary ==============
+
+[Current Inventory]
+
+Energy and Motivation
+- Energy Drink MAX: 1
+- Plain Cupcake: 3
+- Vita 20: 1
+
+Heal Bad Conditions
+- Miracle Cure: 2
+
+Training Effects
+- Coaching Megaphone: 1
+- Good-Luck Charm: 2
+- Motivating Megaphone: 1
+- Power Ankle Weights: 1
+- Reset Whistle: 2
+
+Races
+- Artisan Cleat Hammer: 1
+- Glow Sticks: 1
+
+------------------------------------------------
+Current State: Energy=100%, Mood=GREAT, Megaphone Turn=1, Coins=27
+Selected Training: POWER
+
+Items Used:
+
+- 1x Power Ankle Weights: Boosting POWER training gains.
+================================================
+
+00:57:48.433 [INFO] [TRACKBLAZER] Confirming usage of 1 items.
+00:57:49.285 [INFO] [TRACKBLAZER] Waiting for animation to finish (Delay: 4.0 seconds).
+00:57:53.365 [INFO] [TRACKBLAZER] Closing training items dialog.
+00:57:55.820 [VERBOSE] [TRAINING] Now starting process to execute POWER training...
+00:57:55.821 [VERBOSE] [TRAINING] Executing the POWER Training.
+
+00:57:56.818 [VERBOSE] [TRAINING] Process to execute training completed.
+00:57:56.818 [INFO] [TRACKBLAZER] Megaphone duration reduced. Turns remaining: 0.
+
+00:57:56.819 [INFO] ============== Turn 74 (SENIOR LATE DECEMBER) Decision Report ==============
+State:
+  Energy = 100%
+  Mood = GREAT
+  Negative Statuses = []
+  Megaphone Turns = 1
+  Consecutive Races = 3
+  Used Charm Today = false
+  Used Whistle Today = false
+Inventory (decision-relevant):
+  [Charms & Whistles]
+  Good-Luck Charm = 2
+  Reset Whistle = 2
+  [Megaphones]
+  Coaching Megaphone = 1
+  Empowering Megaphone = 0
+  Motivating Megaphone = 1
+  [Cupcakes & Heals]
+  Berry Sweet Cupcake = 0
+  Plain Cupcake = 3
+  Royal Kale Juice = 0
+  [Race Items]
+  Artisan Cleat Hammer = 1
+  Glow Sticks = 1
+  Master Cleat Hammer = 0
+Settings (decision-relevant):
+  Trackblazer Energy Threshold = 40
+  Force-Train Energy Floor = 20
+  Skip Risky Charm Training Below Gain = 30
+  Consecutive Races Limit = 5
+  Skip Bad-Mood Items Below Gain = 15
+  Skip Empowering Megaphone Below Gain = 0
+  Skip Motivating Megaphone Below Gain = 0
+  Skip Coaching Megaphone Below Gain = 0
+  Whistle Forces Training = true
+  Irregular Training = on (min main 30)
+  Enable In-Game Race Agenda = false
+  Max Failure Chance = 20%
+  Riskier Training = on (max fail 30%, min main 30)
+  Energy Item Reserve = 1
+  Cupcake Reserve = 1
+  Race Item Conservation Start Turn = 65
+  Master Hammer Finale Reserve = 2
+  Artisan Hammer Min Stock G3 = 3
+  Artisan Hammer Min Stock G2 = 2
+  Glow Stick Final-Day Reserve = 1
+  Glow Stick Min Fans = 20000
+Items Used: None
+
+Action: TRAIN
+  Reason: Trackblazer: Finale (day >= 73) prioritizes training
+
+Training selected: POWER (source=ANALYSIS)
+  Reason: Final pick selected by initial analyzer pass (no Reset Whistle used)
+  Pick: fail=0%, gains=[SPD:0 STA:11 PWR:18 GUTS:0 WIT:0]
+  Runner-ups:
+    - SPEED (considered): fail=0%, gains=[SPD:19 STA:0 PWR:7 GUTS:0 WIT:0], considered by analyzer but lost to selection
+    - WIT (considered): fail=0%, gains=[SPD:5 STA:0 PWR:0 GUTS:0 WIT:14], considered by analyzer but lost to selection
+==============================================================
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+00:57:59.683 [INFO] [LOADING] Detected that the game is awaiting a response from the server from the "Connecting" text at the top of the screen. Waiting...
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+00:58:03.215 [INFO] [TRACKBLAZER] Mandatory race ribbon detected. Processing as mandatory race.
+
+00:58:03.257 [VERBOSE] ********************
+00:58:03.257 [VERBOSE] [RACE] Starting Racing process on Finale Semi-Final (Turn 74).
+00:58:04.057 [VERBOSE] [RACE] Starting process for handling a mandatory race.
+00:58:04.058 [INFO] [TRACKBLAZER] Executing scheduled race item logic on Race Prep screen.
+00:58:04.058 [INFO] [TRACKBLAZER] Suitable race items found in inventory (Hammer: Artisan Cleat Hammer, Glow Sticks: false). Opening Training Items dialog.
+00:58:10.272 [INFO] [TRACKBLAZER] Queuing specific item for use: "Artisan Cleat Hammer". (Reason: Race bonus for G1.)
+
+00:58:10.972 [VERBOSE] ============== Item Usage Summary ==============
+
+[Current Inventory]
+
+Energy and Motivation
+- Energy Drink MAX: 1
+- Plain Cupcake: 3
+- Vita 20: 1
+
+Heal Bad Conditions
+- Miracle Cure: 2
+
+Training Effects
+- Coaching Megaphone: 1
+- Good-Luck Charm: 2
+- Motivating Megaphone: 1
+- Power Ankle Weights: 1
+- Reset Whistle: 2
+
+Races
+- Artisan Cleat Hammer: 1
+- Glow Sticks: 1
+
+------------------------------------------------
+
+Items Used:
+
+- 1x Artisan Cleat Hammer: Race bonus for G1.
+================================================
+
+00:58:10.972 [INFO] [TRACKBLAZER] Decremented Artisan Cleat Hammer. Remaining: 0.
+00:58:10.972 [INFO] [TRACKBLAZER] Queued 1 race items for G1 (20000 fans). Confirming usage.
+00:58:10.972 [INFO] [TRACKBLAZER] Confirming usage of 1 items.
+00:58:11.841 [INFO] [TRACKBLAZER] Waiting for animation to finish (Delay: 4.0 seconds).
+00:58:15.913 [INFO] [TRACKBLAZER] Closing training items dialog.
+00:58:18.398 [VERBOSE] [RACE] Confirming the mandatory race selection.
+00:58:19.596 [INFO] [RACE] Confirming any popup from the mandatory race selection.
+00:58:21.812 [INFO] [LOADING] Detected that the game is still loading from the "Now Loading" text at the bottom of the screen. Waiting...
+00:58:23.188 [INFO] [RACE] Proceeding to handle the race...
+00:58:23.815 [INFO] [RACE] Detected ButtonChangeRunningStyle. Handling race prep screen...
+00:58:23.966 [INFO] [RACE] Clicked ViewResults button to skip race.
+00:58:23.995 [INFO] [LOADING] Detected that the game is awaiting a response from the server from the "Connecting" text at the top of the screen. Waiting...
+00:58:27.766 [INFO] [RACE] Reached race results screen. Exiting race retry loop...
+00:58:27.766 [INFO] [RACE] Now performing cleanup and finishing the race.
+00:58:27.839 [INFO] [RACE] Race result detected - 1st place: true.
+00:58:28.052 [INFO] [RACE] Clicked on Next (race results) button.
+00:58:29.463 [INFO] [RACE] Clicked on Next (race end) button.
+00:58:29.518 [VERBOSE] [RACE] Racing process for Mandatory Race is completed. Grade: FINALE
+00:58:29.518 [VERBOSE] ********************
+
+
+
+
+
+
+
+00:58:30.713 [VERBOSE] ********************
+00:58:30.713 [VERBOSE] [TRAINING_EVENT] Starting Training Event process on Finale Semi-Final (Turn 74).
+
+
+
+
+
+
+00:58:31.254 [VERBOSE] ========== Training Event Summary ==========
+Event: "After the All Comers: Win and Run Wild" (Matikanetannhauser) [Confidence: 0.85]
+Current Date: Finale Semi-Final (Turn 74)
+
+Options:
+  Option 1 [Weight: 75]: Speed +20, All I've Got hint +1 <---- SELECTED
+
+Selected: Option 1
+============================================
+
+00:58:31.592 [VERBOSE] [TRAINING_EVENT] Process to handle detected Training Event completed.
+00:58:31.592 [VERBOSE] ********************
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+00:58:40.219 [INFO] [INFO] Misc checks complete.
+00:58:40.899 [VERBOSE] [INFO] Detected date: TS Climax Races Underway
+00:58:41.099 [INFO] [DATE] Trackblazer Finale Finals (Turn 75).
+00:58:41.099 [VERBOSE] [DATE] New date: Finale Finals (Turn 75)
+00:58:42.153 [VERBOSE] [TRAINEE] Name: Oguri CapP
+00:58:42.154 [VERBOSE] [TRAINEE] Stats: Spd=1084, Sta=475, Pow=1079, Gut=446, Wit=863
+00:58:42.154 [VERBOSE] [TRAINEE] Energy: 83%
+00:58:42.154 [VERBOSE] [TRAINEE] Mood: GREAT
+00:58:42.154 [VERBOSE] [TRAINEE] Fans: 559427
+00:58:42.154 [VERBOSE] [TRAINEE] Skill Points: 331
+00:58:42.154 [VERBOSE] [TRAINEE] Track: Turf=A, Dirt=B
+00:58:42.154 [VERBOSE] [TRAINEE] Distance: Sprint=B, Mile=A, Medium=A, Long=B
+00:58:42.154 [VERBOSE] [TRAINEE] Style: Front=F, Pace=A, Late=A, End=B
+00:58:42.154 [VERBOSE] [TRAINEE] Positive Statuses: Charming
+00:58:42.156 [INFO] [TRACKBLAZER] Skipping Training Items dialog as no relevant items are in the cached inventory.
+00:58:42.158 [INFO] [TRACKBLAZER] It is the Finale. Prioritizing training.
+00:58:42.188 [INFO] [TRACKBLAZER] Decision made to train.
+00:58:42.188 [INFO] [TRACKBLAZER] Starting specialized Training process.
+
+00:58:42.894 [VERBOSE] [TRAINING] Now starting process to analyze all 5 Trainings.
+00:58:44.386 [INFO] [TRAINING] 0% within acceptable range of 20%. Proceeding to acquire all other percentages and total stat increases...
+00:58:44.628 [INFO] [TRAINING] SPEED training level detected as Lvl 2.
+00:58:44.629 [INFO] [TRAINING] Skipping STAMINA training due to being blacklisted.
+00:58:45.503 [INFO] [TRAINING] POWER training level detected as Lvl 2.
+00:58:45.504 [INFO] [TRAINING] Skipping GUTS training due to being blacklisted.
+00:58:46.378 [INFO] [TRAINING] WIT training level detected as Lvl 4.
+00:58:46.783 [VERBOSE] [TRAINING] Process to analyze all 5 Trainings complete.
+
+00:58:46.834 [VERBOSE] ========== Training Analysis Results ==========
+Scoring Mode: Stat Efficiency (Year 2+)
+Current Date: Finale Finals (Turn 75)
+Current Stats: Speed=1084, Stamina=475, Power=1079, Guts=446, Wit=863
+Stat Targets: Disabled (treating cap=1200 as the target for all stats)
+Completion: SPEED=90%, STAMINA=40%, POWER=90%, GUTS=37%, WIT=72%
+
+--- Training Details ---
+SPEED Training: stats={SPEED=14, STAMINA=0, POWER=5, GUTS=0, WIT=0}, fail=0%, rainbows=0, level=Lvl 2
+  -> Relationship bars: #1:orange(100%)
+[STAMINA] BLACKLISTED
+POWER Training: stats={SPEED=0, STAMINA=10, POWER=21, GUTS=0, WIT=0}, fail=0%, rainbows=1, level=Lvl 2 <---- SELECTED
+  -> Relationship bars: #1:orange(100%)[Yayoi Akikawa], #2:orange(100%), #3:orange(100%), #4:orange(100%)
+[GUTS] BLACKLISTED
+WIT Training: stats={SPEED=6, STAMINA=0, POWER=0, GUTS=0, WIT=11}, fail=0%, rainbows=0, level=Lvl 4
+  -> Relationship bars: #1:orange(100%)
+
+--- Selection Explanation ---
+POWER beat WIT by 50.37 points (118.8% higher)
+Key factor: Rainbow training detected (multiplier applied).
+Key factor: Yayoi Akikawa is present (special trainer bonus).
+Key factor: Multiple relationship bars present (4).
+================================================
+
+00:58:46.838 [INFO] [TRACKBLAZER] Opening Training Items dialog (Megaphone available, Ankle weights available)...
+00:58:47.494 [INFO] [TRACKBLAZER] Starting inventory management pass.
+00:58:47.494 [INFO] [TRACKBLAZER] Items of interest for this pass: Coaching Megaphone, Vita 20, Plain Cupcake, Motivating Megaphone, Power Ankle Weights, Energy Drink MAX, Miracle Cure.
+00:58:50.679 [VERBOSE] [TRACKBLAZER] Item "Plain Cupcake" read as disabled in dialog, so skipping its usage.
+00:58:51.066 [VERBOSE] [TRACKBLAZER] Item "Miracle Cure" read as disabled in dialog, so skipping its usage.
+00:58:51.807 [INFO] [TRACKBLAZER] Holding Coaching Megaphone: a better eligible megaphone (Motivating Megaphone) is available this turn.
+00:58:52.304 [INFO] [TRACKBLAZER] Queuing best eligible megaphone: "Motivating Megaphone" (main gain 21 >= threshold 0).
+00:58:52.710 [INFO] [TRACKBLAZER] Decremented Motivating Megaphone. Remaining: 0.
+00:58:55.732 [INFO] [TRACKBLAZER] Queuing Power Ankle Weights via inline pass.
+00:58:56.148 [INFO] [TRACKBLAZER] Decremented Power Ankle Weights. Remaining: 0.
+00:58:56.148 [INFO] [TRACKBLAZER] All items of interest processed. Exiting scan early.
+
+00:58:56.148 [VERBOSE] ============== Item Usage Summary ==============
+
+[Current Inventory]
+
+Energy and Motivation
+- Energy Drink MAX: 1
+- Plain Cupcake: 3
+- Vita 20: 1
+
+Heal Bad Conditions
+- Miracle Cure: 2
+
+Training Effects
+- Coaching Megaphone: 1
+- Good-Luck Charm: 2
+- Reset Whistle: 2
+
+Races
+- Glow Sticks: 1

--- a/src/lib/__tests__/storageBridge.test.ts
+++ b/src/lib/__tests__/storageBridge.test.ts
@@ -1,5 +1,5 @@
 import { NativeModules } from "react-native"
-import { storageBridge } from "../storageBridge"
+import { storageBridge, folderDocumentUriFromTreeUri } from "../storageBridge"
 
 jest.mock("react-native", () => ({
     NativeModules: {
@@ -26,5 +26,23 @@ describe("storageBridge", () => {
         const result = await storageBridge.migrateLegacyFiles("move")
         expect(NativeModules.StorageBridgeModule.migrateLegacyFiles).toHaveBeenCalledWith("move")
         expect(result).toEqual({ movedLogs: 5, movedRecordings: 2 })
+    })
+})
+
+describe("folderDocumentUriFromTreeUri", () => {
+    it("appends the encoded tree document id as the document segment", () => {
+        expect(folderDocumentUriFromTreeUri("content://com.android.externalstorage.documents/tree/primary%3ADownload%2FUmaLogs")).toBe(
+            "content://com.android.externalstorage.documents/tree/primary%3ADownload%2FUmaLogs/document/primary%3ADownload%2FUmaLogs"
+        )
+    })
+
+    it("does not double-encode an already-encoded document id", () => {
+        const result = folderDocumentUriFromTreeUri("content://x/tree/primary%3ADownload")
+        expect(result).toContain("/document/primary%3ADownload")
+        expect(result).not.toContain("%253A")
+    })
+
+    it("returns the input unchanged when it is not a tree uri", () => {
+        expect(folderDocumentUriFromTreeUri("content://x/document/abc")).toBe("content://x/document/abc")
     })
 })

--- a/src/lib/eventLogParser.ts
+++ b/src/lib/eventLogParser.ts
@@ -49,6 +49,14 @@ export type DayRecord = {
     energyType?: string
     /** The type of mood recovery if any. */
     moodType?: string
+    /** The name of the race run if any (e.g. "Niigata Junior Stakes"). */
+    raceName?: string
+    /** The finishing place of the race if any (e.g. "1st"). */
+    racePlace?: string
+    /** Whether the race was won (finished 1st). */
+    raceWon?: boolean
+    /** The scenario/campaign this run was played on (e.g. "Trackblazer"). */
+    scenario?: string
 }
 
 export type GapRecord = {
@@ -67,6 +75,8 @@ export type FileDividerRecord = {
     fileName: string
     /** The name of the trainee detected in this file. */
     traineeName?: string
+    /** The scenario/campaign this run was played on (e.g. "Trackblazer"). */
+    scenario?: string
 }
 
 export type ParseError = {
@@ -101,9 +111,12 @@ const ACTION_KEYS = ["training", "race", "energy", "mood", "injury"] as const
 type ActionKey = (typeof ACTION_KEYS)[number]
 
 const REGEX = {
-    // Example: "[DATE] It is currently Junior Year Late Dec / Turn Number 24.".
-    // New Example: "[DATE] New date: JUNIOR YEAR LATE JANUARY (Turn 2)"
-    dateTurn: /(?:Turn Number|Turn)\s+\(?(\d+)\)?/i,
+    // Matches the turn number from an authoritative per-turn marker only: the parenthesized "(Turn N)" form
+    // (e.g. "[DATE] New date: JUNIOR YEAR LATE JANUARY (Turn 2)", "Current Date: ... (Turn 16)") or the legacy
+    // "Turn Number N" form (e.g. "[DATE] It is currently Junior Year Late Dec / Turn Number 24."). This deliberately
+    // does NOT match bare "Turn N (...)" lines like the Smart Race Solver preview schedule ("  Turn 16 (... G3)"),
+    // which reference future turns and would otherwise create phantom day records with the wrong date.
+    dateTurn: /(?:\(Turn\s+(\d+)\)|Turn\s+Number\s+(\d+))/i,
     // Example: "[INFO] Detected date: Junior Year Late Dec".
     dateDetectedText: /\[INFO\][^\n]*Detected date:\s*(.+)$/i,
     // Example: "[DATE] It is currently Senior Year Late Dec / Turn Number 24."
@@ -123,6 +136,15 @@ const REGEX = {
     timestamp: /^(\d{2}):(\d{2}):(\d{2})\.(\d{3})/,
     // Extract trainee name from content: "[TRAINEE] Detected trainee name: Special Week"
     traineeName: /\[TRAINEE\][^\n]*(?:Detected trainee name|Name):\s*(.+)$/i,
+    // Extract the scenario/campaign from the startup banner: "Campaign Selected: Trackblazer".
+    scenario: /Campaign Selected:\s*(.+)$/i,
+    // Extract the selected race name and grade: 'Selected Race: Niigata Junior Stakes (G3) Rival: true'. The greedy name
+    // capture backtracks so the last parenthesized group is the grade (handles inner parens like "Tenno Sho (Spring)").
+    raceSelected: /Selected Race:\s+(.+)\s+\(([^()]+)\)\s+Rival:/i,
+    // Extract the race name and finishing place from the history line: 'Race "Niigata Junior Stakes" on turn 16 confirmed 1st;'.
+    raceResult: /Race\s+"([^"]+)"\s+on\s+turn\s+\d+\s+confirmed\s+(\w+)/i,
+    // Extract whether the race was won (finished 1st): "Race result detected - 1st place: true.".
+    raceWon: /Race result detected -\s+\d+\w+ place:\s+(true|false)/i,
 }
 
 /** Generic matcher that supports substring contains checks only. */
@@ -172,8 +194,9 @@ const MATCHERS: Record<ActionKey, LineMatcher> = {
         regex: [/\[MOOD\] Successfully recovered mood(?: via (.*?)(\.|$))?/i],
     },
     injury: {
-        substr: ["Injury detected and attempted to heal"],
-        regex: [/\[INJURY\] Injury detected and attempted to heal/i],
+        // Current wording is "[INJURY] Injury detected. Attempting to heal...". The legacy "attempted to heal" form is kept for archived logs.
+        substr: ["Injury detected. Attempting to heal", "Injury detected and attempted to heal"],
+        regex: [/\[INJURY\]\s+Injury detected\.?\s+Attempting to heal/i, /\[INJURY\]\s+Injury detected and attempted to heal/i],
     },
 }
 
@@ -189,6 +212,16 @@ function sanitizeSummary(text?: string): string {
 }
 
 /**
+ * Converts a token to title case, e.g. the uppercase training types the bot now logs ("WIT" -> "Wit").
+ * @param text The token to convert.
+ * @returns The token with the first letter uppercased and the rest lowercased.
+ */
+function toTitleCase(text: string): string {
+    if (!text) return text
+    return text.charAt(0).toUpperCase() + text.slice(1).toLowerCase()
+}
+
+/**
  * Composes a summary for a day based on the actions that occurred.
  * @param day The day data containing actions and granular types.
  * @param firstNotable The first notable action that occurred on the day.
@@ -199,6 +232,7 @@ function composeSummary(
         actions: DayActions
         trainingType?: string
         raceGrade?: string
+        raceName?: string
         energyType?: string
         moodType?: string
     },
@@ -207,10 +241,11 @@ function composeSummary(
     const labels: string[] = []
 
     if (day.actions.training) {
-        labels.push(day.trainingType ? `${day.trainingType} Training` : "Training")
+        labels.push(day.trainingType ? `${toTitleCase(day.trainingType)} Training` : "Training")
     }
     if (day.actions.race) {
-        labels.push(day.raceGrade ? `${day.raceGrade} Race` : "Race")
+        if (day.raceName) labels.push(day.raceGrade ? `${day.raceName} (${day.raceGrade})` : day.raceName)
+        else labels.push(day.raceGrade ? `${day.raceGrade} Race` : "Race")
     }
     if (day.actions.energy) {
         // Normalize energy types for clarity.
@@ -258,7 +293,8 @@ function determineYear(dayNumber: number, dateText?: string): string | undefined
     if (dateText) {
         const yearMatch = dateText.match(REGEX.yearExtract)
         if (yearMatch) {
-            return yearMatch[1]
+            // Normalize to canonical title case ("JUNIOR" -> "Junior") so year grouping in aggregateYearSummaries matches.
+            return toTitleCase(yearMatch[1])
         }
     }
     return undefined
@@ -290,6 +326,10 @@ export function parseLogs(files: LogFileInput[]): ParseResult {
             raceGrade?: string // The grade of the race.
             energyType?: string // The type of energy recovery.
             moodType?: string // The type of mood recovery.
+            raceName?: string // The name of the race run.
+            racePlace?: string // The finishing place of the race.
+            raceWon?: boolean // Whether the race was won (1st place).
+            scenario?: string // The scenario/campaign for this run.
         }
     >()
 
@@ -302,6 +342,7 @@ export function parseLogs(files: LogFileInput[]): ParseResult {
         let foundAnyDay = false
         let pendingDateText: string | undefined
         let fileTraineeName: string | undefined
+        let fileScenario: string | undefined
 
         // Try to extract trainee name from filename prefix.
         // Format example: "Admire_Vega_2026-03-06 16_13_03.txt".
@@ -368,7 +409,7 @@ export function parseLogs(files: LogFileInput[]): ParseResult {
 
             const match = line.match(REGEX.dateTurn)
             if (match) {
-                const detectedDay = parseInt(match[1], 10)
+                const detectedDay = parseInt(match[1] ?? match[2], 10)
                 foundAnyDay = true
                 if (firstDaySeen === undefined) firstDaySeen = detectedDay
                 if (lastDaySeen === undefined || detectedDay > lastDaySeen) lastDaySeen = detectedDay
@@ -402,6 +443,7 @@ export function parseLogs(files: LogFileInput[]): ParseResult {
                             ended: false,
                             timestamp: lineTimestamp,
                             traineeName: fileTraineeName,
+                            scenario: fileScenario,
                             raceGrade: undefined,
                             energyType: undefined,
                             moodType: undefined,
@@ -410,6 +452,9 @@ export function parseLogs(files: LogFileInput[]): ParseResult {
                         const existingDay = dayMap.get(currentDay)!
                         if (!existingDay.traineeName && fileTraineeName) {
                             existingDay.traineeName = fileTraineeName
+                        }
+                        if (!existingDay.scenario && fileScenario) {
+                            existingDay.scenario = fileScenario
                         }
                         if (!existingDay.dateText && pendingDateText) {
                             existingDay.dateText = pendingDateText
@@ -442,6 +487,12 @@ export function parseLogs(files: LogFileInput[]): ParseResult {
                 currentDay = undefined
                 statGainsByType.clear()
                 continue
+            }
+
+            // Capture the scenario/campaign once from the startup banner, which is logged before the first day.
+            if (!fileScenario) {
+                const scenarioMatch = line.match(REGEX.scenario)
+                if (scenarioMatch) fileScenario = scenarioMatch[1].trim()
             }
 
             if (currentDay === undefined) {
@@ -494,6 +545,25 @@ export function parseLogs(files: LogFileInput[]): ParseResult {
                 day.traineeName = traineeMatch[1].trim()
             }
 
+            // Capture the race name (and grade), finishing place, and win result when a race is run this turn.
+            const raceSelectedMatch = line.match(REGEX.raceSelected)
+            if (raceSelectedMatch) {
+                day.raceName = raceSelectedMatch[1].trim()
+                if (!day.raceGrade) day.raceGrade = raceSelectedMatch[2].trim()
+                day.triggers.race.push(line)
+            }
+            const raceResultMatch = line.match(REGEX.raceResult)
+            if (raceResultMatch) {
+                day.raceName = raceResultMatch[1].trim()
+                day.racePlace = raceResultMatch[2].trim()
+                day.triggers.race.push(line)
+            }
+            const raceWonMatch = line.match(REGEX.raceWon)
+            if (raceWonMatch) {
+                day.raceWon = raceWonMatch[1].toLowerCase() === "true"
+                day.triggers.race.push(line)
+            }
+
             for (const key of ACTION_KEYS) {
                 const matcher = MATCHERS[key]
                 if (matchesLine(line, matcher)) {
@@ -544,7 +614,7 @@ export function parseLogs(files: LogFileInput[]): ParseResult {
         // Insert file divider if fileName changes (for consecutive days or after gaps).
         // Also insert at the very beginning for the first file.
         if ((prevFileName && entry.fileName !== prevFileName) || prevFileName === undefined) {
-            records.push({ kind: "fileDivider", fileName: entry.fileName, traineeName: entry.traineeName })
+            records.push({ kind: "fileDivider", fileName: entry.fileName, traineeName: entry.traineeName, scenario: entry.scenario })
         }
 
         records.push({
@@ -563,6 +633,10 @@ export function parseLogs(files: LogFileInput[]): ParseResult {
             raceGrade: entry.raceGrade,
             energyType: entry.energyType,
             moodType: entry.moodType,
+            raceName: entry.raceName,
+            racePlace: entry.racePlace,
+            raceWon: entry.raceWon,
+            scenario: entry.scenario,
         })
         prevDay = d
         prevFileName = entry.fileName
@@ -638,6 +712,8 @@ export type YearSummariesResult = {
     totalElapsedTimeFormatted?: string
     /** The total elapsed time in "X hours and Y minutes" format for all years. */
     totalElapsedTimeHuman?: string
+    /** The scenario/campaign this run was played on (e.g. "Trackblazer"). */
+    scenario?: string
 }
 
 /**
@@ -692,6 +768,8 @@ export function aggregateYearSummaries(records: DayRecord[]): YearSummariesResul
     const summaries: YearSummary[] = []
     const yearOrder = ["Junior", "Classic", "Senior"]
     let totalElapsedTimeMs = 0
+    // The scenario is run-wide. Capture it from the first day that carries one.
+    let scenario: string | undefined
 
     for (const year of yearOrder) {
         const days = yearMap.get(year)
@@ -713,6 +791,9 @@ export function aggregateYearSummaries(records: DayRecord[]): YearSummariesResul
             // Collect trainee name if available.
             if (day.traineeName) {
                 traineeNamesSet.add(day.traineeName)
+            }
+            if (!scenario && day.scenario) {
+                scenario = day.scenario
             }
             // Check if this day is Finals (turns 73-75).
             if (day.dayNumber >= 73 && day.dayNumber <= 75) {
@@ -798,5 +879,6 @@ export function aggregateYearSummaries(records: DayRecord[]): YearSummariesResul
         totalElapsedTimeMs: totalElapsedTimeMs > 0 ? totalElapsedTimeMs : undefined,
         totalElapsedTimeFormatted,
         totalElapsedTimeHuman,
+        scenario,
     }
 }

--- a/src/lib/storageBridge.ts
+++ b/src/lib/storageBridge.ts
@@ -46,3 +46,18 @@ const { StorageBridgeModule } = NativeModules as { StorageBridgeModule: StorageB
 
 /** Singleton wrapper around the native SAF bridge. */
 export const storageBridge = StorageBridgeModule
+
+/**
+ * Builds the SAF *document* uri for the root folder of a tree uri (e.g. `.../tree/<id>` -> `.../tree/<id>/document/<id>`).
+ * `ACTION_VIEW` needs the document uri, not the tree uri, to open a folder in the system Files app. The already-encoded
+ * tree document id is reused verbatim so it is not double-encoded.
+ * @param treeUri A SAF tree uri, typically from `getCurrentFolder()`.
+ * @returns The folder's document uri, or the input unchanged when it is not a tree uri.
+ */
+export function folderDocumentUriFromTreeUri(treeUri: string): string {
+    const marker = "/tree/"
+    const idx = treeUri.indexOf(marker)
+    if (idx < 0) return treeUri
+    const encodedDocId = treeUri.substring(idx + marker.length)
+    return `${treeUri}/document/${encodedDocId}`
+}

--- a/src/pages/EventLogVisualizer/index.tsx
+++ b/src/pages/EventLogVisualizer/index.tsx
@@ -16,6 +16,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "../../components/ui/too
 import { Info } from "lucide-react-native"
 import { Row } from "../../components/ui/row"
 import { Switch } from "../../components/ui/switch"
+import { ValuePill } from "../../components/ui/value-pill"
 import Ionicons from "@react-native-vector-icons/ionicons"
 import PageHeader from "../../components/PageHeader"
 import { usePerformanceLogging } from "../../hooks/usePerformanceLogging"
@@ -186,12 +187,18 @@ const EventLogVisualizer: React.FC = () => {
                 <PageHeader title="Event Log Visualizer" style={{ marginBottom: 12 }} />
 
                 <View style={{ flexDirection: "row", alignItems: "center", justifyContent: "space-between", marginBottom: 12, gap: 8 }}>
-                    <CustomButton variant="outline" style={{ flex: 1 }} icon={<Ionicons name="folder-outline" size={16} color={colors.text} />} onPress={openDataDirectory}>
-                        Open Data Directory
-                    </CustomButton>
-                    <CustomButton variant="primary" style={{ flex: 1 }} icon={<Ionicons name="folder-open" size={16} color={colors.onBrand} />} onPress={onPickFiles}>
-                        Select Log Files
-                    </CustomButton>
+                    <View style={{ flexDirection: "row", flex: 1, gap: 8 }}>
+                        <View style={{ flex: 1 }}>
+                            <CustomButton variant="outline" icon={<Ionicons name="folder-outline" size={16} color={colors.text} />} onPress={openDataDirectory}>
+                                Open Data Directory
+                            </CustomButton>
+                        </View>
+                        <View style={{ flex: 1 }}>
+                            <CustomButton variant="primary" icon={<Ionicons name="folder-open" size={16} color={colors.onBrand} />} onPress={onPickFiles}>
+                                Select Log Files
+                            </CustomButton>
+                        </View>
+                    </View>
                     <Tooltip>
                         <TooltipTrigger asChild>
                             <Pressable style={circularPress(40)} android_ripple={{ color: colors.ripple, foreground: true }}>
@@ -201,17 +208,17 @@ const EventLogVisualizer: React.FC = () => {
                         <TooltipContent side="bottom" style={{ backgroundColor: isDark ? colors.surfaceRaised : "black", maxWidth: 300 }}>
                             <WarningContainer>
                                 <View style={{ flexDirection: "row", flexWrap: "wrap" }}>
-                                    <Text style={{ fontWeight: "bold", color: colors.warningText }}>⚠️ File Explorer Note:</Text>
+                                    <Text style={{ fontWeight: "bold", color: colors.warningText }}>⚠️ File Access Note: </Text>
                                     <Text style={{ fontSize: 14, color: colors.warningText, lineHeight: 20 }}>
-                                        To manually access files, you need a file explorer app that can access the /Android/data folder (like CX File Explorer). Standard file managers will not work.
+                                        If you picked a storage folder during setup, your logs are saved there and the "Open Data Directory" button opens it directly, so any file manager works. If you
+                                        left the app on its default internal storage, logs live under /Android/data, which recent Android versions restrict, so reaching them manually needs a file
+                                        explorer like CX File Explorer.
                                     </Text>
                                 </View>
                             </WarningContainer>
                             <Text style={styles.empty}>
                                 Select one or more .txt logs named like "TraineeName_date.txt" or "log @ date.txt" to visualize per-day actions. Files are sorted by filename. Gaps between days are
-                                shown. {"\n\n"}
-                                Note: Recent Android versions heavily restrict access to the app data folder where logs are stored. Use the "Open Data Directory" button above to locate the logs, then
-                                move the files you want to use out of /Android/data/ to a public folder like /Download/ before selecting them here.
+                                shown.
                             </Text>
                         </TooltipContent>
                     </Tooltip>
@@ -269,17 +276,23 @@ const EventLogVisualizer: React.FC = () => {
                     />
                 ) : (
                     <>
-                        {yearSummariesResult.totalElapsedTimeFormatted && (
-                            <View style={[styles.content, { paddingBottom: 8, flexDirection: "row", alignItems: "center", gap: 8 }]}>
-                                <Text style={[styles.totalTimeTitle, { color: colors.text }]}>Total Elapsed Time:</Text>
-                                <Text style={[styles.totalTimeValue, { color: colors.text }]}>{yearSummariesResult.totalElapsedTimeFormatted}</Text>
-                                <Text style={[styles.totalTimeHuman, { color: colors.textMuted }]}>({yearSummariesResult.totalElapsedTimeHuman})</Text>
+                        {(yearSummariesResult.scenario || yearSummariesResult.totalElapsedTimeFormatted) && (
+                            <View style={[styles.content, { paddingBottom: 8, flexDirection: "row", alignItems: "center", gap: 8, flexWrap: "wrap" }]}>
+                                {yearSummariesResult.scenario && <ValuePill label={yearSummariesResult.scenario} />}
+                                {yearSummariesResult.totalElapsedTimeFormatted && (
+                                    <>
+                                        <Text style={[styles.totalTimeTitle, { color: colors.text }]}>Total Elapsed Time:</Text>
+                                        <Text style={[styles.totalTimeValue, { color: colors.text }]}>{yearSummariesResult.totalElapsedTimeFormatted}</Text>
+                                        <Text style={[styles.totalTimeHuman, { color: colors.textMuted }]}>({yearSummariesResult.totalElapsedTimeHuman})</Text>
+                                    </>
+                                )}
                             </View>
                         )}
                         <FlashList
                             data={yearSummariesResult.summaries}
                             renderItem={({ item }) => <YearSummaryCard summary={item} />}
                             keyExtractor={(item) => item.year}
+                            contentContainerStyle={{ paddingHorizontal: 12 }}
                             ListEmptyComponent={<View />}
                         />
                     </>


### PR DESCRIPTION
## Description
- This PR fixes the Event Log Visualizer parser (turn, year, and injury detection) and extends it to capture each race's name/grade/result and the run's scenario, then redesigns the Timeline and Year Summaries as a connected rail with tinted action chips.
- It also repoints the "Open Data Directory" button at the user's chosen storage folder via `openDataDirectory()` and wraps the app in `GestureHandlerRootView` so the navigation drawer no longer sticks open after the log-file picker closes.

The parser previously read the Smart Race Solver preview schedule as real turns, spawning phantom days and dropping the Classic year:

```
Smart Race Solver Preview Schedule (34 races, ...):
  Turn 16 (Junior Class August, Second Half - Niigata Junior Stakes, G3)
  Turn 17 (Junior Class September, First Half - Sapporo Junior Stakes, G3)
```
