### PR TITLE
Fix skill-buy under-spend and skill-name OCR recovery

### DIFF
--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/SkillDatabase.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/SkillDatabase.kt
@@ -154,7 +154,8 @@ class SkillDatabase(private val game: Game) {
             val versionResults: MutableList<String> = mutableListOf()
 
             while (currentId != null) {
-                val name: String = getSkillName(currentId) ?: break
+                // Look up directly so an unreleased upgrade/downgrade target ends the chain silently instead of warning.
+                val name: String = skillIdToName[currentId] ?: break
                 val tmpData: SkillData? = getSkillData(name)
                 if (tmpData == null) {
                     MessageLog.e(TAG, "[ERROR] loadSkillStructure::getVersionNames:: \"$name\" not in skillData.")

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/SkillPlan.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/SkillPlan.kt
@@ -496,7 +496,7 @@ class SkillPlan(private val game: Game, private val campaign: Campaign) {
                 continue
             }
 
-            if (entry.screenPrice <= remainingSkillPoints) {
+            if (entry.bIsAvailable && entry.screenPrice <= remainingSkillPoints) {
                 result[name] = entry.screenPrice
                 remainingSkillPoints -= entry.screenPrice
                 entry.buy()
@@ -788,7 +788,7 @@ class SkillPlan(private val game: Game, private val campaign: Campaign) {
                     continue
                 }
 
-                if (entry.screenPrice > remainingSkillPoints) {
+                if (!entry.bIsAvailable || entry.screenPrice > remainingSkillPoints) {
                     continue
                 }
 

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/types/SkillList.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/types/SkillList.kt
@@ -37,6 +37,26 @@ fun interface OnEntryDetectedCallback {
 }
 
 /**
+ * Strips a trailing rank glyph that OCR misread as a letter ("O"/"x") or left as stray noise, returning the base name.
+ * Glyphs are stored in the database as " <glyph>" with a leading space, so the base must have the misread char removed.
+ *
+ * @param name The raw skill name that may carry a trailing misread glyph.
+ * @return The base skill name with the trailing glyph noise removed.
+ */
+fun stripTrailingGlyphNoise(name: String): String {
+    var s: String = name.trimEnd()
+    // Glued misread glyph, e.g. "SomethingO".
+    if (s.length >= 2 && (s.endsWith("O") || s.endsWith("x")) && s[s.length - 2] != ' ') {
+        s = s.dropLast(1)
+    }
+    // Standalone trailing letter/digit preceded by a space, e.g. "Something O".
+    if (s.isNotEmpty() && s.last().isLetterOrDigit() && (s.length == 1 || s[s.length - 2] == ' ')) {
+        s = s.dropLast(1).trimEnd()
+    }
+    return s
+}
+
+/**
  * Handles all interactions with the skill list screen and manages the [Trainee]'s skill data.
  *
  * This class provides functionality to detect available skills, parse their details (name, price),
@@ -340,7 +360,13 @@ class SkillList(private val game: Game, private val campaign: Campaign) {
         // Handle cases where the capital "I" is misread as a lowercase "l".
         skillName = skillName.replace(Regex("\\bl\\b"), "I")
 
-        // Detect special icons (◎, ○, ×) that indicate skill levels or status.
+        // Strip the "Remove" prefix used for negative skill titles before glyph handling so the base name is clean.
+        // The database stores the base skill name without this prefix.
+        if (skillName.startsWith("remove", ignoreCase = true)) {
+            skillName = skillName.drop("remove".length).trim()
+        }
+
+        // Detect special icons (double-circle, single-circle, cross) that indicate skill levels or status.
         val componentsToCheck: List<ComponentInterface> =
             listOf(
                 IconSkillTitleDoubleCircle,
@@ -357,7 +383,7 @@ class SkillList(private val game: Game, private val campaign: Campaign) {
         }
 
         // Map the detected icon to its corresponding Unicode character.
-        val iconChar: String =
+        var iconChar: String =
             when (match) {
                 IconSkillTitleDoubleCircle -> "◎"
                 IconSkillTitleCircle -> "○"
@@ -365,37 +391,28 @@ class SkillList(private val game: Game, private val campaign: Campaign) {
                 else -> ""
             }
 
-        if (iconChar.isNotEmpty()) {
-            // Clean up OCR noise. These symbols are always preceded by a space in the skill database.
-            // If OCR misread the icon as a character (like 'O' or 'x'), we strip the last character.
-            skillName = skillName.trimEnd()
+        // The base skill name with any trailing misread-glyph letter removed. The database stores glyphs as " <glyph>".
+        val baseName: String = stripTrailingGlyphNoise(skillName)
 
-            // Handle edge cases where an icon (○, ◎, ×) is misread as a letter (O, x) and attached to the word.
-            if (skillName.length >= 2 && (skillName.endsWith("O") || skillName.endsWith("x"))) {
-                if (skillName[skillName.length - 2] != ' ') {
-                    skillName = skillName.dropLast(1)
+        // Template match found no glyph, but OCR left a trailing letter that is really a misread rank glyph.
+        // Single-circle reads as "O"/"0"; cross reads as "x"/"X". Double-circle never appears in a scan, so it is not a case here.
+        // Only accept the recovery when "<base> <glyph>" is a real skill so a legit name ending in a letter is not mangled.
+        if (iconChar.isEmpty()) {
+            val candidateGlyph: String =
+                when (skillName.trimEnd().lastOrNull()) {
+                    'O', '0' -> "○"
+                    'x', 'X' -> "×"
+                    else -> ""
                 }
+            if (candidateGlyph.isNotEmpty() && baseName.isNotEmpty() && game.skillDatabase.checkSkillName("$baseName $candidateGlyph") != null) {
+                iconChar = candidateGlyph
             }
-
-            if (skillName.isNotEmpty() && skillName.last().isLetterOrDigit()) {
-                // If the last character is a single letter/digit with a preceding space, it's likely noise.
-                if (skillName.length == 1 || (skillName.length >= 2 && skillName[skillName.length - 2] == ' ')) {
-                    skillName = skillName.dropLast(1).trimEnd()
-                }
-            }
-
-            // Append the icon character with a preceding space to match database formatting.
-            skillName += " $iconChar"
         }
 
-        // Strip the "Remove" prefix used for negative skill titles in some contexts.
-        // The database stores the base skill name without this prefix.
-        skillName =
-            if (skillName.startsWith("remove", ignoreCase = true)) {
-                skillName.drop("remove".length).trim()
-            } else {
-                skillName
-            }
+        // If a glyph was resolved, re-append it with a leading space to match the database formatting.
+        if (iconChar.isNotEmpty()) {
+            skillName = "$baseName $iconChar"
+        }
 
         return skillName
     }

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/types/SkillList.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/types/SkillList.kt
@@ -493,7 +493,8 @@ class SkillList(private val game: Game, private val campaign: Campaign) {
                 }
             }.apply { isDaemon = true }.start()
         } else {
-            skillName = cachedTitle
+            // Correct the cached title too, mirroring the non-cached path, so a cached OCR misread still resolves.
+            skillName = game.skillDatabase.checkSkillName(cachedTitle, fuzzySearch = true)
         }
 
         // Start thread for price extraction.

--- a/android/app/src/test/java/com/steve1316/uma_android_automation/types/StripTrailingGlyphNoiseTest.kt
+++ b/android/app/src/test/java/com/steve1316/uma_android_automation/types/StripTrailingGlyphNoiseTest.kt
@@ -1,0 +1,85 @@
+package com.steve1316.uma_android_automation.types
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit tests for [stripTrailingGlyphNoise], the pure helper that removes a trailing rank glyph
+ * that OCR misread as a letter ("O"/"x") or left as stray noise. Used by `getSkillListEntryTitle`
+ * to recover the base skill name before re-appending the correct " <glyph>" suffix.
+ */
+@DisplayName("stripTrailingGlyphNoise Tests")
+class StripTrailingGlyphNoiseTest {
+    @Nested
+    @DisplayName("Recovers misread glyphs")
+    inner class RecoversMisreadGlyphs {
+        @Test
+        fun `single-circle misread as spaced O is stripped`() {
+            assertEquals("Standard Distance", stripTrailingGlyphNoise("Standard Distance O"))
+            assertEquals("Medium Corners", stripTrailingGlyphNoise("Medium Corners O"))
+            assertEquals("Medium Straightaways", stripTrailingGlyphNoise("Medium Straightaways O"))
+        }
+
+        @Test
+        fun `cross misread as spaced x is stripped`() {
+            assertEquals("Standard Distance", stripTrailingGlyphNoise("Standard Distance x"))
+        }
+
+        @Test
+        fun `spaced zero is stripped`() {
+            assertEquals("Standard Distance", stripTrailingGlyphNoise("Standard Distance 0"))
+        }
+
+        @Test
+        fun `glued O is stripped`() {
+            assertEquals("Foo", stripTrailingGlyphNoise("FooO"))
+        }
+
+        @Test
+        fun `glued x is stripped`() {
+            assertEquals("Foo", stripTrailingGlyphNoise("Foox"))
+        }
+
+        @Test
+        fun `standalone spaced letter is stripped`() {
+            assertEquals("Foo", stripTrailingGlyphNoise("Foo O"))
+        }
+
+        @Test
+        fun `trailing whitespace is trimmed before stripping`() {
+            assertEquals("Standard Distance", stripTrailingGlyphNoise("Standard Distance O   "))
+        }
+    }
+
+    @Nested
+    @DisplayName("Leaves normal names untouched")
+    inner class LeavesNormalNames {
+        @Test
+        fun `names not ending in a stray letter are unchanged`() {
+            assertEquals("Extra Tank", stripTrailingGlyphNoise("Extra Tank"))
+            assertEquals("Lucky Seven", stripTrailingGlyphNoise("Lucky Seven"))
+            assertEquals("Racing Spirit: Speed", stripTrailingGlyphNoise("Racing Spirit: Speed"))
+        }
+
+        @Test
+        fun `name ending in a glued non-glyph letter is unchanged`() {
+            assertEquals("1,500,000 CC", stripTrailingGlyphNoise("1,500,000 CC"))
+        }
+    }
+
+    @Nested
+    @DisplayName("Edge cases")
+    inner class EdgeCases {
+        @Test
+        fun `empty string stays empty`() {
+            assertEquals("", stripTrailingGlyphNoise(""))
+        }
+
+        @Test
+        fun `single stray letter collapses to empty`() {
+            assertEquals("", stripTrailingGlyphNoise("O"))
+        }
+    }
+}


### PR DESCRIPTION
## Description

- This PR stops the post-career skill planner from double-counting a bundled base skill (buying `Iron Will` at `304` already grants its base `Lay Low` at `160`), so `getSkillsToBuyOptimizeRankStrategy()` and `getNegativeSkills()` no longer inflate the projected spend and leave points unspent.
- This PR recovers skill names that OCR misreads - circle/cross rank glyphs read as trailing letters, and cached titles like `Iron WilI` - so planned skills are not skipped during the buy scan.
- This PR silences a benign startup warning emitted when a skill upgrade chain ends at a version not yet released on Global.

Original under-spend seen in the log:

    ================ Skills To Buy =================
        Iron Will: 304
        Hydrate: 126
        Lay Low: 160
        Professor of Curvature: 252
        TOTAL: 842 / 858 pts with 16 left over pts
    ...
    Buying "Professor of Curvature" for 252 pts
    Buying "Iron Will" for 304 pts
    Buying "Hydrate" for 126 pts
    All skills purchased. Exiting loop early...

`Lay Low` (160) was already granted by buying `Iron Will`, so it was never bought separately - leaving 176 SP unspent instead of the projected 16.
