### PR TITLE
Improve the Remote Log Viewer's flood handling, debug image tiles, and log download

### DIFF
--- a/android/app/src/main/assets/log_viewer.html
+++ b/android/app/src/main/assets/log_viewer.html
@@ -2594,6 +2594,16 @@
             let searchQuery = ""
             let isFiltering = false
             let messageCache = []
+
+            // Live-render coalescing: buffer incoming live messages and flush them once per animation frame.
+            let liveQueue = []
+            let liveFlushHandle = null
+            // Currently visible tab; live log rendering pauses while this isn't "logs" (see scheduleLiveFlush / switchTab).
+            let activeTab = "logs"
+            // Cap on rendered log entries. Trimming the oldest bounds DOM size so a debug flood cannot make each frame's
+            // reflow progressively heavier and saturate the main thread (which starved clicks like the log Download button).
+            const MAX_LOG_ENTRIES = 5000
+
             let reconnectAttempts = 0
             let reconnectInterval = null
             const maxReconnectDelay = 30000
@@ -2737,7 +2747,8 @@
                                 if (isSyncing) {
                                     syncingBuffer.push(data)
                                 } else {
-                                    appendLogMessage(data)
+                                    liveQueue.push(data)
+                                    scheduleLiveFlush()
                                 }
                             }
                         } catch (e) {
@@ -2863,31 +2874,26 @@
             }
 
             /**
-             * Processes and appends a single log message to the log container.
-             * @param {object} parsed - The pre-parsed log object from the server.
+             * Schedules a per-frame live-log flush, but only while the logs view is visible. On other tabs messages
+             * accumulate cheaply in liveQueue and flush on return (see switchTab), so a debug flood cannot saturate the
+             * main thread and block clicks elsewhere (e.g. the log-file Download button). Coalescing per frame also avoids
+             * a synchronous reflow per message.
              */
-            function appendLogMessage(parsed) {
-                if (!parsed) return
-                messageCount++
-
-                // Hide empty state on first message.
-                if (emptyState) {
-                    emptyState.style.display = "none"
+            function scheduleLiveFlush() {
+                if (activeTab !== "logs") return
+                if (liveFlushHandle === null) {
+                    liveFlushHandle = requestAnimationFrame(flushLiveQueue)
                 }
+            }
 
-                allMessages.push({ parsed: parsed })
-
-                // Handle special messages for dashboard updates immediately for individual messages.
-                processSpecialLogs(parsed)
-
-                processParsedMessage(parsed, logContainer)
-
-                updateMessageCountDisplay()
-
-                // Auto-scroll to bottom.
-                if (autoScroll) {
-                    scrollToBottom()
-                }
+            /**
+             * Renders every message queued since the last frame in one batch via appendBatchMessages.
+             */
+            function flushLiveQueue() {
+                liveFlushHandle = null
+                const pending = liveQueue
+                liveQueue = []
+                appendBatchMessages(pending)
             }
 
             /**
@@ -2898,6 +2904,12 @@
                 if (!parsedMessages || parsedMessages.length === 0) return
 
                 messageCount += parsedMessages.length
+
+                // Never render more than the visible window in one batch (e.g. a big history sync or an off-tab backlog);
+                // trimRenderedLog would drop the overflow immediately anyway, so skip building those DOM nodes at all.
+                if (parsedMessages.length > MAX_LOG_ENTRIES) {
+                    parsedMessages = parsedMessages.slice(parsedMessages.length - MAX_LOG_ENTRIES)
+                }
 
                 if (emptyState) {
                     emptyState.style.display = "none"
@@ -2944,12 +2956,36 @@
 
                 logContainer.appendChild(fragment)
                 updateMessageCountDisplay()
-                
+
                 // Apply the final accumulated state from this batch to the DOM.
                 applyBatchStateToDashboard(batchState)
 
+                // Keep the rendered log bounded so the reflow below cannot grow without limit.
+                trimRenderedLog()
+
                 if (autoScroll) {
                     scrollToBottom()
+                }
+            }
+
+            /**
+             * Trims the oldest rendered log entries (DOM nodes, messageCache, allMessages) down to MAX_LOG_ENTRIES so the
+             * log DOM stays bounded. Without this the per-frame scrollToBottom reflow grows with the node count and, under a
+             * debug flood, saturates the main thread - which starves clicks such as the log Download button until a reload.
+             */
+            function trimRenderedLog() {
+                const excess = messageCache.length - MAX_LOG_ENTRIES
+                if (excess > 0) {
+                    const removed = messageCache.splice(0, excess)
+                    for (const old of removed) {
+                        if (old.el) {
+                            if (!old.el.classList.contains("hidden")) visibleMessageCount--
+                            if (old.el.parentNode) old.el.parentNode.removeChild(old.el)
+                        }
+                    }
+                }
+                if (allMessages.length > MAX_LOG_ENTRIES) {
+                    allMessages.splice(0, allMessages.length - MAX_LOG_ENTRIES)
                 }
             }
 
@@ -3206,6 +3242,13 @@
              * Removes all log entries from the display and resets the local message store.
              */
             function clearDisplay() {
+                // Cancel any pending live flush so queued messages are not re-appended after the display is reset.
+                if (liveFlushHandle !== null) {
+                    cancelAnimationFrame(liveFlushHandle)
+                    liveFlushHandle = null
+                }
+                liveQueue = []
+
                 // Remove all log entries but keep the empty state div.
                 var entries = logContainer.querySelectorAll(".log-entry")
                 entries.forEach(function (entry) {
@@ -4181,6 +4224,7 @@
              * @param {string} tabID - The ID of the tab to switch to ('logs', 'images', or 'logFiles').
              */
             function switchTab(tabID) {
+                activeTab = tabID
                 if (tabID !== "analytics") analyticStopRuntimeTicker()
                 // Update buttons.
                 document.getElementById("logsTabBtn").classList.toggle("active", tabID === "logs")
@@ -4194,8 +4238,12 @@
                 document.getElementById("logFilesView").classList.toggle("active", tabID === "logFiles")
                 document.getElementById("analyticsView").classList.toggle("active", tabID === "analytics")
 
-                if (tabID === "logs" && autoScroll) {
-                    scrollToBottom()
+                if (tabID === "logs") {
+                    // Render anything buffered while another tab was showing, then pin to the bottom.
+                    scheduleLiveFlush()
+                    if (autoScroll) {
+                        scrollToBottom()
+                    }
                 }
 
                 // Lazy-load the log files index on first activation; user can hit Refresh for re-fetches.

--- a/android/app/src/main/assets/log_viewer.html
+++ b/android/app/src/main/assets/log_viewer.html
@@ -180,7 +180,8 @@
 
             .image-grid {
                 display: grid;
-                grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+                grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+                align-content: start;
                 gap: 16px;
                 padding: 20px;
                 overflow-y: auto;
@@ -197,6 +198,7 @@
                 cursor: pointer;
                 display: flex;
                 flex-direction: column;
+                height: 360px;
             }
 
             .image-card:hover {
@@ -205,23 +207,46 @@
                 box-shadow: 0 10px 20px rgba(0, 0, 0, 0.3);
             }
 
-            .image-card img {
-                width: 100%;
-                aspect-ratio: 9 / 16;
-                object-fit: cover;
-                display: block;
+            .image-thumb {
+                flex: 1 1 auto;
+                min-height: 0;
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                overflow: hidden;
                 background: #000;
             }
 
+            .image-thumb img {
+                max-width: 100%;
+                max-height: 100%;
+                display: block;
+            }
+
             .image-info {
+                flex: 0 0 auto;
                 padding: 8px 12px;
                 font-size: 11px;
                 color: var(--text-secondary);
                 text-align: center;
-                word-break: break-all;
                 border-bottom: 1px solid var(--border-color);
                 background: var(--bg-tertiary);
                 font-family: var(--font-mono);
+            }
+
+            .image-name {
+                display: -webkit-box;
+                -webkit-line-clamp: 2;
+                -webkit-box-orient: vertical;
+                overflow: hidden;
+                word-break: break-all;
+            }
+
+            .image-time {
+                margin-top: 3px;
+                font-size: 10px;
+                color: var(--text-muted);
+                letter-spacing: 0.3px;
             }
 
             .debug-notice {
@@ -273,6 +298,28 @@
                 border-radius: var(--radius);
                 box-shadow: 0 0 50px rgba(0, 0, 0, 0.8);
                 animation: modalZoom 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+            }
+
+            .modal-caption {
+                position: absolute;
+                bottom: 24px;
+                left: 50%;
+                transform: translateX(-50%);
+                max-width: 90%;
+                padding: 8px 14px;
+                background: rgba(10, 10, 15, 0.85);
+                border: 1px solid var(--border-color);
+                border-radius: var(--radius);
+                color: var(--text-secondary);
+                font-family: var(--font-mono);
+                font-size: 12px;
+                text-align: center;
+                word-break: break-all;
+                pointer-events: none;
+            }
+
+            .modal-caption:empty {
+                display: none;
             }
 
             @keyframes modalZoom {
@@ -2131,6 +2178,7 @@
         <div id="imageModal" class="modal" onclick="closeModal()">
             <span class="modal-close">&times;</span>
             <img class="modal-content" id="enlargedImage">
+            <div id="imageModalCaption" class="modal-caption"></div>
         </div>
 
         <!-- Log Files View -->
@@ -4307,6 +4355,18 @@
             }
 
             /**
+             * Formats an image's creation time (epoch millis from the server) as "Mon D HH:mm:ss".
+             * @param {number} ms - Epoch milliseconds, typically from File.lastModified() on the backend.
+             * @returns {string} The formatted date-time, or "" if the value is missing or unparseable.
+             */
+            function formatImageTimestamp(ms) {
+                if (!Number.isFinite(ms)) return ""
+                const d = new Date(ms)
+                const pad = n => String(n).padStart(2, "0")
+                return CAL_MONTH_LABELS[d.getMonth()] + " " + d.getDate() + " " + pad(d.getHours()) + ":" + pad(d.getMinutes()) + ":" + pad(d.getSeconds())
+            }
+
+            /**
              * Handles an incoming image message from the server.
              * @param {object} data - The image data object.
              */
@@ -4319,15 +4379,33 @@
                 img.src = "data:image/jpeg;base64," + data.data
                 img.alt = data.name
 
+                const thumb = document.createElement("div")
+                thumb.className = "image-thumb"
+                thumb.appendChild(img)
+
                 const info = document.createElement("div")
                 info.className = "image-info"
-                info.textContent = data.name
+
+                const nameEl = document.createElement("div")
+                nameEl.className = "image-name"
+                nameEl.textContent = data.name
+                nameEl.title = data.name
+                info.appendChild(nameEl)
+
+                const time = formatImageTimestamp(data.timestamp)
+                if (time) {
+                    const timeEl = document.createElement("div")
+                    timeEl.className = "image-time"
+                    timeEl.textContent = time
+                    info.appendChild(timeEl)
+                }
 
                 card.appendChild(info)
-                card.appendChild(img)
+                card.appendChild(thumb)
 
+                const caption = time ? data.name + " · " + time : data.name
                 card.onclick = function() {
-                    openModal(img.src)
+                    openModal(img.src, caption)
                 }
 
                 grid.appendChild(card)
@@ -4352,12 +4430,15 @@
             /**
              * Opens the image enlargement modal.
              * @param {string} src - The image source URL.
+             * @param {string} caption - Optional caption (name and creation time) shown over the image; pass "" for none.
              */
-            function openModal(src) {
+            function openModal(src, caption) {
                 const modal = document.getElementById("imageModal")
                 const modalImg = document.getElementById("enlargedImage")
+                const cap = document.getElementById("imageModalCaption")
                 modal.classList.add("visible")
                 modalImg.src = src
+                cap.textContent = caption || ""
             }
 
             /**

--- a/android/app/src/main/assets/log_viewer.html
+++ b/android/app/src/main/assets/log_viewer.html
@@ -4218,49 +4218,15 @@
              * Handles log downloading by fetching from the server endpoint.
              */
             function downloadLogs() {
-                const traineeName = document.getElementById("dashboardName").textContent.trim()
-                const datePart = new Date().toISOString().slice(0, 19).replace(/[:T]/g, "-")
-
-                // Prefer the server-side download for full, non-truncated logs.
-                fetch("/logs/download")
-                    .then((response) => {
-                        if (!response.ok) throw new Error("Server download failed")
-                        return response.blob()
-                    })
-                    .then((blob) => {
-                        const url = URL.createObjectURL(blob)
-                        const a = document.createElement("a")
-                        a.href = url
-                        // Use a descriptive filename.
-                        if (traineeName && traineeName !== "-") {
-                            a.download = `${traineeName}_${datePart}.txt`
-                        } else {
-                            a.download = `log @ ${datePart}.txt`
-                        }
-                        document.body.appendChild(a)
-                        a.click()
-                        document.body.removeChild(a)
-                        URL.revokeObjectURL(url)
-                    })
-                    .catch((err) => {
-                        console.error("Download error:", err)
-                        // Fallback: reconstruct raw log lines from pre-parsed objects.
-                        const content = allMessages.map((m) => {
-                            var line = ""
-                            if (m.parsed.newline) line += m.parsed.newline
-                            if (m.parsed.timestamp) line += m.parsed.timestamp + " "
-                            if (m.parsed.level) line += "[" + m.parsed.level + "] "
-                            line += m.parsed.message
-                            return line
-                        }).join("\n")
-                        const blob = new Blob([content], { type: "text/plain" })
-                        const url = URL.createObjectURL(blob)
-                        const a = document.createElement("a")
-                        a.href = url
-                        a.download = `log @ ${datePart}.txt`
-                        a.click()
-                        URL.revokeObjectURL(url)
-                    })
+                // Native anchor download of the full server-side log. The server sets the filename via Content-Disposition
+                // (trainee name + date), so none is computed here (download="" uses the server's name). Triggered synchronously
+                // so it cannot stall behind a debug-flood render backlog on the logs tab the way a fetch -> blob -> click chain did.
+                const a = document.createElement("a")
+                a.href = "/logs/download"
+                a.download = ""
+                document.body.appendChild(a)
+                a.click()
+                document.body.removeChild(a)
             }
 
             // //////////////////////////////////////////////////////////////////////////////////////////////////

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/utils/LogStreamServer.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/utils/LogStreamServer.kt
@@ -1138,9 +1138,12 @@ object LogStreamServer {
                                         Locale.getDefault(),
                                     ).format(Date())
 
+                                // Prefix the download with the scraped trainee name (falling back to "uaa" before one is read),
+                                // matching how saved log files are named. MessageLog.logFileNamePrefix holds the underscore-joined name.
+                                val namePart = MessageLog.logFileNamePrefix.ifEmpty { "uaa" }
                                 call.response.header(
                                     HttpHeaders.ContentDisposition,
-                                    "attachment; filename=\"uaa_logs_$datePart.txt\"",
+                                    "attachment; filename=\"${namePart}_logs_$datePart.txt\"",
                                 )
                                 call.respondText(fullLogs, ContentType.Text.Plain)
                             } catch (e: Exception) {

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/utils/LogStreamServer.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/utils/LogStreamServer.kt
@@ -490,7 +490,8 @@ object LogStreamServer {
 
         Log.d(TAG, "[DEBUG] sendDebugImages:: Found ${imageFiles.size} image files in temp directory.")
 
-        for (file in imageFiles) {
+        // Send newest first so the most recent capture lands at the top of the viewer grid.
+        for (file in imageFiles.sortedByDescending { it.lastModified() }) {
             try {
                 val bitmap = BitmapFactory.decodeFile(file.absolutePath)
                 if (bitmap != null) {
@@ -504,6 +505,7 @@ object LogStreamServer {
                         JSONObject().apply {
                             put("type", "image")
                             put("name", file.name)
+                            put("timestamp", file.lastModified())
                             put("data", base64Image)
                         }
                     session.send(Frame.Text(json.toString()))


### PR DESCRIPTION
## Description
- This PR reworks the Remote Log Viewer's live rendering so a debug-mode flood no longer makes it fall behind.
- The Debug Images tab now uses uniform fixed-size tiles that show each image whole and centered (no cropping), tag it with its creation time, sort newest-first, and clamp long filenames so they can't resize a card.
- Also fix instances where the log flood would cause the toolbar Download button to be unresponsive.
