### PR TITLE
Add an at-a-glance status and config zone to the Home hero

### DIFF
--- a/src/components/EventLog/ActionChip.tsx
+++ b/src/components/EventLog/ActionChip.tsx
@@ -1,9 +1,6 @@
-import React, { useMemo } from "react"
-import { StyleSheet, Text, View } from "react-native"
+import React from "react"
 import { useTheme } from "../../context/ThemeContext"
-import { TYPE } from "../../lib/type"
-import { SPACING } from "../../lib/spacing"
-import { RADII } from "../../lib/radii"
+import TintedChip from "../ui/tinted-chip"
 import { ACTION_VISUALS, type ActionKey } from "./actionVisuals"
 
 /** Props for `ActionChip`. */
@@ -24,36 +21,8 @@ interface ActionChipProps {
 const ActionChipImpl = ({ action, sublabel }: ActionChipProps) => {
     const { colors } = useTheme()
     const visual = ACTION_VISUALS[action]
-    const tint = colors[visual.colorKey]
-
-    const styles = useMemo(
-        () =>
-            StyleSheet.create({
-                chip: {
-                    flexDirection: "row",
-                    alignItems: "center",
-                    gap: SPACING.xs,
-                    paddingHorizontal: SPACING.sm,
-                    paddingVertical: 3,
-                    borderRadius: RADII.pill,
-                    backgroundColor: colors.surfaceRaised,
-                    borderWidth: 1,
-                    borderColor: colors.borderHair,
-                },
-                label: { ...TYPE.monoLabel, color: tint },
-            }),
-        [colors, tint]
-    )
-
-    const Icon = visual.icon
     const text = sublabel ? `${visual.label} ${sublabel}` : visual.label
-
-    return (
-        <View style={styles.chip}>
-            <Icon size={12} color={tint} />
-            <Text style={styles.label}>{text}</Text>
-        </View>
-    )
+    return <TintedChip icon={visual.icon} label={text} tint={colors[visual.colorKey]} />
 }
 
 export const ActionChip = React.memo(ActionChipImpl)

--- a/src/components/HeroStatusCard/HeroGlance.tsx
+++ b/src/components/HeroStatusCard/HeroGlance.tsx
@@ -1,0 +1,121 @@
+import React, { useMemo } from "react"
+import { Pressable, StyleSheet, Text, View } from "react-native"
+import { Bug, FlaskConical, Bot, ChevronRight, type LucideIcon } from "lucide-react-native"
+import { useTheme } from "../../context/ThemeContext"
+import { TYPE } from "../../lib/type"
+import { SPACING } from "../../lib/spacing"
+import { RADII } from "../../lib/radii"
+import ValuePill from "../ui/value-pill"
+import TintedChip from "../ui/tinted-chip"
+
+/** A settings screen the hero glance can deep-link into. */
+export type HeroGlanceTarget = "debug" | "srs" | "skills" | "training"
+
+/** One active status flag rendered as a tappable chip. */
+interface FlagChip {
+    /** Stable key for the list. */
+    key: string
+    /** Lucide icon for the flag. */
+    icon: LucideIcon
+    /** Chip label (the test name for the Debug Test chip). */
+    label: string
+    /** Resolved tint color. */
+    tint: string
+    /** Where tapping the chip navigates. */
+    target: HeroGlanceTarget
+}
+
+/** Props for `HeroGlance`. */
+export interface HeroGlanceProps {
+    /** Whether Debug Mode is on (renders the Debug chip). */
+    debugMode: boolean
+    /** The armed debug test's display name, or null when none is armed (renders the Test chip). */
+    activeTest: string | null
+    /** Whether the Smart Race Solver is on (renders the SRS chip). */
+    srs: boolean
+    /** Enabled skill-plan titles for the Plans row. */
+    planNames: string[]
+    /** Skill-point threshold for the Plans row, or null to omit the threshold pill. */
+    spThreshold: number | null
+    /** Ordered stat priority abbreviations for the Priority row. */
+    priority: string[]
+    /** Navigate to a settings screen when a chip or row is tapped. */
+    onNavigate: (target: HeroGlanceTarget) => void
+}
+
+/**
+ * The "at a glance" zone below the hero header: active status chips (Debug / Debug Test / SRS), an enabled skill-plans row, and the stat priority row.
+ * Each piece renders only when it has something to show, so an all-off config collapses the zone to nothing. Chips and rows are tappable shortcuts that
+ * deep-link into their settings screens via `onNavigate`.
+ * @param debugMode Whether Debug Mode is on.
+ * @param activeTest The armed debug test's display name, or null.
+ * @param srs Whether the Smart Race Solver is on.
+ * @param planNames Enabled skill-plan titles.
+ * @param spThreshold Skill-point threshold, or null to omit the pill.
+ * @param priority Ordered stat priority abbreviations.
+ * @param onNavigate Navigation callback invoked with the tapped target.
+ * @returns The glance zone, or a compact subset when only some data is present.
+ */
+const HeroGlanceImpl = ({ debugMode, activeTest, srs, planNames, spThreshold, priority, onNavigate }: HeroGlanceProps) => {
+    const { colors } = useTheme()
+    const styles = useMemo(
+        () =>
+            StyleSheet.create({
+                container: { padding: SPACING.md, gap: SPACING.sm },
+                chipRow: { flexDirection: "row", flexWrap: "wrap", gap: 6, alignItems: "center" },
+                row: { flexDirection: "row", alignItems: "center", gap: SPACING.md, marginHorizontal: -SPACING.xs, paddingHorizontal: SPACING.xs, paddingVertical: 2, borderRadius: RADII.sm },
+                rowLabel: { ...TYPE.monoLabel, color: colors.textMuted, width: 68 },
+                rowVal: { flex: 1, flexDirection: "row", flexWrap: "wrap", gap: 6, alignItems: "center" },
+            }),
+        [colors]
+    )
+
+    const flagChips: FlagChip[] = []
+    if (debugMode) flagChips.push({ key: "debug", icon: Bug, label: "Debug", tint: colors.warning, target: "debug" })
+    if (activeTest) flagChips.push({ key: "test", icon: FlaskConical, label: activeTest, tint: colors.info, target: "debug" })
+    if (srs) flagChips.push({ key: "srs", icon: Bot, label: "SRS", tint: colors.brand, target: "srs" })
+
+    const renderRow = (label: string, value: React.ReactNode, target: HeroGlanceTarget) => (
+        <Pressable onPress={() => onNavigate(target)} android_ripple={{ color: colors.ripple }} style={styles.row}>
+            <Text style={styles.rowLabel}>{label}</Text>
+            <View style={styles.rowVal}>{value}</View>
+            <ChevronRight size={16} color={colors.textSubtle} />
+        </Pressable>
+    )
+
+    return (
+        <View style={styles.container}>
+            {flagChips.length > 0 ? (
+                <View style={styles.chipRow}>
+                    {flagChips.map((chip) => (
+                        <TintedChip key={chip.key} icon={chip.icon} label={chip.label} tint={chip.tint} onPress={() => onNavigate(chip.target)} />
+                    ))}
+                </View>
+            ) : null}
+
+            {planNames.length > 0
+                ? renderRow(
+                      "Plans",
+                      <>
+                          {planNames.map((name) => (
+                              <ValuePill key={name} label={name} />
+                          ))}
+                          {spThreshold !== null ? <ValuePill label={`SP ≥ ${spThreshold}`} /> : null}
+                      </>,
+                      "skills"
+                  )
+                : null}
+
+            {priority.length > 0
+                ? renderRow(
+                      "Priority",
+                      priority.map((abbr) => <ValuePill key={abbr} tone="neutral" label={abbr} />),
+                      "training"
+                  )
+                : null}
+        </View>
+    )
+}
+
+export const HeroGlance = React.memo(HeroGlanceImpl)
+export default HeroGlance

--- a/src/components/HeroStatusCard/heroGlanceData.test.ts
+++ b/src/components/HeroStatusCard/heroGlanceData.test.ts
@@ -1,0 +1,62 @@
+import { findActiveDebugTest, activeSkillPlans, abbreviateStatPriority, heroGlanceHasContent } from "./heroGlanceData"
+
+describe("findActiveDebugTest", () => {
+    it("returns null when no test flag is armed", () => {
+        expect(findActiveDebugTest({ enableDebugMode: true, debugMode_startRainbowDetectionTest: false })).toBeNull()
+    })
+
+    it("derives a readable name from the armed test key", () => {
+        expect(findActiveDebugTest({ debugMode_startRainbowDetectionTest: true })).toBe("Rainbow Detection")
+        expect(findActiveDebugTest({ debugMode_startTrackblazerRaceSelectionTest: true })).toBe("Trackblazer Race Selection")
+        expect(findActiveDebugTest({ debugMode_startSingleTrainingOCRTest: true })).toBe("Single Training OCR")
+        expect(findActiveDebugTest({ debugMode_startScrollBarDetectionTest: true })).toBe("Scroll Bar Detection")
+    })
+
+    it("ignores non-test keys and non-true values", () => {
+        expect(findActiveDebugTest({ enableDebugMode: true, someOtherSetting: 5 })).toBeNull()
+    })
+})
+
+describe("activeSkillPlans", () => {
+    it("lists enabled plans in registry order with the threshold", () => {
+        const result = activeSkillPlans({ enableSkillPointCheck: true, skillPointCheck: 750, plans: { preFinals: { enabled: true }, careerComplete: { enabled: false } } })
+        expect(result.names).toEqual(["Skill Point Check", "Pre-Finals"])
+        expect(result.spThreshold).toBe(750)
+    })
+
+    it("omits the threshold and Skill Point Check title when it is off", () => {
+        const result = activeSkillPlans({ enableSkillPointCheck: false, skillPointCheck: 750, plans: { careerComplete: { enabled: true } } })
+        expect(result.names).toEqual(["Career Complete"])
+        expect(result.spThreshold).toBeNull()
+    })
+
+    it("treats a missing plan as disabled", () => {
+        const result = activeSkillPlans({ enableSkillPointCheck: false, plans: {} })
+        expect(result.names).toEqual([])
+        expect(result.spThreshold).toBeNull()
+    })
+})
+
+describe("abbreviateStatPriority", () => {
+    it("maps known stats in order and drops unknowns", () => {
+        expect(abbreviateStatPriority(["Speed", "Stamina", "Power", "Wit", "Guts"])).toEqual(["SPD", "STA", "POW", "WIT", "GUT"])
+        expect(abbreviateStatPriority([])).toEqual([])
+        expect(abbreviateStatPriority(["Nonsense"])).toEqual([])
+    })
+})
+
+describe("heroGlanceHasContent", () => {
+    const empty = { debugMode: false, activeTest: null, srs: false, planNames: [] as string[], priority: [] as string[] }
+
+    it("is false when nothing is active", () => {
+        expect(heroGlanceHasContent(empty)).toBe(false)
+    })
+
+    it("is true when any single piece is present", () => {
+        expect(heroGlanceHasContent({ ...empty, debugMode: true })).toBe(true)
+        expect(heroGlanceHasContent({ ...empty, activeTest: "Rainbow Detection" })).toBe(true)
+        expect(heroGlanceHasContent({ ...empty, srs: true })).toBe(true)
+        expect(heroGlanceHasContent({ ...empty, planNames: ["Pre-Finals"] })).toBe(true)
+        expect(heroGlanceHasContent({ ...empty, priority: ["SPD"] })).toBe(true)
+    })
+})

--- a/src/components/HeroStatusCard/heroGlanceData.ts
+++ b/src/components/HeroStatusCard/heroGlanceData.ts
@@ -1,0 +1,102 @@
+import type { Settings } from "../../context/BotStateContext"
+import { skillPlanSettingsPages } from "../../pages/SkillPlanSettings/config"
+
+// Stat priority abbreviations shown on the hero's Priority row.
+const STAT_ABBREVIATIONS: Record<string, string> = {
+    Speed: "SPD",
+    Stamina: "STA",
+    Power: "POW",
+    Guts: "GUT",
+    Wit: "WIT",
+}
+
+/** Minimal shape of the debug settings slice this module reads (only the boolean test toggles matter here). */
+interface DebugLike {
+    [key: string]: unknown
+}
+
+// Bind the scalar fields to the canonical Settings interface so a rename there surfaces here; `plans` stays a loose read since only `enabled` is used.
+type SkillsLike = Partial<Pick<Settings["skills"], "enableSkillPointCheck" | "skillPointCheck">> & {
+    /** Per-plan config keyed by plan id; only the `enabled` flag is read here. */
+    plans?: Record<string, { enabled?: boolean } | undefined>
+}
+
+/** Enabled skill plans plus the skill-point threshold, ready for the hero's Plans row. */
+export interface ActiveSkillPlans {
+    /** Display titles of the enabled plans, in registry order. */
+    names: string[]
+    /** The skill-point threshold when the Skill Point Check plan is on, else null. */
+    spThreshold: number | null
+}
+
+/** The derived values that decide whether the hero glance zone has anything to show. */
+export interface HeroGlanceContent {
+    /** Whether Debug Mode is on. */
+    debugMode: boolean
+    /** The armed debug test's display name, or null. */
+    activeTest: string | null
+    /** Whether the Smart Race Solver is on. */
+    srs: boolean
+    /** Enabled skill-plan titles. */
+    planNames: string[]
+    /** Ordered stat priority abbreviations. */
+    priority: string[]
+}
+
+/**
+ * Find the debug test currently armed and return its readable name (e.g. "Rainbow Detection"). The 11 test toggles are mutually exclusive, so at most one is on.
+ * The name is derived from the setting key so newly added tests are picked up without a hardcoded list.
+ * @param debug The debug settings slice.
+ * @returns The active test's display name, or null when no test is armed.
+ */
+export function findActiveDebugTest(debug: DebugLike): string | null {
+    const activeKey = Object.keys(debug).find((key) => /^debugMode_start.+Test$/.test(key) && debug[key] === true)
+    return activeKey ? prettifyDebugTestKey(activeKey) : null
+}
+
+/**
+ * Turn a debug-test setting key into a readable name: strip the `debugMode_start` prefix and `Test` suffix, then split camelCase.
+ * @param key The debug-test setting key (e.g. "debugMode_startRainbowDetectionTest").
+ * @returns The readable name (e.g. "Rainbow Detection").
+ */
+function prettifyDebugTestKey(key: string): string {
+    return key
+        .replace(/^debugMode_start/, "")
+        .replace(/Test$/, "")
+        .replace(/([a-z])([A-Z])/g, "$1 $2")
+        .trim()
+}
+
+/**
+ * Collect the enabled skill plans and the skill-point threshold for the hero's Plans row. The Skill Point Check plan is gated by `enableSkillPointCheck`;
+ * the other plans by their own `plans[key].enabled` flag. A plan missing from the live slice is treated as disabled (its default).
+ * @param skills The skills settings slice.
+ * @returns The enabled plan titles and the threshold (null when Skill Point Check is off).
+ */
+export function activeSkillPlans(skills: SkillsLike): ActiveSkillPlans {
+    const names: string[] = []
+    const skillPointCheckOn = skills.enableSkillPointCheck === true
+    if (skillPointCheckOn) names.push(skillPlanSettingsPages.skillPointCheck.title)
+    if (skills.plans?.preFinals?.enabled) names.push(skillPlanSettingsPages.preFinals.title)
+    if (skills.plans?.careerComplete?.enabled) names.push(skillPlanSettingsPages.careerComplete.title)
+    return { names, spThreshold: skillPointCheckOn ? (skills.skillPointCheck ?? null) : null }
+}
+
+/**
+ * Map an ordered stat priority list to short uppercase abbreviations (Speed -> SPD). Unknown entries are dropped.
+ * @param priority The ordered stat priority names.
+ * @returns The abbreviations in the same order.
+ */
+export function abbreviateStatPriority(priority: string[]): string[] {
+    return priority.map((stat) => STAT_ABBREVIATIONS[stat]).filter((abbr): abbr is string => abbr !== undefined)
+}
+
+/**
+ * Whether the hero glance zone has anything to render. Single source of truth for the "mount the glance at all" decision so the hairline divider is never left dangling
+ * over an empty zone. Mirrors the per-row guards inside `HeroGlance`.
+ * @param content The derived glance values.
+ * @returns True when at least one chip or row would render.
+ */
+export function heroGlanceHasContent(content: HeroGlanceContent): boolean {
+    return content.debugMode || content.activeTest !== null || content.srs || content.planNames.length > 0 || content.priority.length > 0
+}

--- a/src/components/HeroStatusCard/index.tsx
+++ b/src/components/HeroStatusCard/index.tsx
@@ -21,6 +21,8 @@ interface HeroStatusCardProps {
     startDisabled?: boolean
     /** Optional custom action rendered on the right side in place of the default Start button. */
     cta?: React.ReactNode
+    /** Optional "at a glance" zone rendered below a divider (active status chips, skill plans, stat priority). */
+    glance?: React.ReactNode
 }
 
 const STATUS_LABEL: Record<HeroStatus, string> = {
@@ -41,9 +43,10 @@ const BULLET = "●" // BLACK CIRCLE
  * @param onStart Press handler for the default Start CTA. Ignored when `cta` is provided.
  * @param startDisabled Whether the default Start button is disabled. Ignored when `cta` is provided.
  * @param cta Optional custom right-side action that replaces the default Start button.
- * @returns A brand-tinted card containing the status pill, profile name, and primary action.
+ * @param glance Optional "at a glance" zone rendered below a divider (active status chips, skill plans, stat priority).
+ * @returns A brand-tinted card containing the status pill, profile name, primary action, and optional glance zone.
  */
-const HeroStatusCard: React.FC<HeroStatusCardProps> = ({ status, profile, onStart, startDisabled = false, cta }) => {
+const HeroStatusCard: React.FC<HeroStatusCardProps> = ({ status, profile, onStart, startDisabled = false, cta, glance }) => {
     const { colors } = useTheme()
     // Status pill color: ready/running -> success token, stopped/error -> warning.
     const isHealthy = status === "ready" || status === "running"
@@ -68,6 +71,7 @@ const HeroStatusCard: React.FC<HeroStatusCardProps> = ({ status, profile, onStar
                     borderRadius: RADII.pill,
                 },
                 profile: { ...TYPE.h2, color: colors.text },
+                hairline: { height: 1, backgroundColor: colors.borderHair, marginHorizontal: SPACING.md },
             }),
         [colors, isHealthy]
     )
@@ -84,6 +88,12 @@ const HeroStatusCard: React.FC<HeroStatusCardProps> = ({ status, profile, onStar
                     </CustomButton>
                 )}
             </View>
+            {glance ? (
+                <>
+                    <View style={styles.hairline} />
+                    {glance}
+                </>
+            ) : null}
         </View>
     )
 }

--- a/src/components/ui/tinted-chip.tsx
+++ b/src/components/ui/tinted-chip.tsx
@@ -1,0 +1,73 @@
+import React, { useMemo } from "react"
+import { Pressable, StyleSheet, Text, View } from "react-native"
+import type { LucideIcon } from "lucide-react-native"
+import { useTheme } from "../../context/ThemeContext"
+import { TYPE } from "../../lib/type"
+import { SPACING } from "../../lib/spacing"
+import { RADII } from "../../lib/radii"
+
+/** Props for `TintedChip`. */
+export interface TintedChipProps {
+    /** Lucide icon rendered at the start of the chip. */
+    icon: LucideIcon
+    /** Uppercase mono label shown after the icon. */
+    label: string
+    /** Resolved tint color for the icon and label. */
+    tint: string
+    /** Optional press handler; when set the chip becomes a tappable shortcut with ripple feedback. */
+    onPress?: () => void
+    /** Icon size in px. Defaults to 12. */
+    iconSize?: number
+}
+
+/**
+ * A small pill with a tinted Lucide icon and an uppercase mono label on a neutral raised surface. Shared by the Event Log action chips and the Home hero
+ * status chips so both read the same. Renders a `Pressable` with ripple when `onPress` is given, otherwise a static `View`.
+ * @param icon The Lucide icon to render.
+ * @param label The uppercase mono label.
+ * @param tint The resolved tint color for the icon and label.
+ * @param onPress Optional press handler that turns the chip into a shortcut.
+ * @param iconSize Icon size in px (default 12).
+ * @returns A tinted icon-and-label pill.
+ */
+const TintedChipImpl = ({ icon: Icon, label, tint, onPress, iconSize = 12 }: TintedChipProps) => {
+    const { colors } = useTheme()
+    const styles = useMemo(
+        () =>
+            StyleSheet.create({
+                chip: {
+                    flexDirection: "row",
+                    alignItems: "center",
+                    gap: SPACING.xs,
+                    paddingHorizontal: SPACING.sm,
+                    paddingVertical: 3,
+                    borderRadius: RADII.pill,
+                    backgroundColor: colors.surfaceRaised,
+                    borderWidth: 1,
+                    borderColor: colors.borderHair,
+                    overflow: "hidden",
+                },
+                label: { ...TYPE.monoLabel, color: tint },
+            }),
+        [colors, tint]
+    )
+
+    const content = (
+        <>
+            <Icon size={iconSize} color={tint} />
+            <Text style={styles.label}>{label}</Text>
+        </>
+    )
+
+    if (onPress) {
+        return (
+            <Pressable onPress={onPress} android_ripple={{ color: colors.ripple }} style={styles.chip}>
+                {content}
+            </Pressable>
+        )
+    }
+    return <View style={styles.chip}>{content}</View>
+}
+
+export const TintedChip = React.memo(TintedChipImpl)
+export default TintedChip

--- a/src/components/ui/value-pill.tsx
+++ b/src/components/ui/value-pill.tsx
@@ -9,17 +9,33 @@ import { RADII } from "../../lib/radii"
 export interface ValuePillProps {
     /** The current value to display inside the pill. */
     label: string
+    /** Color treatment: "brand" (cyan, default) for picker values, "neutral" (muted, hairline-bordered) for read-only tags. */
+    tone?: "brand" | "neutral"
 }
 
 /**
- * A small cyan pill showing a picker's current value. Used in the `right` slot of a `Row` (or a `Pressable` cell) that opens a selector modal.
+ * A small pill showing a picker's current value or a read-only tag. Used in the `right` slot of a `Row` (or a `Pressable` cell) that opens a selector modal.
  * @param label The value text rendered inside the pill.
+ * @param tone Color treatment: "brand" (default) or "neutral".
  * @returns A styled `Text` node sized to fit the value.
  */
-const ValuePillImpl = ({ label }: ValuePillProps) => {
+const ValuePillImpl = ({ label, tone = "brand" }: ValuePillProps) => {
     const { colors } = useTheme()
+    const neutral = tone === "neutral"
     return (
-        <Text style={{ ...TYPE.monoLabel, color: colors.brand, paddingHorizontal: SPACING.sm, paddingVertical: 2, backgroundColor: colors.brandSubtle, borderRadius: RADII.pill, overflow: "hidden" }}>
+        <Text
+            style={{
+                ...TYPE.monoLabel,
+                color: neutral ? colors.textMuted : colors.brand,
+                paddingHorizontal: SPACING.sm,
+                paddingVertical: 2,
+                backgroundColor: neutral ? colors.surfaceRaised : colors.brandSubtle,
+                borderRadius: RADII.pill,
+                borderWidth: neutral ? 1 : 0,
+                borderColor: colors.borderHair,
+                overflow: "hidden",
+            }}
+        >
             {label}
         </Text>
     )

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -1,7 +1,8 @@
 import * as Application from "expo-application"
 import MessageLog from "../../components/MessageLog"
-import { useContext, useEffect, useMemo, useRef, useState } from "react"
-import { BotMetaContext, GeneralMiscContext } from "../../context/BotStateContext"
+import { useCallback, useContext, useEffect, useMemo, useRef, useState } from "react"
+import { BotMetaContext, GeneralMiscContext, DebugContext, RacingContext, SkillsContext, TrainingContext } from "../../context/BotStateContext"
+import { useNavigation, CommonActions } from "@react-navigation/native"
 import { useSettings } from "../../context/SettingsContext"
 import { logWithTimestamp, logErrorWithTimestamp } from "../../lib/logger"
 import { Animated, DeviceEventEmitter, StyleSheet, View, NativeModules } from "react-native"
@@ -18,6 +19,8 @@ import SelectButton from "../../components/SelectButton"
 import PermissionSetupDialog from "../../components/PermissionSetupDialog"
 import { loadDeviceCapabilities, shouldSuggestX8664Variant } from "../../lib/chat/deviceCapabilities"
 import HeroStatusCard, { HeroStatus } from "../../components/HeroStatusCard"
+import HeroGlance, { HeroGlanceTarget } from "../../components/HeroStatusCard/HeroGlance"
+import { findActiveDebugTest, activeSkillPlans, abbreviateStatPriority, heroGlanceHasContent } from "../../components/HeroStatusCard/heroGlanceData"
 import { useProfileContext, DEFAULT_PROFILE_NAME } from "../../context/ProfileContext"
 import { SPACING } from "../../lib/spacing"
 
@@ -45,6 +48,14 @@ const styles = StyleSheet.create({
         width: 100,
     },
 })
+
+// Maps a hero glance target to its screen name inside the nested Settings stack navigator.
+const HERO_NAV_ROUTES: Record<HeroGlanceTarget, string> = {
+    debug: "DebugSettings",
+    srs: "SmartRaceSolverSettings",
+    skills: "Skills",
+    training: "TrainingSettings",
+}
 
 /**
  * List of scenarios that are supported by the app.
@@ -87,9 +98,14 @@ const Home = () => {
 
     const { readyStatus, setReadyStatus, setAppName, setAppVersion } = useContext(BotMetaContext)
     const { general, updateGeneral } = useContext(GeneralMiscContext)
+    const { debug } = useContext(DebugContext)
+    const { racing } = useContext(RacingContext)
+    const { skills } = useContext(SkillsContext)
+    const { training } = useContext(TrainingContext)
     const mlc = useContext(MessageLogDispatchContext)
     const { saveSettings } = useSettings()
     const { currentProfileName } = useProfileContext()
+    const navigation = useNavigation()
 
     const pulseAnim = useRef(new Animated.Value(1)).current
 
@@ -346,6 +362,17 @@ Note: Reinstall using the x86_64 release APK for much better performance.`)
     // or ABI mismatch) surface as "error". An unselected scenario lands on "stopped". Otherwise the bot is "ready".
     const heroStatus: HeroStatus = isRunning ? "running" : unsupportedReason !== null || abiMismatch ? "error" : readyStatus && deviceMetrics !== null ? "ready" : "stopped"
     const heroProfile = currentProfileName ?? DEFAULT_PROFILE_NAME
+
+    // Derive the hero "at a glance" data from the settings slices. Each piece renders only when it has something to show.
+    const activeTest = useMemo(() => findActiveDebugTest(debug), [debug])
+    const { names: planNames, spThreshold } = useMemo(() => activeSkillPlans(skills), [skills])
+    const statPriority = useMemo(() => abbreviateStatPriority(training.statPrioritization ?? []), [training.statPrioritization])
+    const hasGlance = heroGlanceHasContent({ debugMode: debug.enableDebugMode, activeTest, srs: racing.enableSmartRaceSolver, planNames, priority: statPriority })
+    const handleHeroNavigate = useCallback(
+        (target: HeroGlanceTarget) => navigation.dispatch(CommonActions.navigate({ name: "Settings", params: { screen: HERO_NAV_ROUTES[target], initial: false } })),
+        [navigation]
+    )
+
     return (
         <View style={styles.root}>
             {/* MessageLog uses FlashList, which doesn't support sticky headers the same way as ScrollView, so PageHeader stays a sibling above (non-sticky). */}
@@ -355,6 +382,19 @@ Note: Reinstall using the x86_64 release APK for much better performance.`)
                 <HeroStatusCard
                     status={heroStatus}
                     profile={heroProfile}
+                    glance={
+                        hasGlance ? (
+                            <HeroGlance
+                                debugMode={debug.enableDebugMode}
+                                activeTest={activeTest}
+                                srs={racing.enableSmartRaceSolver}
+                                planNames={planNames}
+                                spThreshold={spThreshold}
+                                priority={statPriority}
+                                onNavigate={handleHeroNavigate}
+                            />
+                        ) : undefined
+                    }
                     cta={
                         <SelectButton
                             variant={getSelectButtonVariant()}


### PR DESCRIPTION
## Description

- This PR expands the Home hero card with an "at a glance" zone that surfaces the bot's active configuration: `Debug Mode`, the armed Debug Test, and the Smart Race Solver as chips, plus the enabled skill plans (with the skill-point threshold) and the current stat priority order.
- Every chip and row is a tappable shortcut that deep-links into its settings screen, and each piece renders only when it's active so an all-off config keeps the hero compact.