### PR TITLE
Read all trainee conditions and scroll the full list

### DIFF
--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Campaign.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Campaign.kt
@@ -57,6 +57,7 @@ import com.steve1316.uma_android_automation.components.LabelScheduledRace
 import com.steve1316.uma_android_automation.components.LabelStatTableHeaderSkillPoints
 import com.steve1316.uma_android_automation.components.LabelUmamusumeClassFans
 import com.steve1316.uma_android_automation.types.BoundingBox
+import com.steve1316.uma_android_automation.types.ConditionList
 import com.steve1316.uma_android_automation.types.DateMonth
 import com.steve1316.uma_android_automation.types.DatePhase
 import com.steve1316.uma_android_automation.types.DateYear
@@ -597,6 +598,10 @@ abstract class Campaign(game: Game) : Task(game) {
                     // Reset this flag since our preferred running style has changed.
                     trainee.bHasSetRunningStyle = false
                 }
+
+                // Read the trainee's active conditions from the Conditions sublist, scrolling if the list overflows.
+                val conditions = ConditionList(game).parseDetailsConditionsTab()
+                trainee.setConditions(conditions.positive, conditions.negative)
                 result.dialog.close(game.imageUtils)
             }
 

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/Trackblazer.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/Trackblazer.kt
@@ -1596,14 +1596,14 @@ class Trackblazer(game: Game) : Campaign(game) {
                                 if (itemName == "Miracle Cure" || itemName == "Rich Hand Cream") {
                                     // We want to buy as many of these when possible as we will be racing above the consecutive race limit often.
                                     5
-                                } else if (condition != null && trainee.currentNegativeStatuses.contains(condition)) {
+                                } else if (condition != null && trainee.hasNegativeStatus(condition)) {
                                     1
                                 } else {
                                     0
                                 }
                             } else {
                                 val condition = goodConditionMap[itemName]
-                                if (condition != null && !trainee.currentPositiveStatuses.contains(condition)) {
+                                if (condition != null && !trainee.hasPositiveStatus(condition)) {
                                     1
                                 } else {
                                     0
@@ -2878,7 +2878,7 @@ class Trackblazer(game: Game) : Campaign(game) {
     private fun canHealActiveNegativeStatus(itemName: String, trainee: Trainee): Boolean {
         if (itemName == "Miracle Cure") return true
         val target = badConditionMap[itemName] ?: return false
-        return trainee.currentNegativeStatuses.contains(target)
+        return trainee.hasNegativeStatus(target)
     }
 
     /**

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/types/ConditionList.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/types/ConditionList.kt
@@ -26,6 +26,18 @@ private const val MAX_CONDITION_SCROLLS = 6
 /** Holds the trainee's active conditions read from the Details Conditions sublist. */
 data class DetailsConditionsResult(val positive: List<String>, val negative: List<String>)
 
+/** Outcome of reading one condition row. */
+private sealed interface RowRead {
+    /** The row is not a condition pill (color mismatch): the sublist ends here. */
+    object EndOfList : RowRead
+
+    /** The row is a condition pill but its name did not OCR cleanly: skip it, keep scanning. */
+    object Unreadable : RowRead
+
+    /** A successfully read condition. */
+    data class Condition(val name: String, val isNegative: Boolean) : RowRead
+}
+
 // //////////////////////////////////////////////////////////////////////////////////////////////////
 // //////////////////////////////////////////////////////////////////////////////////////////////////
 // Reader
@@ -33,7 +45,8 @@ data class DetailsConditionsResult(val positive: List<String>, val negative: Lis
 /**
  * Reads the trainee's active conditions from the Details dialog's Conditions sublist (the default tab).
  * Polarity is decided by the pill background color, independent of any name list. Each name is stored as
- * raw OCR text and deduped fuzzily across scroll passes. Mirrors [SkillList.parseDetailsSkillsTab].
+ * raw OCR text and deduped fuzzily across scroll passes. Scrolls the sublist until it is exhausted, the same approach used for other
+ * scrollable Details lists.
  *
  * @param game A reference to the [Game] instance for screen capture and gestures.
  */
@@ -59,17 +72,21 @@ class ConditionList(private val game: Game) {
             var newFound = 0
             var frameFull = true
             for (row in 0 until VISIBLE_CONDITION_ROWS) {
-                val read = readConditionRow(sourceBitmap, refPoint, row, pass)
-                if (read == null) {
+                when (val read = readConditionRow(sourceBitmap, refPoint, row, pass)) {
                     // A non-pill slot means the sublist ends inside this frame, so nothing more can be below.
-                    frameFull = false
-                    break
-                }
-                val (name, isBad) = read
-                val list = if (isBad) negatives else positives
-                if (!fuzzyMatchesAny(name, list, STATUS_DEDUP_THRESHOLD)) {
-                    list.add(name)
-                    newFound++
+                    is RowRead.EndOfList -> {
+                        frameFull = false
+                        break
+                    }
+                    // A pill is present but did not OCR cleanly this pass. Skip its name but keep scanning: an overlapping later pass may read it.
+                    is RowRead.Unreadable -> Unit
+                    is RowRead.Condition -> {
+                        val list = if (read.isNegative) negatives else positives
+                        if (!fuzzyMatchesAny(read.name, list, STATUS_DEDUP_THRESHOLD)) {
+                            list.add(read.name)
+                            newFound++
+                        }
+                    }
                 }
             }
             emptyPasses = if (newFound == 0) emptyPasses + 1 else 0
@@ -89,15 +106,16 @@ class ConditionList(private val game: Game) {
      * @param refPoint The anchored reference point of the Conditions sublist.
      * @param row The 0-indexed visible row.
      * @param pass The current scroll pass, used only for debug crop naming.
-     * @return A pair of (raw OCR name, isNegative), or null when the row is not a condition pill.
+     * @return [RowRead.Condition] with the raw name and polarity, [RowRead.Unreadable] when a pill is present but its name did not OCR,
+     * or [RowRead.EndOfList] when the row is not a condition pill.
      */
-    private fun readConditionRow(sourceBitmap: Bitmap, refPoint: Point, row: Int, pass: Int): Pair<String, Boolean>? {
+    private fun readConditionRow(sourceBitmap: Bitmap, refPoint: Point, row: Int, pass: Int): RowRead {
         val imageUtils = game.imageUtils
         val cropX = imageUtils.relX(refPoint.x, 10)
         val cropY = imageUtils.relY(refPoint.y, 85 + (row * 180))
         val cropWidth = imageUtils.relWidth(455)
         val cropHeight = imageUtils.relHeight(55)
-        val croppedBitmap = imageUtils.createSafeBitmap(sourceBitmap, cropX, cropY, cropWidth, cropHeight, "conditionRow_${pass}_$row") ?: return null
+        val croppedBitmap = imageUtils.createSafeBitmap(sourceBitmap, cropX, cropY, cropWidth, cropHeight, "conditionRow_${pass}_$row") ?: return RowRead.EndOfList
 
         // Sample the pill background near the bottom-right to avoid text overlap.
         val pixel = croppedBitmap.getPixel(croppedBitmap.width - 20, croppedBitmap.height - 20)
@@ -107,16 +125,16 @@ class ConditionList(private val game: Game) {
         // Bad color: #519FFB (blue). Good color: #FF9741 (orange).
         val isBad = (r in 70..95 && g in 145..175 && b in 240..255)
         val isGood = (r in 240..255 && g in 140..165 && b in 50..80)
-        if (!isBad && !isGood) return null
+        if (!isBad && !isGood) return RowRead.EndOfList
 
         val statusTitle =
             imageUtils.performOCROnRegion(sourceBitmap, cropX, cropY, cropWidth, cropHeight, useThreshold = false, useGrayscale = true, scale = 2.0, ocrEngine = "mlkit", debugName = "conditionRow_${pass}_$row").trim()
-        if (statusTitle.length < 3) return null
-        return Pair(statusTitle, isBad)
+        if (statusTitle.length < 3) return RowRead.Unreadable
+        return RowRead.Condition(statusTitle, isBad)
     }
 
     /**
-     * Scrolls the Conditions sublist up with a short, slow, overlapping swipe (anti-fling), mirroring [SkillList.scrollSkillsPanel].
+     * Scrolls the Conditions sublist up with a short, slow, overlapping swipe (anti-fling) to avoid overshooting rows.
      * Endpoints are calibrated against a crowded conditions screen.
      */
     private fun scrollConditionsPanel() {

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/types/ConditionList.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/types/ConditionList.kt
@@ -1,0 +1,127 @@
+package com.steve1316.uma_android_automation.types
+
+import android.graphics.Bitmap
+import android.graphics.Color
+import com.steve1316.automation_library.data.SharedData
+import com.steve1316.automation_library.utils.MessageLog
+import com.steve1316.uma_android_automation.MainActivity
+import com.steve1316.uma_android_automation.bot.Game
+import com.steve1316.uma_android_automation.components.ButtonConditions
+import org.opencv.core.Point
+
+// //////////////////////////////////////////////////////////////////////////////////////////////////
+// //////////////////////////////////////////////////////////////////////////////////////////////////
+// Constants
+
+/** Condition rows visible in the Details Conditions sublist at once (calibrated live). */
+private const val VISIBLE_CONDITION_ROWS = 3
+
+/** Maximum scroll passes. Conditions never approach the skill count, so this stays small. */
+private const val MAX_CONDITION_SCROLLS = 6
+
+// //////////////////////////////////////////////////////////////////////////////////////////////////
+// //////////////////////////////////////////////////////////////////////////////////////////////////
+// Result type
+
+/** Holds the trainee's active conditions read from the Details Conditions sublist. */
+data class DetailsConditionsResult(val positive: List<String>, val negative: List<String>)
+
+// //////////////////////////////////////////////////////////////////////////////////////////////////
+// //////////////////////////////////////////////////////////////////////////////////////////////////
+// Reader
+
+/**
+ * Reads the trainee's active conditions from the Details dialog's Conditions sublist (the default tab).
+ * Polarity is decided by the pill background color, independent of any name list. Each name is stored as
+ * raw OCR text and deduped fuzzily across scroll passes. Mirrors [SkillList.parseDetailsSkillsTab].
+ *
+ * @param game A reference to the [Game] instance for screen capture and gestures.
+ */
+class ConditionList(private val game: Game) {
+    companion object {
+        const val TAG: String = "[${MainActivity.loggerTag}]ConditionList"
+    }
+
+    /**
+     * Reads every active condition, scrolling the sublist until a frame ends short or two passes reveal nothing new.
+     * The common case (0 to 3 conditions) ends on the first frame with no swipe.
+     *
+     * @return The deduped positive and negative condition names.
+     */
+    fun parseDetailsConditionsTab(): DetailsConditionsResult {
+        val imageUtils = game.imageUtils
+        val refPoint = ButtonConditions.findImageWithBitmap(imageUtils = imageUtils, sourceBitmap = imageUtils.getSourceBitmap()) ?: Point(285.0, 1210.0)
+        val positives = mutableListOf<String>()
+        val negatives = mutableListOf<String>()
+        var emptyPasses = 0
+        for (pass in 0..MAX_CONDITION_SCROLLS) {
+            val sourceBitmap = imageUtils.getSourceBitmap()
+            var newFound = 0
+            var frameFull = true
+            for (row in 0 until VISIBLE_CONDITION_ROWS) {
+                val read = readConditionRow(sourceBitmap, refPoint, row, pass)
+                if (read == null) {
+                    // A non-pill slot means the sublist ends inside this frame, so nothing more can be below.
+                    frameFull = false
+                    break
+                }
+                val (name, isBad) = read
+                val list = if (isBad) negatives else positives
+                if (!fuzzyMatchesAny(name, list, STATUS_DEDUP_THRESHOLD)) {
+                    list.add(name)
+                    newFound++
+                }
+            }
+            emptyPasses = if (newFound == 0) emptyPasses + 1 else 0
+            // Frame ended short: bottom reached. Otherwise stop only after two empty passes so a fling settling mid-row does not end the scan early.
+            if (!frameFull) break
+            if (pass > 0 && emptyPasses >= 2) break
+            scrollConditionsPanel()
+        }
+        MessageLog.i(TAG, "[INFO] Read ${positives.size} positive, ${negatives.size} negative conditions. Positive: ${positives.joinToString(", ")}. Negative: ${negatives.joinToString(", ")}.")
+        return DetailsConditionsResult(positives, negatives)
+    }
+
+    /**
+     * Reads one condition row: classifies polarity by the pill background color, then OCRs the name.
+     *
+     * @param sourceBitmap The current screen bitmap.
+     * @param refPoint The anchored reference point of the Conditions sublist.
+     * @param row The 0-indexed visible row.
+     * @param pass The current scroll pass, used only for debug crop naming.
+     * @return A pair of (raw OCR name, isNegative), or null when the row is not a condition pill.
+     */
+    private fun readConditionRow(sourceBitmap: Bitmap, refPoint: Point, row: Int, pass: Int): Pair<String, Boolean>? {
+        val imageUtils = game.imageUtils
+        val cropX = imageUtils.relX(refPoint.x, 10)
+        val cropY = imageUtils.relY(refPoint.y, 85 + (row * 180))
+        val cropWidth = imageUtils.relWidth(455)
+        val cropHeight = imageUtils.relHeight(55)
+        val croppedBitmap = imageUtils.createSafeBitmap(sourceBitmap, cropX, cropY, cropWidth, cropHeight, "conditionRow_${pass}_$row") ?: return null
+
+        // Sample the pill background near the bottom-right to avoid text overlap.
+        val pixel = croppedBitmap.getPixel(croppedBitmap.width - 20, croppedBitmap.height - 20)
+        val r = Color.red(pixel)
+        val g = Color.green(pixel)
+        val b = Color.blue(pixel)
+        // Bad color: #519FFB (blue). Good color: #FF9741 (orange).
+        val isBad = (r in 70..95 && g in 145..175 && b in 240..255)
+        val isGood = (r in 240..255 && g in 140..165 && b in 50..80)
+        if (!isBad && !isGood) return null
+
+        val statusTitle =
+            imageUtils.performOCROnRegion(sourceBitmap, cropX, cropY, cropWidth, cropHeight, useThreshold = false, useGrayscale = true, scale = 2.0, ocrEngine = "mlkit", debugName = "conditionRow_${pass}_$row").trim()
+        if (statusTitle.length < 3) return null
+        return Pair(statusTitle, isBad)
+    }
+
+    /**
+     * Scrolls the Conditions sublist up with a short, slow, overlapping swipe (anti-fling), mirroring [SkillList.scrollSkillsPanel].
+     * Endpoints are calibrated against a crowded conditions screen.
+     */
+    private fun scrollConditionsPanel() {
+        val cx = (SharedData.displayWidth / 2).toFloat()
+        game.gestureUtils.swipe(cx, (SharedData.displayHeight * 0.82).toFloat(), cx, (SharedData.displayHeight * 0.70).toFloat(), 700L)
+        game.wait(0.5, skipWaitingForLoading = true)
+    }
+}

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/types/ConditionList.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/types/ConditionList.kt
@@ -93,7 +93,7 @@ class ConditionList(private val game: Game) {
             // Frame ended short: bottom reached. Otherwise stop only after two empty passes so a fling settling mid-row does not end the scan early.
             if (!frameFull) break
             if (pass > 0 && emptyPasses >= 2) break
-            scrollConditionsPanel()
+            if (pass < MAX_CONDITION_SCROLLS) scrollConditionsPanel()
         }
         MessageLog.i(TAG, "[INFO] Read ${positives.size} positive, ${negatives.size} negative conditions. Positive: ${positives.joinToString(", ")}. Negative: ${negatives.joinToString(", ")}.")
         return DetailsConditionsResult(positives, negatives)

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/types/StatusMatching.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/types/StatusMatching.kt
@@ -13,6 +13,9 @@ const val STATUS_DEDUP_THRESHOLD = 0.9
 /** Similarity floor for matching a clean canonical condition name against a possibly-noisy raw read. */
 const val STATUS_QUERY_THRESHOLD = 0.8
 
+/** Shared, stateless Jaro-Winkler similarity service reused across all match calls. */
+private val SIMILARITY_SERVICE = StringSimilarityServiceImpl(JaroWinklerStrategy())
+
 /**
  * Returns true when [candidate] Jaro-Winkler matches any entry in [names] at or above [threshold].
  * Pure and list-free: used both to dedup raw OCR reads and to answer canonical-name membership queries.
@@ -24,7 +27,6 @@ const val STATUS_QUERY_THRESHOLD = 0.8
  */
 fun fuzzyMatchesAny(candidate: String, names: List<String>, threshold: Double): Boolean {
     if (candidate.isBlank() || names.isEmpty()) return false
-    val service = StringSimilarityServiceImpl(JaroWinklerStrategy())
     val lowered = candidate.lowercase()
-    return names.any { service.score(lowered, it.lowercase()) >= threshold }
+    return names.any { SIMILARITY_SERVICE.score(lowered, it.lowercase()) >= threshold }
 }

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/types/StatusMatching.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/types/StatusMatching.kt
@@ -1,0 +1,30 @@
+package com.steve1316.uma_android_automation.types
+
+import net.ricecode.similarity.JaroWinklerStrategy
+import net.ricecode.similarity.StringSimilarityServiceImpl
+
+// //////////////////////////////////////////////////////////////////////////////////////////////////
+// //////////////////////////////////////////////////////////////////////////////////////////////////
+// Thresholds
+
+/** Similarity floor for treating two raw condition reads as the same pill (dedup across scroll passes). */
+const val STATUS_DEDUP_THRESHOLD = 0.9
+
+/** Similarity floor for matching a clean canonical condition name against a possibly-noisy raw read. */
+const val STATUS_QUERY_THRESHOLD = 0.8
+
+/**
+ * Returns true when [candidate] Jaro-Winkler matches any entry in [names] at or above [threshold].
+ * Pure and list-free: used both to dedup raw OCR reads and to answer canonical-name membership queries.
+ *
+ * @param candidate The raw or canonical name to test.
+ * @param names The names to compare against.
+ * @param threshold The similarity floor (0.0 to 1.0).
+ * @return True when at least one name meets the threshold.
+ */
+fun fuzzyMatchesAny(candidate: String, names: List<String>, threshold: Double): Boolean {
+    if (candidate.isBlank() || names.isEmpty()) return false
+    val service = StringSimilarityServiceImpl(JaroWinklerStrategy())
+    val lowered = candidate.lowercase()
+    return names.any { service.score(lowered, it.lowercase()) >= threshold }
+}

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/types/Trainee.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/types/Trainee.kt
@@ -527,6 +527,37 @@ class Trainee {
     }
 
     /**
+     * Replaces the trainee's active conditions with a freshly-read set and logs them.
+     *
+     * @param positive The positive condition names read from the Conditions sublist.
+     * @param negative The negative condition names read from the Conditions sublist.
+     */
+    fun setConditions(positive: List<String>, negative: List<String>) {
+        currentPositiveStatuses.clear()
+        currentPositiveStatuses.addAll(positive)
+        currentNegativeStatuses.clear()
+        currentNegativeStatuses.addAll(negative)
+        if (currentPositiveStatuses.isNotEmpty()) MessageLog.v(TAG, "[TRAINEE] Positive Statuses: ${currentPositiveStatuses.joinToString(", ")}")
+        if (currentNegativeStatuses.isNotEmpty()) MessageLog.v(TAG, "[TRAINEE] Negative Statuses: ${currentNegativeStatuses.joinToString(", ")}")
+    }
+
+    /**
+     * Returns true when [name] fuzzy-matches any active positive condition. Tolerant of OCR noise since reads are stored raw.
+     *
+     * @param name The canonical positive condition name to look for.
+     * @return True when a raw positive read matches at the query threshold.
+     */
+    fun hasPositiveStatus(name: String): Boolean = fuzzyMatchesAny(name, currentPositiveStatuses, STATUS_QUERY_THRESHOLD)
+
+    /**
+     * Returns true when [name] fuzzy-matches any active negative condition. Tolerant of OCR noise since reads are stored raw.
+     *
+     * @param name The canonical negative condition name to look for.
+     * @return True when a raw negative read matches at the query threshold.
+     */
+    fun hasNegativeStatus(name: String): Boolean = fuzzyMatchesAny(name, currentNegativeStatuses, STATUS_QUERY_THRESHOLD)
+
+    /**
      * Reads the trainee's name from the Umamusume Details dialog using color-filtered OCR.
      *
      * The name text uses a uniform color #794016 (Brown-ish). This method uses [LabelStatTrackSurface] as a dynamic reference point to calculate the name's position on the screen.

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/types/Trainee.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/types/Trainee.kt
@@ -6,7 +6,6 @@ import com.steve1316.automation_library.utils.BotService
 import com.steve1316.automation_library.utils.MessageLog
 import com.steve1316.automation_library.utils.SettingsHelper
 import com.steve1316.uma_android_automation.MainActivity
-import com.steve1316.uma_android_automation.components.ButtonConditions
 import com.steve1316.uma_android_automation.components.ComponentInterface
 import com.steve1316.uma_android_automation.components.IconMoodAwful
 import com.steve1316.uma_android_automation.components.IconMoodBad
@@ -27,15 +26,11 @@ import com.steve1316.uma_android_automation.components.LabelStatTrackSurface
 import com.steve1316.uma_android_automation.types.Aptitude
 import com.steve1316.uma_android_automation.types.FanCountClass
 import com.steve1316.uma_android_automation.types.Mood
-import com.steve1316.uma_android_automation.types.NegativeStatus
-import com.steve1316.uma_android_automation.types.PositiveStatus
 import com.steve1316.uma_android_automation.types.RunningStyle
 import com.steve1316.uma_android_automation.types.StatName
 import com.steve1316.uma_android_automation.types.TrackDistance
 import com.steve1316.uma_android_automation.types.TrackSurface
 import com.steve1316.uma_android_automation.utils.CustomImageUtils
-import net.ricecode.similarity.JaroWinklerStrategy
-import net.ricecode.similarity.StringSimilarityServiceImpl
 import org.opencv.core.Point
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CountDownLatch
@@ -521,7 +516,6 @@ class Trainee {
         updateTrackSurfaceAptitudes(imageUtils = imageUtils)
         updateTrackDistanceAptitudes(imageUtils = imageUtils)
         updateRunningStyleAptitudes(imageUtils = imageUtils)
-        updateConditions(imageUtils = imageUtils)
 
         bHasUpdatedAptitudes = true
     }
@@ -613,118 +607,6 @@ class Trainee {
         } else {
             MessageLog.w(TAG, "[WARN] readName:: Could not detect Trainee name from the aptitude dialog.")
         }
-    }
-
-    /**
-     * Reads the trainee's current conditions (positive and negative) from the Umamusume Details dialog.
-     *
-     * Conditions are categorized by their background color:
-     * - Negative Condition: #519FFB (Blue-ish)
-     * - Positive Condition: #FF9741 (Orange-ish)
-     *
-     * @param imageUtils Reference to a [CustomImageUtils] instance.
-     */
-    private fun updateConditions(imageUtils: CustomImageUtils) {
-        val sourceBitmap = imageUtils.getSourceBitmap()
-        val refPoint = ButtonConditions.findImageWithBitmap(imageUtils = imageUtils, sourceBitmap = sourceBitmap) ?: Point(285.0, 1210.0)
-        currentPositiveStatuses.clear()
-        currentNegativeStatuses.clear()
-
-        for (i in 0 until 3) {
-            val offsetX = 10
-            val offsetY = 85 + (i * 180)
-            val cropX = imageUtils.relX(refPoint.x, offsetX)
-            val cropY = imageUtils.relY(refPoint.y, offsetY)
-            val cropWidth = imageUtils.relWidth(455)
-            val cropHeight = imageUtils.relHeight(55)
-
-            val croppedBitmap = imageUtils.createSafeBitmap(sourceBitmap, cropX, cropY, cropWidth, cropHeight, "updateConditions crop $i") ?: continue
-
-            // Identify the status type by sampling the background color of the status label.
-            // Adjusted samping positions to avoid accidental text overlap causing incorrect color matches.
-            val sampleX = croppedBitmap.width - 20
-            val sampleY = croppedBitmap.height - 20
-            val pixel = croppedBitmap.getPixel(sampleX, sampleY)
-            val r = android.graphics.Color.red(pixel)
-            val g = android.graphics.Color.green(pixel)
-            val b = android.graphics.Color.blue(pixel)
-            MessageLog.d(TAG, "[DEBUG] updateConditions:: Checking condition colors [$r, $g, $b] at ($cropX, $cropY)")
-            // Bad color: #519FFB. Good color: #FF9741.
-            val isBad = (r in 70..95 && g in 145..175 && b in 240..255)
-            val isGood = (r in 240..255 && g in 140..165 && b in 50..80)
-
-            if (isBad || isGood) {
-                val statusTitle =
-                    imageUtils.performOCROnRegion(
-                        sourceBitmap,
-                        cropX,
-                        cropY,
-                        cropWidth,
-                        cropHeight,
-                        useThreshold = false,
-                        useGrayscale = true,
-                        scale = 2.0,
-                        ocrEngine = "mlkit",
-                        debugName = "updateConditions_status_$i",
-                    ).trim()
-                if (statusTitle.isNotEmpty()) {
-                    val expectedList = if (isBad) NegativeStatus.names else PositiveStatus.names
-                    val match = findClosestMatch(statusTitle, expectedList)
-
-                    if (match != null) {
-                        if (isBad) {
-                            currentNegativeStatuses.add(match)
-                        } else {
-                            currentPositiveStatuses.add(match)
-                        }
-                    } else if (statusTitle.length >= 3) {
-                        // If no match found, but it's long enough, add the original OCR text.
-                        // This is done so we can see what was detected and potentially add it to the lists.
-                        if (isBad) {
-                            currentNegativeStatuses.add(statusTitle)
-                        } else {
-                            currentPositiveStatuses.add(statusTitle)
-                        }
-                    }
-                }
-            } else {
-                // Break once we encounter a non-status pixel.
-                break
-            }
-        }
-        // Remote log output consistency
-        if (currentPositiveStatuses.isNotEmpty()) {
-            MessageLog.v(TAG, "[TRAINEE] Positive Statuses: ${currentPositiveStatuses.joinToString(", ")}")
-        }
-        if (currentNegativeStatuses.isNotEmpty()) {
-            MessageLog.v(TAG, "[TRAINEE] Negative Statuses: ${currentNegativeStatuses.joinToString(", ")}")
-        }
-    }
-
-    /**
-     * Finds the closest match for a detected OCR string from a known list of statuses.
-     *
-     * @param ocrText The raw text returned by the OCR engine.
-     * @param expectedList List of valid status names to compare against.
-     * @param threshold Similarity threshold (0.0 to 1.0).
-     * @return The matched status string, or null if no match is confident enough.
-     */
-    private fun findClosestMatch(ocrText: String, expectedList: List<String>, threshold: Double = 0.8): String? {
-        val strategy = JaroWinklerStrategy()
-        val service = StringSimilarityServiceImpl(strategy)
-
-        var bestMatch: String? = null
-        var bestScore = 0.0
-
-        for (expected in expectedList) {
-            val score = service.score(ocrText.lowercase(), expected.lowercase())
-            if (score > bestScore) {
-                bestScore = score
-                bestMatch = expected
-            }
-        }
-
-        return if (bestScore >= threshold) bestMatch else null
     }
 
     /**

--- a/android/app/src/test/java/com/steve1316/uma_android_automation/types/FuzzyStatusMatchTest.kt
+++ b/android/app/src/test/java/com/steve1316/uma_android_automation/types/FuzzyStatusMatchTest.kt
@@ -1,0 +1,57 @@
+package com.steve1316.uma_android_automation.types
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit tests for [fuzzyMatchesAny], the pure Jaro-Winkler helper that both dedups raw condition reads
+ * (0.9) and answers canonical-name membership queries (0.8) without any hardcoded condition list.
+ */
+@DisplayName("fuzzyMatchesAny Tests")
+class FuzzyStatusMatchTest {
+    @Nested
+    @DisplayName("Query threshold (0.8)")
+    inner class QueryMatch {
+        @Test
+        fun `identical name matches`() {
+            assertTrue(fuzzyMatchesAny("Night Owl", listOf("Night Owl"), STATUS_QUERY_THRESHOLD))
+        }
+
+        @Test
+        fun `one-character OCR error still matches`() {
+            assertTrue(fuzzyMatchesAny("Night Owl", listOf("Nlght Owl"), STATUS_QUERY_THRESHOLD))
+        }
+
+        @Test
+        fun `unrelated name does not match`() {
+            assertFalse(fuzzyMatchesAny("Charming", listOf("Night Owl", "Migraine"), STATUS_QUERY_THRESHOLD))
+        }
+
+        @Test
+        fun `blank candidate never matches`() {
+            assertFalse(fuzzyMatchesAny("   ", listOf("Night Owl"), STATUS_QUERY_THRESHOLD))
+        }
+
+        @Test
+        fun `empty list never matches`() {
+            assertFalse(fuzzyMatchesAny("Night Owl", emptyList(), STATUS_QUERY_THRESHOLD))
+        }
+    }
+
+    @Nested
+    @DisplayName("Dedup threshold (0.9)")
+    inner class DedupMatch {
+        @Test
+        fun `OCR jitter of the same pill collapses`() {
+            assertTrue(fuzzyMatchesAny("Nlght Owl", listOf("Night Owl"), STATUS_DEDUP_THRESHOLD))
+        }
+
+        @Test
+        fun `two distinct conditions stay separate`() {
+            assertFalse(fuzzyMatchesAny("Migraine", listOf("Slacker", "Night Owl"), STATUS_DEDUP_THRESHOLD))
+        }
+    }
+}


### PR DESCRIPTION
## Description
- This PR lets the app recognize any of the trainee's active conditions instead of only a fixed preset list, so newly added or previously-unrecognized conditions are no longer missed.
- It also reads the full conditions list even when it is long enough to scroll, so none get dropped.
