### PR TITLE
Redesign the Remote Log Viewer with estimated rank and a skills panel

### DIFF
--- a/android/app/src/main/assets/log_viewer.html
+++ b/android/app/src/main/assets/log_viewer.html
@@ -3072,7 +3072,10 @@
                 allMessages.forEach(function (msg) {
                     processSpecialLogs(msg.parsed, batchState)
                 })
-                
+
+                // Zero the cumulative counters first so the additive apply below rebuilds the exact absolute total,
+                // even when the display already held counts (e.g. the sync path applies a batch just before this).
+                resetActionTotals()
                 applyBatchStateToDashboard(batchState)
                 
                 if (autoScroll) {
@@ -3313,19 +3316,11 @@
                 document.getElementById("imageGrid").innerHTML = "";
                 document.getElementById("imageCount").textContent = "0";
 
-                // Reset dashboard counters.
-                document.getElementById("countTraining").textContent = "0"
-                document.getElementById("countRace").textContent = "0"
-                document.getElementById("countInjury").textContent = "0"
-                document.getElementById("countMood").textContent = "0"
-                document.getElementById("countEnergy").textContent = "0"
+                // Reset dashboard counters and their granular breakdowns (cumulative running totals).
+                resetActionTotals()
 
-                // Reset granular breakdowns.
-                trainingBreakdown = { Speed: 0, Stamina: 0, Power: 0, Guts: 0, Wit: 0 }
+                // trainingLevels holds the latest facility level per stat, not a running count, so reset it here.
                 trainingLevels = { Speed: null, Stamina: null, Power: null, Guts: null, Wit: null }
-                raceBreakdown = { Finale: 0, G1: 0, G2: 0, G3: 0, OP: 0, "Pre-OP": 0, Maiden: 0, Mandatory: 0, Standalone: 0 }
-                moodBreakdown = { Standard: 0, Date: 0, Summer: 0 }
-                energyBreakdown = { Rest: 0, Date: 0, Summer: 0 }
 
                 // Reset the trainee name display.
                 document.getElementById("dashboardName").textContent = "-"
@@ -3875,8 +3870,7 @@
                     }[actionKey]
                     
                     if (elId) {
-                        const el = document.getElementById(elId)
-                        el.textContent = parseInt(el.textContent || "0") + 1
+                        addToCounter(elId, 1)
                     }
 
                     if (subType) {
@@ -3957,6 +3951,45 @@
             }
 
             /**
+             * Adds a delta to a numeric counter element. Action counters are cumulative running totals, so a batch
+             * contributes its own count on top of what is already displayed rather than replacing it.
+             * @param {string} elementId - The id of the counter element to update.
+             * @param {number} delta - The amount to add (this batch's count for that action).
+             */
+            function addToCounter(elementId, delta) {
+                const el = document.getElementById(elementId)
+                el.textContent = parseInt(el.textContent || "0") + (delta || 0)
+            }
+
+            /**
+             * Adds each of a batch's breakdown counts onto the running total for that breakdown category.
+             * @param {object} target - The running-total breakdown object (e.g. trainingBreakdown).
+             * @param {object} source - This batch's breakdown counts, or null/undefined to skip.
+             */
+            function mergeBreakdown(target, source) {
+                if (!source) return
+                for (const [key, count] of Object.entries(source)) {
+                    target[key] = (target[key] || 0) + count
+                }
+            }
+
+            /**
+             * Resets the cumulative action counters and their breakdowns back to zero. Used both when clearing the
+             * display and before a full history rebuild, so the rebuild's additive apply lands on a clean baseline.
+             */
+            function resetActionTotals() {
+                document.getElementById("countTraining").textContent = "0"
+                document.getElementById("countRace").textContent = "0"
+                document.getElementById("countInjury").textContent = "0"
+                document.getElementById("countMood").textContent = "0"
+                document.getElementById("countEnergy").textContent = "0"
+                trainingBreakdown = { Speed: 0, Stamina: 0, Power: 0, Guts: 0, Wit: 0 }
+                raceBreakdown = { Finale: 0, G1: 0, G2: 0, G3: 0, OP: 0, "Pre-OP": 0, Maiden: 0, Mandatory: 0, Standalone: 0 }
+                moodBreakdown = { Standard: 0, Date: 0, Summer: 0 }
+                energyBreakdown = { Rest: 0, Date: 0, Summer: 0 }
+            }
+
+            /**
              * Helper to apply a collected batch state to the dashboard DOM.
              * @param {object} state - The collected state from the batch.
              */
@@ -4008,42 +4041,26 @@
                     }
                 }
                 
-                // Batch update action counters.
+                // Action counters and their breakdowns are cumulative running totals, so add this batch's counts on
+                // top of the current values instead of overwriting. The full-history rebuild zeroes them first (via
+                // resetActionTotals) so its additive apply still lands the correct absolute total.
                 if (state.actions) {
-                    document.getElementById("countTraining").textContent = state.actions.training
-                    document.getElementById("countRace").textContent = state.actions.race
-                    document.getElementById("countMood").textContent = state.actions.mood
-                    document.getElementById("countEnergy").textContent = state.actions.energy
-                    document.getElementById("countInjury").textContent = state.actions.injury
-                    
-                    // Batch update training breakdown.
-                    if (state.trainingBreakdown) {
-                        for (const [stat, count] of Object.entries(state.trainingBreakdown)) {
-                            trainingBreakdown[stat] = count
-                        }
-                    }
-                    // Batch update training levels.
+                    addToCounter("countTraining", state.actions.training)
+                    addToCounter("countRace", state.actions.race)
+                    addToCounter("countMood", state.actions.mood)
+                    addToCounter("countEnergy", state.actions.energy)
+                    addToCounter("countInjury", state.actions.injury)
+
+                    // Add this batch's breakdowns onto their running totals.
+                    mergeBreakdown(trainingBreakdown, state.trainingBreakdown)
+                    mergeBreakdown(raceBreakdown, state.raceBreakdown)
+                    mergeBreakdown(moodBreakdown, state.moodBreakdown)
+                    mergeBreakdown(energyBreakdown, state.energyBreakdown)
+
+                    // Training levels are latest-value, not counts, so overwrite rather than add.
                     if (state.trainingLevels) {
                         for (const [stat, level] of Object.entries(state.trainingLevels)) {
                             trainingLevels[stat] = level
-                        }
-                    }
-                    // Batch update race breakdown.
-                    if (state.raceBreakdown) {
-                        for (const [grade, count] of Object.entries(state.raceBreakdown)) {
-                            raceBreakdown[grade] = count
-                        }
-                    }
-                    // Batch update mood breakdown.
-                    if (state.moodBreakdown) {
-                        for (const [type, count] of Object.entries(state.moodBreakdown)) {
-                            moodBreakdown[type] = count
-                        }
-                    }
-                    // Batch update energy breakdown.
-                    if (state.energyBreakdown) {
-                        for (const [type, count] of Object.entries(state.energyBreakdown)) {
-                            energyBreakdown[type] = count
                         }
                     }
                 }

--- a/android/app/src/main/assets/log_viewer.html
+++ b/android/app/src/main/assets/log_viewer.html
@@ -1810,26 +1810,40 @@
                 border-radius: 50%;
                 flex-shrink: 0;
             }
-            .skill-pill.gold {
-                border-color: rgba(230, 160, 44, 0.5);
+            /* Category-colored bullet matching the in-game skill color: green recovery, blue stamina, yellow speed, red debuff. */
+            .skill-pill.c-green .dotc {
+                background: #3cc06e;
             }
-            .skill-pill.gold .dotc {
-                background: #e8a02c;
+            .skill-pill.c-blue .dotc {
+                background: #38a7e8;
             }
-            .skill-pill.uniq {
-                border-color: rgba(155, 109, 255, 0.5);
+            .skill-pill.c-yellow .dotc {
+                background: #f2c94c;
             }
-            .skill-pill.uniq .dotc {
-                background: var(--accent-purple);
+            .skill-pill.c-red .dotc {
+                background: #ef4444;
             }
             .skill-pill.norm .dotc {
                 background: var(--text-secondary);
             }
+            /* Gold-rarity skills keep their category bullet but gain a gold border. */
+            .skill-pill.gold {
+                border-color: rgba(230, 160, 44, 0.65);
+            }
+            /* Negative skills: purple bullet and purple border. */
             .skill-pill.neg {
-                border-color: rgba(239, 68, 68, 0.5);
+                border-color: rgba(155, 109, 255, 0.5);
             }
             .skill-pill.neg .dotc {
-                background: var(--log-error);
+                background: var(--accent-purple);
+            }
+            /* Unique skills: rainbow bullet and rainbow border, mirroring the in-game rainbow frame. */
+            .skill-pill.uniq {
+                border: 1px solid transparent;
+                background: linear-gradient(var(--bg-primary), var(--bg-primary)) padding-box, linear-gradient(100deg, #ff5d5d, #f2c94c, #3cc06e, #38a7e8, #9b6dff) border-box;
+            }
+            .skill-pill.uniq .dotc {
+                background: conic-gradient(from 210deg, #ff5d5d, #f2c94c, #3cc06e, #38a7e8, #9b6dff, #ff5d5d);
             }
             .skill-pill .lv {
                 margin-left: auto;
@@ -4038,7 +4052,7 @@
             }
 
             /**
-             * Renders the owned-skills panel from a SKILLS: snapshot. Each skill becomes a colored pill (unique / gold / negative / normal) and the unique carries its level.
+             * Renders the owned-skills panel from a SKILLS: snapshot. Each skill becomes a pill colored by its category (green/blue/yellow/red) with unique/negative/gold treatment via skillPillClass, and the unique carries its level.
              * Passing null clears the panel back to its placeholder hint.
              * @param {object} snapshot - The parsed skills snapshot ({ skills, stars }), or null.
              */
@@ -4050,11 +4064,10 @@
                 if (skills.length === 0) {
                     panel.innerHTML = '<div class="skills-hint">No owned skills read yet - the bot fills this in when it reads the Skills tab.</div>'
                 } else {
-                    var pillClass = { unique: "uniq", gold: "gold", negative: "neg", normal: "norm" }
                     var html = '<div class="skills-grid">'
                     for (var i = 0; i < skills.length; i++) {
                         var s = skills[i]
-                        var cls = pillClass[s.type] || "norm"
+                        var cls = skillPillClass(s)
                         var lv = s.level ? '<span class="lv">Lv' + s.level + "</span>" : ""
                         html += '<div class="skill-pill ' + cls + '"><span class="dotc"></span>' + escapeHtml(s.name) + lv + "</div>"
                     }
@@ -4062,6 +4075,19 @@
                     panel.innerHTML = html
                 }
                 renderSidePanel()
+            }
+
+            /**
+             * Picks the CSS classes for one skill pill. Unique wins (rainbow), then negative (purple); otherwise the pill takes its in-game category color (green/blue/yellow/red) and
+             * adds a gold border for gold-rarity skills. Falls back to the older single `type` field so a stale bot payload still renders.
+             * @param {object} s - The skill entry from the SKILLS snapshot ({name, color, gold, unique, negative, ...} or the legacy {type}).
+             * @returns {string} The space-separated class list for the `.skill-pill` element.
+             */
+            function skillPillClass(s) {
+                if (s.unique || s.type === "unique") return "uniq"
+                if (s.negative || s.type === "negative") return "neg"
+                var base = { green: "c-green", blue: "c-blue", yellow: "c-yellow", red: "c-red" }[s.color] || "norm"
+                return s.gold || s.type === "gold" ? base + " gold" : base
             }
 
             // Latest snapshot kept for the hover-tooltip lookup. Decisions and results are

--- a/android/app/src/main/assets/log_viewer.html
+++ b/android/app/src/main/assets/log_viewer.html
@@ -4054,7 +4054,7 @@
             /**
              * Renders the owned-skills panel from a SKILLS: snapshot. Each skill becomes a pill colored by its category (green/blue/yellow/red) with unique/negative/gold treatment via skillPillClass, and the unique carries its level.
              * Passing null clears the panel back to its placeholder hint.
-             * @param {object} snapshot - The parsed skills snapshot ({ skills, stars }), or null.
+             * @param {object} snapshot - The parsed skills snapshot ({ skills }), or null.
              */
             function renderSkills(snapshot) {
                 skillsData = snapshot

--- a/android/app/src/main/assets/log_viewer.html
+++ b/android/app/src/main/assets/log_viewer.html
@@ -3752,6 +3752,14 @@
             // //////////////////////////////////////////////////////////////////////////////////////////////////
             // Search Input Handler
 
+            // Sync the search state from whatever the browser restored into the input on reload,
+            // so a page refresh keeps filtering instead of showing everything until the user types.
+            function initSearch() {
+                searchQuery = searchInput.value.toLowerCase().trim()
+                searchClear.classList.toggle("visible", searchInput.value.length > 0)
+                applyFilters()
+            }
+
             // Listen for input changes in the search field to filter logs in real-time.
             searchInput.addEventListener("input", function () {
                 searchQuery = this.value.toLowerCase().trim()
@@ -5466,6 +5474,8 @@
             // Initiate the connection and settings when the page loads.
             initFontSize()
             initToolbar()
+            // Restore search filtering from the value the browser kept in the input across a refresh.
+            initSearch()
             // Paint an empty Race History grid so the panel takes its full layout immediately,
             // before any CAL: snapshot arrives.
             renderCalendar(null)

--- a/android/app/src/main/assets/log_viewer.html
+++ b/android/app/src/main/assets/log_viewer.html
@@ -3536,20 +3536,20 @@
              * Trainee rank ladder, ordered weakest to strongest. A label's array index is the utx_txt_rank image number served at /ranks/<index>. Plain "G" is index 0 and has
              * no badge image, so it renders without one. Shared by the per-stat grades and the estimated overall rank.
              */
-            const RANK_LADDER = ["G", "G+", "F", "F+", "E", "E+", "D", "D+", "C", "C+", "B", "B+", "A", "A+", "S", "S+", "SS", "SS+"]
+            // The letter ladder (indices 0..17 = G..SS+) plus the "ultra" super-grades above SS+. Each super letter is a base tier plus levels 1..9 (10 tiers), matching the
+            // utx_txt_rank image set: index 18 = UG, 19..27 = UG1..UG9, 28 = UF, ... 97 = US9. The array index is the badge image number.
+            const RANK_LADDER = ["G", "G+", "F", "F+", "E", "E+", "D", "D+", "C", "C+", "B", "B+", "A", "A+", "S", "S+", "SS", "SS+"].concat(
+                ["UG", "UF", "UE", "UD", "UC", "UB", "UA", "US"].flatMap(letter => [letter, ...Array.from({ length: 9 }, (_, i) => letter + (i + 1))])
+            )
             const RANK_LABEL_TO_INDEX = RANK_LADDER.reduce((map, label, index) => { map[label] = index; return map }, {})
 
             /**
-             * Resolves a rank label to its utx_txt_rank image index. Handles the fixed ladder (G+..SS+, indices 1..17) plus the dynamic "UG" tiers above SS+. Image #18 is the base
-             * "UG" badge, so numbered tiers start one later: UGn -> index 18 + n (UG1..UG79 map to images 19..97).
-             * @param {string} label - The rank label, e.g. "SS+" or "UG6".
-             * @returns {number|undefined} The badge image index, or undefined when the label has no badge (plain "G" or an unknown label).
+             * Resolves a rank label to its utx_txt_rank image index via its ladder position. Plain "G" is index 0 (it has no badge image) and any label off the ladder returns
+             * undefined, so callers treat a falsy result as "no image".
+             * @param {string} label - The rank label, e.g. "SS+" or "UF3".
+             * @returns {number|undefined} The badge image index, or undefined when the label is not on the ladder.
              */
             function rankLabelToIndex(label) {
-                if (typeof label === "string" && label.startsWith("UG")) {
-                    const n = parseInt(label.slice(2), 10)
-                    return Number.isFinite(n) ? 18 + n : undefined
-                }
                 return RANK_LABEL_TO_INDEX[label]
             }
 
@@ -3566,14 +3566,14 @@
 
             /**
              * Maps a raw stat value to its in-game letter grade. A "+" marks the upper half of each band (the band midpoint), matching the character-details badges. Above SS+ the
-             * game shows "UG" tiers: UG1 begins at 1210 and each level spans 10 stat points (UG1..UG79 cover 1210..1990, the span the badge image set covers).
+             * game shows the "ultra" super-grades: the base UG tier begins at 1200 and every 10 stat points steps up one ladder tier (UG, UG1..UG9, UF, UF1..UF9, UE, ...).
              * @param {string|number} value - The stat value.
-             * @returns {string} The letter grade (e.g. "B+" or "UG6"), or "" when there is no valid value.
+             * @returns {string} The letter grade (e.g. "B+" or "UF3"), or "" when there is no valid value.
              */
             function statValueToRankLabel(value) {
                 const v = parseInt(value, 10)
                 if (!Number.isFinite(v) || v < 1) return ""
-                if (v >= 1210) return "UG" + Math.min(79, Math.floor((v - 1210) / 10) + 1)
+                if (v >= 1200) return RANK_LADDER[Math.min(RANK_LABEL_TO_INDEX["UG"] + Math.floor((v - 1200) / 10), RANK_LADDER.length - 1)]
                 const bands = [
                     [1, "G"], [50, "G+"], [100, "F"], [150, "F+"], [200, "E"], [250, "E+"],
                     [300, "D"], [350, "D+"], [400, "C"], [500, "C+"], [600, "B"], [700, "B+"],

--- a/android/app/src/main/assets/log_viewer.html
+++ b/android/app/src/main/assets/log_viewer.html
@@ -1435,6 +1435,14 @@
                 font-weight: 600;
                 color: var(--text-primary);
             }
+            /* GameTora-hosted skill icon shown atop the owned-skill hover tooltip. */
+            .skill-tip-icon {
+                display: block;
+                width: 44px;
+                height: 44px;
+                margin: 0 auto 8px;
+                image-rendering: -webkit-optimize-contrast;
+            }
             @media (max-width: 800px) {
                 .header {
                     flex-wrap: wrap;
@@ -4069,7 +4077,8 @@
                         var s = skills[i]
                         var cls = skillPillClass(s)
                         var lv = s.level ? '<span class="lv">Lv' + s.level + "</span>" : ""
-                        html += '<div class="skill-pill ' + cls + '"><span class="dotc"></span>' + escapeHtml(s.name) + lv + "</div>"
+                        var hover = ' onmouseenter="showSkillTooltip(event, ' + i + ')" onmousemove="updateTooltipPosition(event)" onmouseleave="hideTooltip()"'
+                        html += '<div class="skill-pill ' + cls + '"' + hover + '><span class="dotc"></span>' + escapeHtml(s.name) + lv + "</div>"
                     }
                     html += "</div>"
                     panel.innerHTML = html
@@ -4327,6 +4336,23 @@
                 }
 
                 showTooltip(event, title, content)
+            }
+
+            /**
+             * Shows the owned-skill hover tooltip for a pill: the skill name (title), its GameTora-hosted icon, and its description. A missing icon (unmatched skill, iconId 0, or a
+             * GameTora 404) hides itself via onerror so the name and description still show. Mirrors showRaceCellTooltip's O(1) lookup into the cached snapshot.
+             *
+             * @param {MouseEvent} event Hover event used for tooltip positioning.
+             * @param {number} i Index of the hovered skill in the cached SKILLS snapshot.
+             */
+            function showSkillTooltip(event, i) {
+                if (!skillsData || !skillsData.skills || !skillsData.skills[i]) return
+                var s = skillsData.skills[i]
+                var icon = s.iconId
+                    ? '<img class="skill-tip-icon" src="https://media.gametora.com/umamusume/skills/icon/' + s.iconId + '.png" alt="" onerror="this.style.display=\'none\'">'
+                    : ""
+                var desc = s.desc ? escapeHtml(s.desc) : '<span style="opacity:0.6;font-style:italic">No description.</span>'
+                showTooltip(event, escapeHtml(s.name), icon + "<div>" + desc + "</div>")
             }
 
             // //////////////////////////////////////////////////////////////////////////////////////////////////

--- a/android/app/src/main/assets/log_viewer.html
+++ b/android/app/src/main/assets/log_viewer.html
@@ -974,7 +974,7 @@
                 display: flex;
                 background: var(--bg-secondary);
                 border-bottom: 1px solid var(--border-color);
-                height: 264px;
+                height: 320px;
                 flex-shrink: 0;
                 overflow: hidden;
             }
@@ -1149,26 +1149,26 @@
             .meters {
                 display: flex;
                 flex-direction: column;
-                gap: 5px;
-                max-width: 820px;
+                gap: 10px;
+                max-width: 1080px;
             }
             .meter {
                 display: grid;
-                grid-template-columns: 40px 1fr 72px 44px;
+                grid-template-columns: 40px 1fr 76px 52px;
                 align-items: center;
                 gap: 8px;
             }
             .meter .nm {
                 font-family: var(--font-mono);
-                font-size: 11px;
+                font-size: 12px;
                 font-weight: 700;
                 color: var(--c);
                 letter-spacing: 0.5px;
             }
             .meter .track {
                 position: relative;
-                height: 10px;
-                border-radius: 5px;
+                height: 14px;
+                border-radius: 7px;
                 background: rgba(255, 255, 255, 0.05);
                 overflow: hidden;
             }
@@ -1176,25 +1176,25 @@
                 position: absolute;
                 inset: 0 auto 0 0;
                 width: 0;
-                border-radius: 5px;
+                border-radius: 7px;
                 background: var(--c);
                 box-shadow: 0 0 10px -2px var(--c);
                 transition: width var(--transition);
             }
             .meter .vc {
                 font-family: var(--font-mono);
-                font-size: 13px;
+                font-size: 15px;
                 font-weight: 700;
-                text-align: right;
+                text-align: left;
                 color: var(--text-primary);
             }
             .meter .vc .cap {
-                font-size: 10px;
+                font-size: 11px;
                 font-weight: 400;
                 color: var(--text-muted);
             }
             .meter .stat-grade-img {
-                height: 28px;
+                height: 36px;
                 width: auto;
                 justify-self: center;
             }
@@ -1211,7 +1211,7 @@
                 display: flex;
                 align-items: center;
                 gap: 20px;
-                max-width: 820px;
+                max-width: 1080px;
             }
             .erank {
                 display: flex;

--- a/android/app/src/main/assets/log_viewer.html
+++ b/android/app/src/main/assets/log_viewer.html
@@ -37,6 +37,14 @@
                 --font-mono: "JetBrains Mono", "Cascadia Code", "Fira Code", monospace;
                 --radius: 8px;
                 --transition: 150ms cubic-bezier(0.4, 0, 0.2, 1);
+                /* Per-stat accent colors (Speed / Stamina / Power / Guts / Wit) for the dashboard meters. */
+                --spd: #38a7e8;
+                --sta: #e8563c;
+                --pow: #e89a2c;
+                --gut: #e8489a;
+                --wit: #3cc06e;
+                /* Height of the collapsed mobile peek-sheet glance bar (drives the sheet slide, log bottom padding, and scroll-button offset). */
+                --peek-h: 52px;
             }
 
             *,
@@ -78,36 +86,36 @@
             .header {
                 background: var(--bg-secondary);
                 border-bottom: 1px solid var(--border-color);
-                padding: 12px 20px;
+                padding: 0 20px;
                 display: flex;
                 align-items: center;
-                justify-content: space-between;
                 flex-shrink: 0;
-                gap: 16px;
+                gap: 24px;
                 height: 54px;
             }
 
+            /* Tabs sit inline in the header row; each stretches full-height so the active underline meets the header's bottom border. */
             .tab-nav {
                 display: flex;
-                background: var(--bg-secondary);
-                padding: 0 20px;
-                border-bottom: 1px solid var(--border-color);
-                gap: 20px;
-                flex-shrink: 0;
+                gap: 22px;
+                align-self: stretch;
             }
 
             .tab-btn {
-                padding: 12px 0;
+                display: flex;
+                align-items: center;
+                padding: 0;
                 background: none;
                 border: none;
+                border-bottom: 2px solid transparent;
                 color: var(--text-secondary);
-                font-size: 13px;
+                font-size: 12px;
                 font-weight: 600;
                 cursor: pointer;
-                position: relative;
                 transition: color var(--transition);
                 text-transform: uppercase;
                 letter-spacing: 0.5px;
+                white-space: nowrap;
             }
 
             .tab-btn:hover {
@@ -116,17 +124,7 @@
 
             .tab-btn.active {
                 color: var(--accent-blue);
-            }
-
-            .tab-btn.active::after {
-                content: "";
-                position: absolute;
-                bottom: -1px;
-                left: 0;
-                right: 0;
-                height: 2px;
-                background: var(--accent-blue);
-                border-radius: 2px 2px 0 0;
+                border-bottom-color: var(--accent-blue);
             }
 
             .tab-view {
@@ -375,6 +373,7 @@
             }
 
             .status-badge {
+                margin-left: auto;
                 display: flex;
                 align-items: center;
                 gap: 6px;
@@ -385,6 +384,27 @@
                 text-transform: uppercase;
                 letter-spacing: 0.5px;
                 transition: all var(--transition);
+            }
+
+            /* Status text stacked over the host so the chip stays narrow (the single-line form overflowed on mobile). */
+            .status-lines {
+                display: flex;
+                flex-direction: column;
+                align-items: flex-start;
+                line-height: 1.15;
+            }
+
+            /* Connected host shown inside the status chip on its own line (replaces the removed footer). Empty when disconnected, collapsing the chip to one line. */
+            .status-host {
+                color: var(--text-secondary);
+                font-weight: 500;
+                font-family: var(--font-mono);
+                font-size: 10px;
+                text-transform: none;
+                letter-spacing: 0;
+            }
+            .status-host:empty {
+                display: none;
             }
 
             .status-dot {
@@ -654,6 +674,37 @@
                 color: var(--accent-blue);
             }
 
+            /* Option C: level filters collapse into one segmented control. */
+            .filter-group.segmented {
+                gap: 0;
+                border: 1px solid var(--border-color);
+                border-radius: 6px;
+                overflow: hidden;
+            }
+            .filter-group.segmented .filter-btn {
+                border: none;
+                border-right: 1px solid var(--border-color);
+                border-radius: 0;
+                padding: 4px 10px;
+            }
+            .filter-group.segmented .filter-btn:last-child {
+                border-right: none;
+            }
+
+            /* Icon-only action buttons in the toolbar's right-hand action cluster. */
+            .toolbar-btn.icon {
+                padding: 5px;
+                width: 30px;
+                justify-content: center;
+            }
+            .toolbar-btn.icon svg {
+                width: 14px;
+                height: 14px;
+            }
+            .toolbar-grow {
+                flex: 1;
+            }
+
             .font-size-container {
                 display: flex;
                 align-items: center;
@@ -826,6 +877,29 @@
                 color: var(--log-error);
             }
 
+            /* Option C: a colored left-rule per level for faster scanning (errors get a faint tint). Toggled by the .ruled class on the log container. */
+            .log-container.ruled .log-entry {
+                border-left: 2px solid transparent;
+                padding-left: 8px;
+                margin-left: -2px;
+            }
+            .log-container.ruled .log-entry.level-verbose {
+                border-left-color: var(--log-verbose);
+            }
+            .log-container.ruled .log-entry.level-debug {
+                border-left-color: var(--log-debug);
+            }
+            .log-container.ruled .log-entry.level-info {
+                border-left-color: var(--log-info);
+            }
+            .log-container.ruled .log-entry.level-warn {
+                border-left-color: var(--log-warn);
+            }
+            .log-container.ruled .log-entry.level-error {
+                border-left-color: var(--log-error);
+                background: rgba(239, 68, 68, 0.05);
+            }
+
             .log-timestamp {
                 color: var(--text-muted);
                 margin-right: 8px;
@@ -885,162 +959,338 @@
                 display: flex;
             }
 
-            .footer {
-                background: var(--bg-secondary);
-                border-top: 1px solid var(--border-color);
-                padding: 6px 20px;
-                font-size: 11px;
-                color: var(--text-muted);
-                display: flex;
-                align-items: center;
-                justify-content: space-between;
-                flex-shrink: 0;
+            /* //////// Mobile bottom peek-sheet //////// */
+            /* On desktop the wrapper is transparent (display:contents) so the dashboard renders inline; the glance bar + backdrop are mobile-only (see the max-width:800px block). */
+            .mobile-sheet {
+                display: contents;
+            }
+            .sheet-peek,
+            .sheet-backdrop {
+                display: none;
             }
 
-            .footer-left {
-                flex: 1;
-                text-align: left;
-            }
-
-            .footer-right {
-                flex: 1;
-                text-align: right;
-            }
-
+            /* //////// Dashboard: three hairline-divided zones (Identity | Stats | right rail) //////// */
             .dashboard {
+                display: flex;
                 background: var(--bg-secondary);
                 border-bottom: 1px solid var(--border-color);
-                padding: 10px 16px;
-                display: flex;
-                flex-direction: row;
-                justify-content: space-between;
-                align-items: stretch;
-                gap: 16px;
+                height: 264px;
                 flex-shrink: 0;
+                overflow: hidden;
             }
-
-            .dashboard-info {
+            .zone {
+                padding: 12px 16px;
                 display: flex;
                 flex-direction: column;
-                gap: 6px;
+                min-height: 0;
             }
-            .info-left-col, .info-right-col {
-                display: flex;
-                flex-direction: column;
-                gap: 6px;
+            .zone + .zone {
+                border-left: 1px solid var(--border-color);
             }
-
-            .dashboard-row {
-                display: flex;
-                align-items: center;
-                gap: 16px;
-                flex-wrap: wrap;
-            }
-
-            .dashboard-item {
-                display: flex;
-                flex-direction: column;
-                gap: 2px;
-            }
-
-            .dashboard-label {
-                font-size: 11px;
+            /* Small uppercase zone/section caption. */
+            .zt {
+                font-size: 9px;
                 font-weight: 700;
+                letter-spacing: 1px;
                 color: var(--text-muted);
                 text-transform: uppercase;
-                letter-spacing: 0.5px;
+                margin-bottom: 9px;
             }
 
-            .dashboard-value {
-                font-size: 15px;
-                font-weight: 600;
+            /* Identity zone: name, mood, vitals, date/turn, aptitudes, conditions. Scrolls internally if a trainee has many conditions rather than spilling into the log. */
+            .z-id {
+                flex: 0 0 200px;
+                overflow-x: hidden;
+                overflow-y: auto;
+            }
+            .z-id::-webkit-scrollbar {
+                width: 6px;
+            }
+            .z-id::-webkit-scrollbar-thumb {
+                background: var(--scrollbar-thumb);
+                border-radius: 3px;
+            }
+            .z-id .name {
+                font-size: 18px;
+                font-weight: 800;
+                letter-spacing: -0.3px;
+                color: var(--text-primary);
+            }
+            .mood-slot {
+                margin-top: 5px;
+                min-height: 20px;
+            }
+            .vitals {
+                margin-top: 8px;
+                display: flex;
+                flex-direction: column;
+                gap: 5px;
+                font-size: 11px;
+            }
+            .vital {
+                display: flex;
+                align-items: center;
+                gap: 7px;
+            }
+            .vital .k {
+                color: var(--text-muted);
+                width: 42px;
+            }
+            .vital .b {
+                flex: 1;
+                height: 6px;
+                border-radius: 3px;
+                background: rgba(255, 255, 255, 0.06);
+                overflow: hidden;
+            }
+            .vital .b i {
+                display: block;
+                height: 100%;
+                width: 0;
+                background: linear-gradient(90deg, #f59e0b, #22c55e);
+                transition: width var(--transition);
+            }
+            .vital .v {
+                font-family: var(--font-mono);
+                color: var(--text-primary);
+            }
+            .idmeta {
+                margin-top: 8px;
+                font-size: 11px;
+                color: var(--text-secondary);
+                line-height: 1.5;
+            }
+            .idmeta b {
                 color: var(--text-primary);
                 font-family: var(--font-mono);
             }
-
-            .stats-container {
-                display: flex;
-                gap: 8px;
-                background: var(--bg-tertiary);
-                padding: 6px 12px;
-                border-radius: var(--radius);
-                border: 1px solid var(--border-color);
+            .apts {
+                margin-top: 8px;
+                padding-top: 8px;
+                border-top: 1px solid var(--border-color);
             }
-
-            .stats-container.session-stats {
-                border-color: rgba(155, 109, 255, 0.3);
-            }
-
-            .stat-box {
+            .aptrow {
                 display: flex;
-                flex-direction: column;
                 align-items: center;
-                min-width: 42px;
+                gap: 9px;
+                margin-bottom: 5px;
+            }
+            .aptrow .al {
+                flex-shrink: 0;
+                color: var(--text-muted);
+                width: 40px;
+                font-size: 9.5px;
+                text-transform: uppercase;
+                letter-spacing: 0.3px;
+            }
+            /* Fixed 4-column grid so badges line up in straight columns across rows; short rows (Track's 2) leave the trailing columns empty rather than centering. */
+            .aptrow .cells {
+                display: grid;
+                grid-template-columns: repeat(4, 19px);
+                gap: 5px;
+            }
+            /* Aptitude badge wrapper carries a hover tooltip (the full name) via data-tip. */
+            .apt {
+                position: relative;
+            }
+            .apt::after {
+                content: attr(data-tip);
+                position: absolute;
+                bottom: 128%;
+                left: 50%;
+                transform: translateX(-50%);
+                background: #05050a;
+                color: var(--text-primary);
+                font-size: 10px;
+                padding: 3px 7px;
+                border-radius: 5px;
+                white-space: nowrap;
+                border: 1px solid var(--border-accent);
+                opacity: 0;
+                pointer-events: none;
+                transition: opacity 0.12s;
+                z-index: 5;
+            }
+            .apt:hover::after {
+                opacity: 1;
             }
 
-            .stat-label {
+            /* Condition chips sit after the aptitudes: aptitudes are fixed and stay visible, conditions are the variable content that wraps. Empty "None" placeholders are hidden. */
+            .cond-strip {
+                margin-top: 8px;
+                display: flex;
+                flex-wrap: wrap;
+                gap: 4px;
+                min-height: 0;
+            }
+            .cond-inline {
+                display: inline-flex;
+                flex-wrap: wrap;
+                gap: 4px;
+                min-height: 0;
+            }
+            .cond-inline .condition-badge {
                 font-size: 10px;
-                font-weight: 700;
-                color: var(--text-muted);
+                padding: 1px 6px;
+            }
+            .cond-inline .condition-empty {
+                display: none;
+            }
+
+            /* Stats zone: horizontal meters filling toward each stat's OCR'd cap. */
+            .z-stat {
+                flex: 1 1 0;
+                min-width: 0;
+            }
+            /* Tighter gap under the Stats header so the freed space redistributes below the last meter (statfoot is bottom-aligned via margin-top: auto). */
+            .z-stat > .zt {
                 margin-bottom: 2px;
             }
-
-            .stat-value {
-                font-size: 14px;
+            .meters {
+                display: flex;
+                flex-direction: column;
+                gap: 5px;
+                max-width: 820px;
+            }
+            .meter {
+                display: grid;
+                grid-template-columns: 40px 1fr 72px 44px;
+                align-items: center;
+                gap: 8px;
+            }
+            .meter .nm {
+                font-family: var(--font-mono);
+                font-size: 11px;
                 font-weight: 700;
+                color: var(--c);
+                letter-spacing: 0.5px;
+            }
+            .meter .track {
+                position: relative;
+                height: 10px;
+                border-radius: 5px;
+                background: rgba(255, 255, 255, 0.05);
+                overflow: hidden;
+            }
+            .meter .fill {
+                position: absolute;
+                inset: 0 auto 0 0;
+                width: 0;
+                border-radius: 5px;
+                background: var(--c);
+                box-shadow: 0 0 10px -2px var(--c);
+                transition: width var(--transition);
+            }
+            .meter .vc {
+                font-family: var(--font-mono);
+                font-size: 13px;
+                font-weight: 700;
+                text-align: right;
+                color: var(--text-primary);
+            }
+            .meter .vc .cap {
+                font-size: 10px;
+                font-weight: 400;
+                color: var(--text-muted);
+            }
+            .meter .stat-grade-img {
+                height: 28px;
+                width: auto;
+                justify-self: center;
+            }
+            .stat-grade-img:not([src]),
+            .stat-grade-img[src=""] {
+                display: none;
+            }
+
+            /* Stats footer: estimated rank badge + session action counters. */
+            .statfoot {
+                margin-top: auto;
+                padding-top: 8px;
+                border-top: 1px solid var(--border-color);
+                display: flex;
+                align-items: center;
+                gap: 20px;
+                max-width: 820px;
+            }
+            .erank {
+                display: flex;
+                align-items: center;
+                gap: 12px;
+            }
+            .est-rank-img {
+                height: 46px;
+                width: auto;
+                filter: drop-shadow(0 0 7px rgba(255, 180, 40, 0.28));
+            }
+            .est-rank-img:not([src]),
+            .est-rank-img[src=""] {
+                display: none;
+            }
+            .est-rank-text {
+                font-size: 26px;
+                font-weight: 800;
+                line-height: 1;
                 color: var(--accent-blue);
             }
-
-            .aptitude-table {
-                width: auto;
-                min-width: 300px;
-                border-collapse: collapse;
-                background: var(--bg-tertiary);
-                border-radius: var(--radius);
-                overflow: hidden;
-                border: 1px solid var(--border-color);
-                font-size: 11px;
+            .erank .score {
+                font-family: var(--font-mono);
+                font-size: 26px;
+                font-weight: 800;
+                line-height: 1;
+                letter-spacing: -0.5px;
+                color: var(--text-primary);
             }
-
-            .aptitude-table th,
-            .aptitude-table td {
-                padding: 4px 8px;
-                text-align: center;
-                border: 1px solid var(--border-color);
-            }
-
-            .aptitude-table th {
-                background: rgba(255, 255, 255, 0.03);
-                color: var(--text-secondary);
-                font-weight: 600;
-                font-size: 10px;
+            .erank .lab {
+                font-size: 9px;
+                color: var(--text-muted);
                 text-transform: uppercase;
-                width: 100px;
+                letter-spacing: 1.5px;
+                margin-top: 4px;
             }
-
-            .aptitude-cell {
-                display: inline-flex;
+            .ctrs {
+                margin-left: auto;
+                display: flex;
+                gap: 6px;
+                padding: 6px;
+                background: var(--bg-primary);
+                border: 1px solid var(--border-color);
+                border-radius: 8px;
+            }
+            .ctr {
+                display: flex;
                 flex-direction: column;
                 align-items: center;
-                gap: 2px;
-                margin: 0 8px;
+                min-width: 44px;
+                padding: 2px 4px;
+                cursor: default;
             }
-
-            .aptitude-name {
-                font-size: 11px;
+            .ctr .n {
+                font-family: var(--font-mono);
+                font-size: 15px;
+                font-weight: 700;
+                color: var(--text-primary);
+            }
+            .ctr .k {
+                font-size: 8px;
                 color: var(--text-muted);
-                font-weight: 500;
+                letter-spacing: 0.5px;
+                margin-top: 1px;
+            }
+            .ctr + .ctr {
+                border-left: 1px solid var(--border-color);
             }
 
+            /* Aptitude grade badge (used inside the Identity zone's aptitude rows). */
             .grade-badge {
-                display: inline-block;
-                width: 20px;
-                height: 20px;
-                line-height: 20px;
-                text-align: center;
+                display: inline-flex;
+                align-items: center;
+                justify-content: center;
+                width: 19px;
+                height: 19px;
                 border-radius: 4px;
                 font-weight: 800;
-                font-size: 13px;
+                font-size: 11px;
                 background: #333;
                 color: #fff;
             }
@@ -1072,29 +1322,7 @@
                 background: #444;
             }
 
-            /* Conditions Section */
-            .conditions-section {
-                padding: 10px;
-                width: auto;
-                background: var(--bg-secondary);
-                border: 1px solid var(--border-color);
-                border-radius: var(--radius);
-                display: flex;
-                flex-direction: column;
-                gap: 10px;
-            }
-            .condition-group {
-                display: flex;
-                flex-direction: column;
-                gap: 5px;
-            }
-            .condition-group-label {
-                font-size: 10px;
-                font-weight: 700;
-                color: var(--text-muted);
-                text-transform: uppercase;
-                letter-spacing: 0.5px;
-            }
+            /* Conditions (folded into the Identity zone via .cond-strip). */
             .condition-list {
                 display: flex;
                 flex-wrap: wrap;
@@ -1207,179 +1435,414 @@
                 font-weight: 600;
                 color: var(--text-primary);
             }
-            @media screen and (max-width: 800px) {
+            @media (max-width: 800px) {
+                .header {
+                    flex-wrap: wrap;
+                    height: auto;
+                    padding: 10px 14px;
+                    gap: 8px 16px;
+                }
+                .tab-nav {
+                    order: 3;
+                    width: 100%;
+                    overflow-x: auto;
+                    gap: 18px;
+                    padding-bottom: 2px;
+                }
+                .status-badge {
+                    margin-left: auto;
+                }
+
+                /* //////// Dashboard as a bottom peek-sheet //////// */
+                /* A slim glance bar pins to the bottom; the sheet slides up from behind it to reveal the full dashboard, freeing the whole screen for the log when collapsed. */
+                .mobile-sheet {
+                    display: flex;
+                    flex-direction: column;
+                    position: fixed;
+                    left: 0;
+                    right: 0;
+                    bottom: 0;
+                    height: 90vh;
+                    z-index: 60;
+                    background: var(--bg-secondary);
+                    border-top: 1px solid var(--border-color);
+                    box-shadow: 0 -8px 28px rgba(0, 0, 0, 0.45);
+                    transform: translateY(calc(90vh - var(--peek-h)));
+                    transition: transform 0.32s cubic-bezier(0.4, 0, 0.2, 1);
+                }
+                .mobile-sheet.open {
+                    transform: translateY(0);
+                }
+                .sheet-peek {
+                    display: flex;
+                    align-items: center;
+                    justify-content: center;
+                    flex-shrink: 0;
+                    height: var(--peek-h);
+                    padding: 0 16px;
+                    cursor: pointer;
+                    user-select: none;
+                    -webkit-tap-highlight-color: transparent;
+                    border-bottom: 1px solid var(--border-color);
+                }
+                /* Glance (collapsed only): trainee name, turn, estimated rank. Hidden when expanded so it never repeats the dashboard below. */
+                .peek-glance {
+                    display: flex;
+                    align-items: center;
+                    gap: 9px;
+                    flex: 1;
+                }
+                .mobile-sheet.open .peek-glance {
+                    display: none;
+                }
+                /* Grip handle (expanded only): the sheet's grabber. */
+                .peek-grip {
+                    display: none;
+                    width: 40px;
+                    height: 4px;
+                    border-radius: 2px;
+                    background: var(--text-muted);
+                    opacity: 0.5;
+                }
+                .mobile-sheet.open .peek-grip {
+                    display: block;
+                }
+                .peek-name {
+                    font-size: 14px;
+                    font-weight: 800;
+                    color: var(--text-primary);
+                    white-space: nowrap;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    max-width: 42vw;
+                }
+                .peek-turn {
+                    font-size: 11px;
+                    font-family: var(--font-mono);
+                    color: var(--text-muted);
+                    white-space: nowrap;
+                }
+                .peek-fill {
+                    flex: 1;
+                }
+                .peek-rank {
+                    height: 26px;
+                    width: auto;
+                }
+                .peek-rank:not([src]),
+                .peek-rank[src=""] {
+                    display: none;
+                }
+                .peek-score {
+                    font-size: 14px;
+                    font-weight: 800;
+                    font-family: var(--font-mono);
+                    color: var(--text-primary);
+                    white-space: nowrap;
+                }
+                .peek-chevron {
+                    font-size: 11px;
+                    color: var(--text-secondary);
+                }
+                .sheet-backdrop {
+                    display: block;
+                    position: fixed;
+                    inset: 0;
+                    background: rgba(0, 0, 0, 0.55);
+                    opacity: 0;
+                    pointer-events: none;
+                    transition: opacity 0.32s;
+                    z-index: 59;
+                }
+                .sheet-backdrop.show {
+                    opacity: 1;
+                    pointer-events: auto;
+                }
+
+                /* The dashboard fills the sheet below the glance bar and scrolls as one column. */
                 .dashboard {
-                    flex-wrap: wrap !important;
-                    flex-direction: row !important;
-                    padding: 6px 10px !important;
-                    gap: 8px !important;
+                    flex: 1;
+                    flex-direction: column;
+                    height: auto;
+                    min-height: 0;
+                    overflow-y: auto;
+                    border-bottom: none;
                 }
-                .aptitude-table {
-                    flex: 1 1 50% !important;
-                    max-width: 58% !important;
-                    min-width: 0 !important;
-                    font-size: 8px !important;
-                    background: rgba(255, 255, 255, 0.02) !important;
+                .zone + .zone {
+                    border-left: none;
+                    border-top: 1px solid var(--border-color);
                 }
-                .aptitude-table th {
-                    width: 50px !important;
-                    padding: 2px 4px !important;
+
+                /* Identity text and aptitudes side by side to use the width. */
+                .z-id {
+                    flex: none;
+                    width: 100%;
+                    overflow: visible;
+                    display: flex;
+                    flex-flow: row wrap;
+                    column-gap: 14px;
                 }
-                .aptitude-table td {
-                    padding: 2px 4px !important;
+                .id-main {
+                    display: flex;
+                    flex-direction: column;
+                    flex: 1 1 150px;
+                    min-width: 0;
                 }
-                .aptitude-cell {
-                    margin: 0 2px !important;
-                    gap: 1px !important;
+                .apts {
+                    flex: 1 1 130px;
+                    align-self: flex-start;
+                    margin-top: 0;
+                    padding-top: 0;
+                    padding-left: 14px;
+                    border-top: none;
+                    border-left: 1px solid var(--border-color);
                 }
-                .aptitude-name {
-                    font-size: 8px !important;
+                .cond-strip {
+                    flex-basis: 100%;
                 }
-                .grade-badge {
-                    width: 16px !important;
-                    height: 16px !important;
-                    line-height: 16px !important;
-                    font-size: 10px !important;
+
+                /* Stats meters get breathing room under the last (WIT) row before the divider. */
+                .z-stat {
+                    flex: none;
+                    width: 100%;
                 }
-                .conditions-section {
-                    flex: 1 1 35% !important;
-                    max-width: 40% !important;
-                    min-width: 0 !important;
-                    padding: 4px 6px !important;
-                    gap: 4px !important;
+                .meters {
+                    max-width: none;
+                    margin-bottom: 14px;
                 }
-                .condition-group-label {
-                    font-size: 8px !important;
+                /* Estimated rank + counters share one row. */
+                .statfoot {
+                    max-width: none;
+                    flex-wrap: nowrap;
+                    gap: 10px;
                 }
-                .condition-badge {
-                    font-size: 9px !important;
-                    padding: 1px 4px !important;
+                .erank {
+                    gap: 9px;
                 }
-                .dashboard-info {
-                    flex: 1 0 100% !important;
-                    flex-direction: row !important;
-                    align-items: flex-start !important;
-                    text-align: left !important;
-                    gap: 8px !important;
-                    margin-top: 4px !important;
+                .est-rank-img {
+                    height: 40px;
                 }
-                .info-left-col {
-                    flex: 1 !important;
-                    align-items: flex-start !important;
-                    gap: 4px !important;
+                .erank .score {
+                    font-size: 22px;
                 }
-                .info-right-col {
-                    flex: 1 !important;
-                    align-items: center !important;
-                    gap: 8px !important;
+                .ctrs {
+                    margin-left: auto;
+                    gap: 2px;
+                    padding: 5px 4px;
                 }
-                .dashboard-row {
-                    justify-content: flex-start !important;
-                    width: 100% !important;
-                    gap: 8px !important;
+                .ctr {
+                    min-width: 0;
+                    padding: 2px 5px;
                 }
-                .info-right-col .dashboard-row {
-                    justify-content: center !important;
+                .ctr .n {
+                    font-size: 13px;
                 }
-                .stat-box {
-                    min-width: 32px !important;
+
+                /* Right rail becomes horizontal tabs above its panel, which flows in the sheet scroll. The .dashboard prefix outranks the base right-zone rules defined later in the file. */
+                .dashboard .z-side {
+                    flex: none;
+                    width: 100%;
+                    min-width: 0;
+                    flex-direction: column;
+                    padding: 0;
                 }
-                .stat-label {
-                    font-size: 8px !important;
+                .dashboard .rail {
+                    flex-direction: row;
+                    width: 100%;
+                    border-left: none;
+                    border-bottom: 1px solid var(--border-color);
+                    order: -1;
                 }
-                .stat-value {
-                    font-size: 11px !important;
+                .dashboard .rail-tab {
+                    flex: 1;
+                    padding: 9px;
                 }
-                .dashboard-label {
-                    font-size: 8px !important;
+                .dashboard .rail-tab span {
+                    writing-mode: horizontal-tb;
+                    transform: none;
                 }
-                .dashboard-value {
-                    font-size: 11px !important;
+                .dashboard .rail-tab.active {
+                    box-shadow: inset 0 -3px 0 var(--accent-blue);
                 }
-                .stats-container {
-                    padding: 4px 8px !important;
-                    gap: 6px !important;
+                .dashboard .side-body {
+                    max-height: none;
+                    overflow: visible;
+                }
+                .dashboard .year-cards {
+                    grid-template-columns: 1fr;
+                }
+                .dashboard .calendar-row {
+                    grid-template-columns: repeat(4, minmax(0, 1fr));
                 }
                 .search-container {
-                    min-width: 100% !important;
-                    max-width: none !important;
+                    min-width: 100%;
+                    max-width: none;
+                }
+
+                /* Toolbar tidied into rows: search (full) / filters + auto-scroll + count / font stepper + action icons. The desktop spacers are dropped so nothing scatters. */
+                .toolbar-content {
+                    gap: 8px;
+                }
+                .toolbar-grow,
+                .toolbar-separator {
+                    display: none;
+                }
+                .filter-group.segmented {
+                    flex-shrink: 0;
+                }
+                .filter-group.segmented .filter-btn {
+                    padding: 4px 8px;
+                }
+                .message-count {
+                    margin-left: auto;
+                }
+                .mc-label {
+                    display: none;
+                }
+                #compactBtn {
+                    margin-left: auto;
+                }
+
+                /* Keep the log clear of the fixed glance bar. */
+                .log-container {
+                    padding-bottom: calc(var(--peek-h) + 8px);
+                }
+                .scroll-bottom-btn {
+                    bottom: calc(var(--peek-h) + 14px);
                 }
             }
 
-            /* Race History Calendar (Smart Race Solver). Rightmost dashboard flex child. max-height matches the row so it
-               never stretches it and overflow scrolls internally. Mirrors the React Native SRS Settings page - keep palette and sizes in sync. */
-            /* Position-absolute body trick: the section is only the header in normal flow so it never grows the dashboard row,
-               then align-self: stretch expands it to full height and the absolute body fills the rest with internal scrolling. */
-            .race-history-section {
-                position: relative;
-                padding: 8px 10px;
+            /* //////// Right zone: shared rail (Race History / Skills panels) //////// */
+            /* The panel body scrolls internally within the fixed-height dashboard. Calendar palette/sizes mirror the React Native SRS Settings page - keep them in sync. */
+            .z-side {
+                flex: 1.15 1 0;
+                min-width: 360px;
+                padding: 0;
+                flex-direction: row;
+            }
+            .side-main {
+                flex: 1;
+                display: flex;
+                flex-direction: column;
+                padding: 12px 14px;
+                min-width: 0;
+            }
+            .side-head {
+                display: flex;
+                align-items: center;
+                margin-bottom: 9px;
+            }
+            .side-turn {
+                font-size: 10px;
+                font-family: var(--font-mono);
+                color: var(--text-secondary);
                 background: var(--bg-primary);
                 border: 1px solid var(--border-color);
-                border-radius: var(--radius);
-                flex: 1 1 auto;
-                min-width: 0;
-                align-self: stretch;
-                overflow: hidden;
+                border-radius: 10px;
+                padding: 2px 10px;
             }
-
-            /* Hide the panel when the Smart Race Solver is disabled. Uses visibility: hidden, not display: none, so the section
-               keeps its flex slot and the other dashboard tiles do not shift. Kotlin pushes SRS_STATE via LogStreamServer at run
-               start. This class stays the initial state so the empty grid never flashes before the first message arrives. */
-            .race-history-section.srs-disabled {
-                visibility: hidden;
-            }
-
-            .race-history-body {
-                position: absolute;
-                top: 36px;
-                left: 10px;
-                right: 10px;
-                bottom: 8px;
+            .side-body {
+                flex: 1;
                 overflow-y: auto;
+                min-height: 0;
+                padding-right: 4px;
             }
-
-            .race-history-header {
+            /* Vertical rail of panel tabs; the active tab reveals its panel and clicking it again collapses the body. */
+            .rail {
+                display: flex;
+                flex-direction: column;
+                width: 34px;
+                flex-shrink: 0;
+                border-left: 1px solid var(--border-color);
+            }
+            .rail-tab {
+                flex: 1;
                 display: flex;
                 align-items: center;
-                justify-content: space-between;
-                gap: 8px;
-            }
-
-            .race-history-header-left {
-                display: flex;
-                align-items: center;
-                gap: 8px;
-            }
-
-            /* Chevron is mobile-only; on desktop the panel is always expanded and the
-               collapsed class becomes a no-op. */
-            .race-history-chevron {
-                display: none;
-                width: 10px;
-                color: var(--text-secondary);
-                transform: rotate(0deg);
-                transition: transform 0.15s ease;
-            }
-
-            .race-history-section.collapsed .race-history-chevron {
-                transform: rotate(-90deg);
-            }
-
-            .race-history-title {
-                font-size: 13px;
+                justify-content: center;
+                cursor: pointer;
+                color: var(--text-muted);
+                background: var(--bg-tertiary);
+                font-size: 10px;
                 font-weight: 700;
-                color: var(--text-primary);
-                letter-spacing: 0.5px;
+                letter-spacing: 1.5px;
                 text-transform: uppercase;
             }
-
-            .race-history-turn-badge {
-                font-size: 11px;
+            .rail-tab span {
+                writing-mode: vertical-rl;
+                transform: rotate(180deg);
+            }
+            .rail-tab + .rail-tab {
+                border-top: 1px solid var(--border-color);
+            }
+            .rail-tab:hover {
                 color: var(--text-secondary);
-                background: var(--bg-primary);
+            }
+            .rail-tab.active {
+                color: var(--accent-blue);
+                background: var(--bg-secondary);
+                box-shadow: inset 3px 0 0 var(--accent-blue);
+            }
+            /* Collapsed: the panel body hides and the Stats zone grows into the freed space. */
+            .dashboard.side-collapsed .side-main {
+                display: none;
+            }
+
+            /* Skills panel (populated once the Skills-tab reader feeds it; see the owned-skill tracking work). */
+            .skills-grid {
+                display: grid;
+                grid-template-columns: repeat(2, 1fr);
+                gap: 6px;
+            }
+            .skill-pill {
+                display: flex;
+                align-items: center;
+                gap: 7px;
+                padding: 6px 8px;
                 border: 1px solid var(--border-color);
-                border-radius: 4px;
-                padding: 2px 8px;
+                border-radius: 6px;
+                background: var(--bg-primary);
+                font-size: 11px;
+            }
+            .skill-pill .dotc {
+                width: 8px;
+                height: 8px;
+                border-radius: 50%;
+                flex-shrink: 0;
+            }
+            .skill-pill.gold {
+                border-color: rgba(230, 160, 44, 0.5);
+            }
+            .skill-pill.gold .dotc {
+                background: #e8a02c;
+            }
+            .skill-pill.uniq {
+                border-color: rgba(155, 109, 255, 0.5);
+            }
+            .skill-pill.uniq .dotc {
+                background: var(--accent-purple);
+            }
+            .skill-pill.norm .dotc {
+                background: var(--text-secondary);
+            }
+            .skill-pill.neg {
+                border-color: rgba(239, 68, 68, 0.5);
+            }
+            .skill-pill.neg .dotc {
+                background: var(--log-error);
+            }
+            .skill-pill .lv {
+                margin-left: auto;
+                font-family: var(--font-mono);
+                font-size: 9px;
+                color: var(--text-muted);
+            }
+            .skills-hint {
+                grid-column: 1 / -1;
+                font-size: 11px;
+                color: var(--text-muted);
+                font-style: italic;
+                margin-top: 4px;
             }
 
             .year-cards {
@@ -1502,46 +1965,6 @@
                 margin-top: 3px;
             }
 
-            @media (max-width: 1024px) {
-                /* On mobile the panel sits on its own row below the dashboard, so the desktop
-                   absolute-body trick is unnecessary - put the body back in normal flow so it
-                   contributes to the section's height when expanded and disappears when collapsed. */
-                .race-history-section {
-                    flex: 1 0 100%;
-                    max-height: none;
-                    display: flex;
-                    flex-direction: column;
-                    gap: 6px;
-                }
-                .race-history-body {
-                    position: static;
-                    top: auto;
-                    left: auto;
-                    right: auto;
-                    bottom: auto;
-                    max-height: 360px;
-                    overflow-y: auto;
-                }
-                .race-history-chevron {
-                    display: inline-block;
-                }
-                .race-history-header {
-                    cursor: pointer;
-                    user-select: none;
-                }
-                .race-history-section.collapsed .race-history-body {
-                    display: none;
-                }
-                /* On mobile the panel takes its own row, so hiding it via `display: none` is fine -
-                   no adjacent tile shifts. Override the desktop `visibility: hidden` rule so the
-                   empty band does not stay reserved on narrow viewports. */
-                .race-history-section.srs-disabled {
-                    display: none;
-                }
-                .year-cards {
-                    grid-template-columns: 1fr;
-                }
-            }
 
             @media (max-width: 768px) {
                 .calendar-cell {
@@ -1908,184 +2331,143 @@
         </style>
     </head>
     <body>
-        <!-- Header -->
+        <!-- Header with inline tabs and a connection status chip (which also shows the connected host, replacing the old footer). -->
         <header class="header">
-            <div class="header-left">
-                <div>
-                    <div class="logo">Uma Android Automation</div>
-                    <div class="logo-sub">Remote Log Viewer</div>
-                </div>
+            <div class="logo-block">
+                <div class="logo">Uma Android Automation</div>
+                <div class="logo-sub">Remote Log Viewer</div>
             </div>
-            <!-- Connection status indicator badge. -->
+            <nav class="tab-nav">
+                <button id="logsTabBtn" class="tab-btn active" onclick="switchTab('logs')">Logs & Dashboard</button>
+                <button id="imagesTabBtn" class="tab-btn" onclick="switchTab('images')">Debug Images</button>
+                <button id="logFilesTabBtn" class="tab-btn" onclick="switchTab('logFiles')">Log Files</button>
+                <button id="analyticsTabBtn" class="tab-btn" onclick="switchTab('analytics')">Analytics</button>
+            </nav>
             <div id="statusBadge" class="status-badge status-connecting">
                 <div class="status-dot"></div>
-                <span id="statusText">Connecting</span>
+                <div class="status-lines">
+                    <span id="statusText">Connecting</span>
+                    <span id="statusHost" class="status-host"></span>
+                </div>
             </div>
         </header>
 
-        <!-- Tabs -->
-        <nav class="tab-nav">
-            <button id="logsTabBtn" class="tab-btn active" onclick="switchTab('logs')">Logs & Dashboard</button>
-            <button id="imagesTabBtn" class="tab-btn" onclick="switchTab('images')">Debug Images</button>
-            <button id="logFilesTabBtn" class="tab-btn" onclick="switchTab('logFiles')">Log Files</button>
-            <button id="analyticsTabBtn" class="tab-btn" onclick="switchTab('analytics')">Analytics</button>
-        </nav>
-
         <!-- Logs & Dashboard View -->
         <div id="logsView" class="tab-view active">
-            <!-- Dashboard -->
-            <div class="dashboard">
-            <table class="aptitude-table">
-                <tr>
-                    <th>Terrain</th>
-                    <td id="rowTerrain">
-                        <div class="aptitude-cell"><span class="aptitude-name">Turf</span><span id="aptTurf" class="grade-badge grade-G">-</span></div>
-                        <div class="aptitude-cell"><span class="aptitude-name">Dirt</span><span id="aptDirt" class="grade-badge grade-G">-</span></div>
-                    </td>
-                </tr>
-                <tr>
-                    <th>Distance</th>
-                    <td id="rowDistance">
-                        <div class="aptitude-cell"><span class="aptitude-name">Sprint</span><span id="aptSprint" class="grade-badge grade-G">-</span></div>
-                        <div class="aptitude-cell"><span class="aptitude-name">Mile</span><span id="aptMile" class="grade-badge grade-G">-</span></div>
-                        <div class="aptitude-cell"><span class="aptitude-name">Medium</span><span id="aptMedium" class="grade-badge grade-G">-</span></div>
-                        <div class="aptitude-cell"><span class="aptitude-name">Long</span><span id="aptLong" class="grade-badge grade-G">-</span></div>
-                    </td>
-                </tr>
-                <tr>
-                    <th>Style</th>
-                    <td id="rowStyle">
-                        <div class="aptitude-cell"><span class="aptitude-name">Front</span><span id="aptFront" class="grade-badge grade-G">-</span></div>
-                        <div class="aptitude-cell"><span class="aptitude-name">Pace</span><span id="aptPace" class="grade-badge grade-G">-</span></div>
-                        <div class="aptitude-cell"><span class="aptitude-name">Late</span><span id="aptLate" class="grade-badge grade-G">-</span></div>
-                        <div class="aptitude-cell"><span class="aptitude-name">End</span><span id="aptEnd" class="grade-badge grade-G">-</span></div>
-                    </td>
-                </tr>
-            </table>
-                <!-- Trainee Conditions -->
-                <div class="conditions-section">
-            <div class="condition-group">
-                <div class="condition-group-label">Mood Conditions</div>
-                <div id="moodConditions" class="condition-list">
-                    <span class="condition-empty">Unknown</span>
+            <!-- Dashboard. On mobile it collapses into a bottom peek-sheet; the glance bar (#sheetPeek) doubles as the expand/collapse handle. -->
+            <div class="mobile-sheet" id="mobileSheet">
+                <!-- Collapsed glance bar (mobile only): trainee name, turn, estimated rank. Tap or swipe to expand the full dashboard. -->
+                <div class="sheet-peek" id="sheetPeek">
+                    <!-- Expanded: a centered grip handle (tap/swipe/backdrop to collapse). The glance shows only when collapsed so it never repeats the dashboard below it. -->
+                    <span class="peek-grip" aria-hidden="true"></span>
+                    <div class="peek-glance">
+                        <span class="peek-name" id="peekName">No trainee</span>
+                        <span class="peek-turn" id="peekTurn">Turn -</span>
+                        <span class="peek-fill"></span>
+                        <img class="peek-rank" id="peekRankImg" alt="" />
+                        <span class="peek-score" id="peekScore"></span>
+                        <span class="peek-chevron" id="peekChevron" aria-hidden="true">&#9650;</span>
+                    </div>
                 </div>
-            </div>
-                    <div class="condition-group">
-                        <div class="condition-group-label">Positive Conditions</div>
-                        <div id="positiveConditions" class="condition-list">
-                            <span class="condition-empty">None</span>
+                <div class="dashboard" id="dashboard">
+                <!-- Identity zone: name, mood, vitals, date/turn, aptitudes, conditions. -->
+                <div class="zone z-id">
+                    <!-- id-main groups the identity text so it can sit beside the aptitudes on mobile (display:contents on desktop keeps the original vertical stacking). -->
+                    <div class="id-main">
+                    <div id="dashboardName" class="name">-</div>
+                    <div id="moodConditions" class="mood-slot"><span class="condition-empty">Unknown</span></div>
+                    <div class="vitals">
+                        <div class="vital"><span class="k">Energy</span><span class="b"><i id="energyBar"></i></span><span id="dashboardEnergy" class="v">-</span></div>
+                        <div class="vital"><span class="k">Fans</span><span id="dashboardFans" class="v">-</span><span class="k" style="width: auto; margin-left: auto">SP</span><span id="dashboardSkillPoints" class="v">-</span></div>
+                    </div>
+                    <div class="idmeta"><span id="dashboardDate">-</span> &middot; Turn <b id="dashboardTurn">-</b></div>
+                    </div>
+                    <div class="apts">
+                        <div class="zt">Aptitudes</div>
+                        <div class="aptrow">
+                            <span class="al">Track</span>
+                            <span class="cells">
+                                <span class="apt" data-tip="Turf"><span id="aptTurf" class="grade-badge grade-G">-</span></span>
+                                <span class="apt" data-tip="Dirt"><span id="aptDirt" class="grade-badge grade-G">-</span></span>
+                            </span>
+                        </div>
+                        <div class="aptrow">
+                            <span class="al">Dist</span>
+                            <span class="cells">
+                                <span class="apt" data-tip="Sprint"><span id="aptSprint" class="grade-badge grade-G">-</span></span>
+                                <span class="apt" data-tip="Mile"><span id="aptMile" class="grade-badge grade-G">-</span></span>
+                                <span class="apt" data-tip="Medium"><span id="aptMedium" class="grade-badge grade-G">-</span></span>
+                                <span class="apt" data-tip="Long"><span id="aptLong" class="grade-badge grade-G">-</span></span>
+                            </span>
+                        </div>
+                        <div class="aptrow">
+                            <span class="al">Style</span>
+                            <span class="cells">
+                                <span class="apt" data-tip="Front"><span id="aptFront" class="grade-badge grade-G">-</span></span>
+                                <span class="apt" data-tip="Pace"><span id="aptPace" class="grade-badge grade-G">-</span></span>
+                                <span class="apt" data-tip="Late"><span id="aptLate" class="grade-badge grade-G">-</span></span>
+                                <span class="apt" data-tip="End"><span id="aptEnd" class="grade-badge grade-G">-</span></span>
+                            </span>
                         </div>
                     </div>
-                    <div class="condition-group">
-                        <div class="condition-group-label">Negative Conditions</div>
-                        <div id="negativeConditions" class="condition-list">
-                            <span class="condition-empty">None</span>
+                    <div class="cond-strip">
+                        <span id="positiveConditions" class="condition-list cond-inline"><span class="condition-empty">None</span></span>
+                        <span id="negativeConditions" class="condition-list cond-inline"><span class="condition-empty">None</span></span>
+                    </div>
+                </div>
+
+                <!-- Stats zone: five meters filling toward each OCR'd cap, then estimated rank + session counters. -->
+                <div class="zone z-stat">
+                    <div class="zt">Stats &middot; progress to cap</div>
+                    <div class="meters">
+                        <div class="meter" style="--c: var(--spd)"><span class="nm">SPD</span><span class="track"><span id="statSpeedFill" class="fill"></span></span><span class="vc"><span id="statSpeed">-</span><span id="statSpeedCap" class="cap"></span></span><img id="statSpeedGrade" class="stat-grade-img" alt="" /></div>
+                        <div class="meter" style="--c: var(--sta)"><span class="nm">STA</span><span class="track"><span id="statStaminaFill" class="fill"></span></span><span class="vc"><span id="statStamina">-</span><span id="statStaminaCap" class="cap"></span></span><img id="statStaminaGrade" class="stat-grade-img" alt="" /></div>
+                        <div class="meter" style="--c: var(--pow)"><span class="nm">POW</span><span class="track"><span id="statPowerFill" class="fill"></span></span><span class="vc"><span id="statPower">-</span><span id="statPowerCap" class="cap"></span></span><img id="statPowerGrade" class="stat-grade-img" alt="" /></div>
+                        <div class="meter" style="--c: var(--gut)"><span class="nm">GUT</span><span class="track"><span id="statGutsFill" class="fill"></span></span><span class="vc"><span id="statGuts">-</span><span id="statGutsCap" class="cap"></span></span><img id="statGutsGrade" class="stat-grade-img" alt="" /></div>
+                        <div class="meter" style="--c: var(--wit)"><span class="nm">WIT</span><span class="track"><span id="statWitFill" class="fill"></span></span><span class="vc"><span id="statWit">-</span><span id="statWitCap" class="cap"></span></span><img id="statWitGrade" class="stat-grade-img" alt="" /></div>
+                    </div>
+                    <div class="statfoot">
+                        <div class="erank" title="Estimated overall rank (approximate: stats + aptitudes + owned skills)">
+                            <img id="estRankImg" class="est-rank-img" alt="" />
+                            <div id="estRankText" class="est-rank-text"></div>
+                            <div>
+                                <div id="estRankScore" class="score">-</div>
+                                <div class="lab">Estimated Rank</div>
+                            </div>
+                        </div>
+                        <div class="ctrs">
+                            <div class="ctr" onmouseenter="showTrainingTooltip(event)" onmouseleave="hideTooltip()"><div id="countTraining" class="n">0</div><div class="k">TRAIN</div></div>
+                            <div class="ctr" onmouseenter="showRaceTooltip(event)" onmouseleave="hideTooltip()"><div id="countRace" class="n">0</div><div class="k">RACE</div></div>
+                            <div class="ctr" onmouseenter="showSimpleTooltip(event, 'Injury Recovery')" onmouseleave="hideTooltip()"><div id="countInjury" class="n">0</div><div class="k">INJURY</div></div>
+                            <div class="ctr" onmouseenter="showMoodTooltip(event)" onmouseleave="hideTooltip()"><div id="countMood" class="n">0</div><div class="k">MOOD</div></div>
+                            <div class="ctr" onmouseenter="showEnergyTooltip(event)" onmouseleave="hideTooltip()"><div id="countEnergy" class="n">0</div><div class="k">ENERGY</div></div>
                         </div>
                     </div>
                 </div>
 
-            <div class="dashboard-info">
-                <div class="info-left-col">
-                    <div class="dashboard-row">
-                        <div class="dashboard-item">
-                            <div class="dashboard-label">Trainee</div>
-                            <div id="dashboardName" class="dashboard-value" style="font-weight: 600; letter-spacing: 0.3px">-</div>
+                <!-- Right zone: shared rail (Race History / Skills). Keeps id raceHistorySection for the SRS wiring. -->
+                <div class="zone z-side srs-disabled" id="raceHistorySection">
+                    <div class="side-main">
+                        <div class="side-head"><span class="side-turn" id="raceHistoryTurnBadge">Turn -</span></div>
+                        <div class="side-body">
+                            <div id="raceHistoryPanel">
+                                <div id="raceHistoryYears" class="year-cards"></div>
+                                <div id="raceHistoryDisabled" class="skills-hint" style="display: none">Smart Race Solver is off - no race plan for this run.</div>
+                            </div>
+                            <div id="skillsPanel" style="display: none">
+                                <div class="skills-hint">Owned skills - populated once the Skills-tab reader lands.</div>
+                            </div>
                         </div>
                     </div>
-                    <div class="dashboard-row">
-                        <div class="dashboard-item">
-                            <div class="dashboard-label">Energy</div>
-                            <div id="dashboardEnergy" class="dashboard-value">-</div>
-                        </div>
-                        <div class="dashboard-item">
-                            <div class="dashboard-label">Fans</div>
-                            <div id="dashboardFans" class="dashboard-value">-</div>
-                        </div>
-                        <div class="dashboard-item">
-                            <div class="dashboard-label">Skill Points</div>
-                            <div id="dashboardSkillPoints" class="dashboard-value">-</div>
-                        </div>
-                    </div>
-                    <div class="dashboard-row">
-                        <div class="dashboard-item">
-                            <div class="dashboard-label">Current Date</div>
-                            <div id="dashboardDate" class="dashboard-value">-</div>
-                        </div>
-                        <div class="dashboard-item">
-                            <div class="dashboard-label">Turn</div>
-                            <div id="dashboardTurn" class="dashboard-value">-</div>
-                        </div>
+                    <div class="rail">
+                        <div class="rail-tab active" id="tabRace" onclick="railClick('race')"><span>Race History</span></div>
+                        <div class="rail-tab" id="tabSkills" onclick="railClick('skills')"><span>Skills</span></div>
                     </div>
                 </div>
-                <div class="info-right-col">
-                    <div class="dashboard-row">
-                        <div class="stats-container">
-                            <div class="stat-box" title="Speed">
-                                <div class="stat-label">SPD</div>
-                                <div id="statSpeed" class="stat-value">-</div>
-                            </div>
-                            <div class="stat-box" title="Stamina">
-                                <div class="stat-label">STA</div>
-                                <div id="statStamina" class="stat-value">-</div>
-                            </div>
-                            <div class="stat-box" title="Power">
-                                <div class="stat-label">POW</div>
-                                <div id="statPower" class="stat-value">-</div>
-                            </div>
-                            <div class="stat-box" title="Guts">
-                                <div class="stat-label">GUT</div>
-                                <div id="statGuts" class="stat-value">-</div>
-                            </div>
-                            <div class="stat-box" title="Wit">
-                                <div class="stat-label">WIT</div>
-                                <div id="statWit" class="stat-value">-</div>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="dashboard-row">
-                        <!-- Session Action Counters -->
-                        <div class="stats-container session-stats">
-                            <div class="stat-box" onmouseenter="showTrainingTooltip(event)" onmouseleave="hideTooltip()">
-                                <div class="stat-label">TRN</div>
-                                <div id="countTraining" class="stat-value">0</div>
-                            </div>
-                            <div class="stat-box" onmouseenter="showRaceTooltip(event)" onmouseleave="hideTooltip()">
-                                <div class="stat-label">RCE</div>
-                                <div id="countRace" class="stat-value">0</div>
-                            </div>
-                            <div class="stat-box" onmouseenter="showSimpleTooltip(event, 'Injury Recovery')" onmouseleave="hideTooltip()">
-                                <div class="stat-label">INJ</div>
-                                <div id="countInjury" class="stat-value">0</div>
-                            </div>
-                            <div class="stat-box" onmouseenter="showMoodTooltip(event)" onmouseleave="hideTooltip()">
-                                <div class="stat-label">MOD</div>
-                                <div id="countMood" class="stat-value">0</div>
-                            </div>
-                            <div class="stat-box" onmouseenter="showEnergyTooltip(event)" onmouseleave="hideTooltip()">
-                                <div class="stat-label">ENG</div>
-                                <div id="countEnergy" class="stat-value">0</div>
-                            </div>
-                        </div>
-                    </div>
                 </div>
             </div>
-
-            <!-- Race History calendar (Smart Race Solver). Sits inside the dashboard row so it
-                 occupies the empty space that .dashboard-info used to consume via flex:1, without
-                 changing the widths or positions of the existing 3 blocks. -->
-            <div id="raceHistorySection" class="race-history-section collapsed srs-disabled">
-                <div class="race-history-header" onclick="toggleRaceHistory()">
-                    <div class="race-history-header-left">
-                        <span class="race-history-chevron">v</span>
-                        <span class="race-history-title">Race History</span>
-                    </div>
-                    <span class="race-history-turn-badge" id="raceHistoryTurnBadge">Turn -</span>
-                </div>
-                <div class="race-history-body">
-                    <div id="raceHistoryYears" class="year-cards"></div>
-                </div>
-            </div>
-        </div>
+            <!-- Backdrop behind the expanded mobile sheet; tap it to collapse. -->
+            <div class="sheet-backdrop" id="sheetBackdrop"></div>
 
         <!-- Toolbar -->
         <div id="toolbar" class="toolbar">
@@ -2097,10 +2479,8 @@
                         <span id="searchClear" class="search-clear">✕</span>
                     </div>
 
-                    <div class="toolbar-separator"></div>
-
-                    <!-- Log level filtering buttons. -->
-                    <div class="filter-group">
+                    <!-- Log level segmented control. -->
+                    <div class="filter-group segmented">
                         <button class="filter-btn active" data-level="VERBOSE" onclick="toggleFilter('VERBOSE', this)">V</button>
                         <button class="filter-btn active" data-level="DEBUG" onclick="toggleFilter('DEBUG', this)">D</button>
                         <button class="filter-btn active" data-level="INFO" onclick="toggleFilter('INFO', this)">I</button>
@@ -2108,14 +2488,16 @@
                         <button class="filter-btn active" data-level="ERROR" onclick="toggleFilter('ERROR', this)">E</button>
                     </div>
 
-                    <div class="toolbar-separator"></div>
-
-                    <!-- Log action buttons. -->
                     <button id="autoScrollBtn" class="toolbar-btn active" onclick="toggleAutoScroll()">⬇ Auto-scroll</button>
-                    <button id="compactBtn" class="toolbar-btn active" onclick="toggleCondensing()" title="Toggle Log Condensation (timestamps may appear out of order when enabled)">➞ Compact</button>
+
+                    <div class="toolbar-grow"></div>
+
+                    <!-- Message counter. -->
+                    <div class="message-count"><span class="mc-label">Messages:</span> <span id="messageCount">0</span></div>
 
                     <div class="toolbar-separator"></div>
 
+                    <!-- Action cluster: font-size stepper + compact / copy / download / clear icon buttons. -->
                     <div class="font-size-container">
                         <button class="size-btn" onclick="adjustFontSize(-0.5)" title="Decrease font size">-</button>
                         <input type="number" id="fontSizeInput" class="font-size-input" min="8" max="24" step="0.5" value="12.5" />
@@ -2123,14 +2505,18 @@
                         <button class="size-btn" onclick="adjustFontSize(0.5)" title="Increase font size">+</button>
                     </div>
 
-                    <button class="toolbar-btn" onclick="copyAllLogs()">📋 Copy</button>
-
-                    <button class="toolbar-btn" onclick="downloadLogs()">📥 Download</button>
-
-                    <button class="toolbar-btn" onclick="clearDisplay()">🗑 Clear</button>
-
-                    <!-- Message counter. -->
-                    <div class="message-count">Messages: <span id="messageCount">0</span></div>
+                    <button id="compactBtn" class="toolbar-btn icon active" onclick="toggleCondensing()" title="Toggle log condensation (timestamps may appear out of order when enabled)">
+                        <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.4"><path d="M3 5h10M3 8h10M3 11h10" /></svg>
+                    </button>
+                    <button class="toolbar-btn icon" onclick="copyAllLogs()" title="Copy all logs">
+                        <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.4"><rect x="5" y="5" width="8" height="9" rx="1.5" /><path d="M3 11V3.5A1.5 1.5 0 0 1 4.5 2H10" /></svg>
+                    </button>
+                    <button class="toolbar-btn icon" onclick="downloadLogs()" title="Download logs">
+                        <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.4"><path d="M8 2v8m0 0l3-3m-3 3L5 7M3 13h10" /></svg>
+                    </button>
+                    <button class="toolbar-btn icon" onclick="clearDisplay()" title="Clear logs">
+                        <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.4"><path d="M3 4h10M6 4V2.8h4V4m-5 0l.6 9h4.8L11 4" /></svg>
+                    </button>
                 </div>
             </div>
 
@@ -2143,7 +2529,7 @@
         </div>
 
         <!-- Log container -->
-        <div class="log-container" id="logContainer">
+        <div class="log-container ruled" id="logContainer">
             <!-- Empty state displayed when no logs are present. -->
             <div class="empty-state" id="emptyState">
                 <div class="empty-state-icon">📡</div>
@@ -2479,12 +2865,6 @@
             </div>
         </div>
 
-        <!-- Footer -->
-        <footer class="footer">
-            <span class="footer-left">Uma Android Automation - Remote Log Viewer</span>
-            <span id="footerInfo" class="footer-right"></span>
-        </footer>
-
         <script>
             // //////////////////////////////////////////////////////////////////////////////////////////////////
             // //////////////////////////////////////////////////////////////////////////////////////////////////
@@ -2685,7 +3065,7 @@
             const scrollBottomBtn = document.getElementById("scrollBottomBtn")
             const autoScrollBtn = document.getElementById("autoScrollBtn")
             const fontSizeInput = document.getElementById("fontSizeInput")
-            const footerInfo = document.getElementById("footerInfo")
+            const statusHost = document.getElementById("statusHost")
 
             let currentFontSize = 12.5 // Default font size in pixels.
 
@@ -2738,7 +3118,7 @@
                     if (reconnectInterval) clearInterval(reconnectInterval)
                     setStatus("connected")
                     reconnectAttempts = 0
-                    footerInfo.textContent = "Connected to " + location.host
+                    if (statusHost) statusHost.textContent = location.host
 
                     // Clear the display on a fresh connection so logs from a previous run do not duplicate when history resyncs.
                     clearDisplay()
@@ -2782,6 +3162,13 @@
                             onAnalyticsSnapshot(JSON.parse(event.data.substring(10)))
                         } catch (e) {
                             console.error("Error parsing analytics snapshot:", e)
+                        }
+                    } else if (event.data.startsWith("SKILLS:")) {
+                        // Owned-skills snapshot pushed after the Skills tab is read; feeds the right-rail Skills panel.
+                        try {
+                            renderSkills(JSON.parse(event.data.substring(7)))
+                        } catch (e) {
+                            console.error("Error parsing skills snapshot:", e)
                         }
                     } else {
                         // Process individual log messages, images or unknown formats.
@@ -2827,8 +3214,8 @@
                 reconnectAttempts++
                 var countdown = 5
 
-                // Update the footer to show connection is lost
-                footerInfo.textContent = "Connection lost. Retrying..."
+                // Clear the connected host from the status chip while the connection is down.
+                if (statusHost) statusHost.textContent = ""
 
                 // Start countdown immediately and tick every second
                 setStatus("connecting", `Reconnecting in ${countdown}...`)
@@ -2971,6 +3358,7 @@
                     energy: null,
                     fans: null,
                     skillPoints: null,
+                    estRank: null,
                     date: null,
                     turn: null,
                     stats: {},
@@ -3047,6 +3435,7 @@
                     energy: null,
                     fans: null,
                     skillPoints: null,
+                    estRank: null,
                     date: null,
                     turn: null,
                     mood: null,
@@ -3127,6 +3516,144 @@
                 const parts = num.toString().split(".")
                 parts[0] = parts[0].replace(/\B(?=(\d{3})+(?!\d))/g, ",")
                 return parts.join(".")
+            }
+
+            /**
+             * Trainee rank ladder, ordered weakest to strongest. A label's array index is the utx_txt_rank image number served at /ranks/<index>. Plain "G" is index 0 and has
+             * no badge image, so it renders without one. Shared by the per-stat grades and the estimated overall rank.
+             */
+            const RANK_LADDER = ["G", "G+", "F", "F+", "E", "E+", "D", "D+", "C", "C+", "B", "B+", "A", "A+", "S", "S+", "SS", "SS+"]
+            const RANK_LABEL_TO_INDEX = RANK_LADDER.reduce((map, label, index) => { map[label] = index; return map }, {})
+
+            /**
+             * Resolves a rank label to its utx_txt_rank image index. Handles the fixed ladder (G+..SS+, indices 1..17) plus the dynamic "UG" tiers above SS+. Image #18 is the base
+             * "UG" badge, so numbered tiers start one later: UGn -> index 18 + n (UG1..UG79 map to images 19..97).
+             * @param {string} label - The rank label, e.g. "SS+" or "UG6".
+             * @returns {number|undefined} The badge image index, or undefined when the label has no badge (plain "G" or an unknown label).
+             */
+            function rankLabelToIndex(label) {
+                if (typeof label === "string" && label.startsWith("UG")) {
+                    const n = parseInt(label.slice(2), 10)
+                    return Number.isFinite(n) ? 18 + n : undefined
+                }
+                return RANK_LABEL_TO_INDEX[label]
+            }
+
+            /**
+             * Builds the URL for a rank badge image. The images are hosted on uma.moe and loaded directly by the viewer's browser (which has internet access), so they are not
+             * bundled in the app. The index is the ladder position, zero-padded to two digits to match the utx_txt_rank_NN.webp filenames.
+             * @param {number} index - The rank ladder index (1..97).
+             * @returns {string} The image URL.
+             */
+            const RANK_IMAGE_BASE = "https://uma.moe/assets/images/icon/ranks/utx_txt_rank_"
+            function rankImageUrl(index) {
+                return RANK_IMAGE_BASE + String(index).padStart(2, "0") + ".webp"
+            }
+
+            /**
+             * Maps a raw stat value to its in-game letter grade. A "+" marks the upper half of each band (the band midpoint), matching the character-details badges. Above SS+ the
+             * game shows "UG" tiers: UG1 begins at 1210 and each level spans 10 stat points (UG1..UG79 cover 1210..1990, the span the badge image set covers).
+             * @param {string|number} value - The stat value.
+             * @returns {string} The letter grade (e.g. "B+" or "UG6"), or "" when there is no valid value.
+             */
+            function statValueToRankLabel(value) {
+                const v = parseInt(value, 10)
+                if (!Number.isFinite(v) || v < 1) return ""
+                if (v >= 1210) return "UG" + Math.min(79, Math.floor((v - 1210) / 10) + 1)
+                const bands = [
+                    [1, "G"], [50, "G+"], [100, "F"], [150, "F+"], [200, "E"], [250, "E+"],
+                    [300, "D"], [350, "D+"], [400, "C"], [500, "C+"], [600, "B"], [700, "B+"],
+                    [800, "A"], [900, "A+"], [1000, "S"], [1050, "S+"], [1100, "SS"], [1150, "SS+"]
+                ]
+                let label = "G"
+                for (const [min, l] of bands) {
+                    if (v >= min) label = l
+                    else break
+                }
+                return label
+            }
+
+            /**
+             * Sets a stat tile's rank badge image from its numeric value. Hides the badge when there is no value or the grade has no image (plain "G").
+             * @param {HTMLImageElement} imgEl - The badge <img> element.
+             * @param {string|number} value - The stat value.
+             */
+            function setStatGrade(imgEl, value) {
+                if (!imgEl) return
+                const label = statValueToRankLabel(value)
+                const index = rankLabelToIndex(label)
+                if (!index) {
+                    imgEl.removeAttribute("src")
+                    imgEl.title = ""
+                    imgEl.alt = ""
+                } else {
+                    imgEl.src = rankImageUrl(index)
+                    imgEl.title = label + " rank"
+                    imgEl.alt = label
+                }
+            }
+
+            /**
+             * Renders one stat meter: the value, the "/cap" suffix, the fill width (progress toward the cap), and the rank badge. The raw string is "1267" or "1267/1387"
+             * (the july build adds the OCR'd cap); with no cap the bar stays empty. Passing "-" clears the meter.
+             * @param {string} elId - The stat value element id (e.g. "statSpeed").
+             * @param {string|number} val - The raw stat string.
+             */
+            function setStatMeter(elId, val) {
+                const valueEl = document.getElementById(elId)
+                if (!valueEl) return
+                const parts = String(val).split("/")
+                const value = parts[0].trim()
+                const cap = parts.length > 1 ? parts[1].trim() : ""
+                valueEl.textContent = value
+                const capEl = document.getElementById(elId + "Cap")
+                if (capEl) capEl.textContent = cap ? "/" + cap : ""
+                const fillEl = document.getElementById(elId + "Fill")
+                if (fillEl) {
+                    const v = parseInt(value, 10)
+                    const c = parseInt(cap, 10)
+                    const pct = Number.isFinite(v) && Number.isFinite(c) && c > 0 ? Math.max(0, Math.min(100, (v / c) * 100)) : 0
+                    fillEl.style.width = pct + "%"
+                }
+                setStatGrade(document.getElementById(elId + "Grade"), value)
+            }
+
+            /**
+             * Sets the energy readout and its bar fill. The text is like "86%"; the bar width tracks the numeric part (0 when there is none).
+             * @param {string} text - The energy string (e.g. "86%").
+             */
+            function setEnergy(text) {
+                const el = document.getElementById("dashboardEnergy")
+                if (el) el.textContent = text
+                const bar = document.getElementById("energyBar")
+                if (bar) {
+                    const n = parseInt(text, 10)
+                    bar.style.width = (Number.isFinite(n) ? Math.max(0, Math.min(100, n)) : 0) + "%"
+                }
+            }
+
+            /**
+             * Renders the estimated overall rank badge + score. Shows the rank image when the label has one (G..SS+); otherwise falls back to the label text (e.g. plain "G" or
+             * the rare ultra tiers). Always shows the numeric score.
+             * @param {string} label - The rank label, e.g. "S" or "SS+".
+             * @param {string|number} score - The total evaluation score.
+             */
+            function setEstRank(label, score) {
+                const img = document.getElementById("estRankImg")
+                const text = document.getElementById("estRankText")
+                const scoreEl = document.getElementById("estRankScore")
+                const index = rankLabelToIndex(label)
+                if (index) {
+                    img.src = rankImageUrl(index)
+                    img.alt = label
+                    text.textContent = ""
+                    text.style.display = "none"
+                } else {
+                    img.removeAttribute("src")
+                    text.textContent = label || "-"
+                    text.style.display = ""
+                }
+                scoreEl.textContent = score ? formatNumberWithCommas(score) : ""
             }
 
             /**
@@ -3277,13 +3804,13 @@
                     })
                     .join("\n")
                 navigator.clipboard.writeText(text).then(function () {
-                    // Briefly flash the button to confirm.
+                    // Briefly flash the icon button to confirm, then restore its original SVG.
                     var btn = event.target.closest(".toolbar-btn")
                     if (btn) {
-                        var original = btn.textContent
-                        btn.textContent = "✓ Copied!"
+                        var original = btn.innerHTML
+                        btn.textContent = "✓"
                         setTimeout(function () {
-                            btn.innerHTML = "📋 Copy"
+                            btn.innerHTML = original
                         }, 1500)
                     }
                 })
@@ -3324,7 +3851,7 @@
 
                 // Reset the trainee name display.
                 document.getElementById("dashboardName").textContent = "-"
-                document.getElementById("dashboardEnergy").textContent = "-"
+                setEnergy("-")
                 document.getElementById("dashboardFans").textContent = "-"
                 document.getElementById("dashboardSkillPoints").textContent = "-"
                 
@@ -3337,12 +3864,20 @@
                 document.getElementById("dashboardDate").textContent = "-"
                 document.getElementById("dashboardTurn").textContent = "-"
 
-                // Reset stats.
+                // Reset stats (value, cap, bar fill, and rank badge each cleared by setStatMeter).
                 const stats = ["statSpeed", "statStamina", "statPower", "statGuts", "statWit"]
-                stats.forEach(id => {
-                    const el = document.getElementById(id)
-                    if (el) el.textContent = "-"
-                })
+                stats.forEach((id) => setStatMeter(id, "-"))
+
+                // Reset estimated rank.
+                const estImg = document.getElementById("estRankImg")
+                if (estImg) estImg.removeAttribute("src")
+                const estText = document.getElementById("estRankText")
+                if (estText) {
+                    estText.textContent = "-"
+                    estText.style.display = ""
+                }
+                const estScore = document.getElementById("estRankScore")
+                if (estScore) estScore.textContent = ""
 
                 // Reset aptitudes.
                 const apts = [
@@ -3358,8 +3893,9 @@
                     }
                 })
 
-                // Reset the Race History calendar so a fresh run starts blank.
+                // Reset the Race History calendar and the Skills panel so a fresh run starts blank.
                 resetCalendar()
+                renderSkills(null)
 
                 // Show empty state again.
                 if (emptyState) {
@@ -3453,14 +3989,79 @@
                 return (turn >= 37 && turn <= 40) || (turn >= 61 && turn <= 64)
             }
 
+            // Right-zone rail state: which panel is shown (race | skills), whether the body is collapsed, and whether the Smart Race Solver is on this run.
+            var sideActive = "race"
+            var sideCollapsed = false
+            var srsEnabled = false
+            var raceTurnLabel = "Turn -"
+            var skillsData = null
+
             /**
-             * Toggles the Race History panel collapsed state. Only effective on mobile-width
-             * viewports; the chevron is hidden on desktop so the click is a no-op there.
+             * Renders the shared right-zone rail: highlights the active tab, shows its panel, and (when collapsed) hides the body so the Stats zone grows into the space. The
+             * Race panel shows the calendar when the Smart Race Solver is on, otherwise a short "off" note.
              */
-            function toggleRaceHistory() {
-                if (window.innerWidth > 1024) return
-                var section = document.getElementById("raceHistorySection")
-                if (section) section.classList.toggle("collapsed")
+            function renderSidePanel() {
+                var dash = document.getElementById("dashboard")
+                if (dash) dash.classList.toggle("side-collapsed", sideCollapsed)
+                var tabRace = document.getElementById("tabRace")
+                var tabSkills = document.getElementById("tabSkills")
+                if (tabRace) tabRace.classList.toggle("active", sideActive === "race")
+                if (tabSkills) tabSkills.classList.toggle("active", sideActive === "skills")
+                var racePanel = document.getElementById("raceHistoryPanel")
+                var skillsPanel = document.getElementById("skillsPanel")
+                if (racePanel) racePanel.style.display = sideActive === "race" ? "" : "none"
+                if (skillsPanel) skillsPanel.style.display = sideActive === "skills" ? "" : "none"
+                var years = document.getElementById("raceHistoryYears")
+                var disabled = document.getElementById("raceHistoryDisabled")
+                if (years) years.style.display = srsEnabled ? "" : "none"
+                if (disabled) disabled.style.display = srsEnabled ? "none" : ""
+                // The head badge shows the turn on the Race panel and the skill count on the Skills panel.
+                var badge = document.getElementById("raceHistoryTurnBadge")
+                if (badge) {
+                    var n = skillsData && skillsData.skills ? skillsData.skills.length : 0
+                    badge.textContent = sideActive === "skills" ? n + (n === 1 ? " skill" : " skills") : raceTurnLabel
+                }
+            }
+
+            /**
+             * Handles a rail tab click: switch to that panel, or collapse the body when the already-active tab is clicked again.
+             * @param {string} name - The panel to activate ("race" or "skills").
+             */
+            function railClick(name) {
+                if (name === sideActive) {
+                    sideCollapsed = !sideCollapsed
+                } else {
+                    sideActive = name
+                    sideCollapsed = false
+                }
+                renderSidePanel()
+            }
+
+            /**
+             * Renders the owned-skills panel from a SKILLS: snapshot. Each skill becomes a colored pill (unique / gold / negative / normal) and the unique carries its level.
+             * Passing null clears the panel back to its placeholder hint.
+             * @param {object} snapshot - The parsed skills snapshot ({ skills, stars }), or null.
+             */
+            function renderSkills(snapshot) {
+                skillsData = snapshot
+                var panel = document.getElementById("skillsPanel")
+                if (!panel) return
+                var skills = snapshot && Array.isArray(snapshot.skills) ? snapshot.skills : []
+                if (skills.length === 0) {
+                    panel.innerHTML = '<div class="skills-hint">No owned skills read yet - the bot fills this in when it reads the Skills tab.</div>'
+                } else {
+                    var pillClass = { unique: "uniq", gold: "gold", negative: "neg", normal: "norm" }
+                    var html = '<div class="skills-grid">'
+                    for (var i = 0; i < skills.length; i++) {
+                        var s = skills[i]
+                        var cls = pillClass[s.type] || "norm"
+                        var lv = s.level ? '<span class="lv">Lv' + s.level + "</span>" : ""
+                        html += '<div class="skill-pill ' + cls + '"><span class="dotc"></span>' + escapeHtml(s.name) + lv + "</div>"
+                    }
+                    html += "</div>"
+                    panel.innerHTML = html
+                }
+                renderSidePanel()
             }
 
             // Latest snapshot kept for the hover-tooltip lookup. Decisions and results are
@@ -3492,7 +4093,8 @@
                     (snapshot.results || []).length > 0
                 )
                 var currentTurn = typeof snapshot.currentTurn === "number" ? snapshot.currentTurn : 1
-                badgeEl.textContent = hasRealSnapshot ? ("Turn " + currentTurn + " / 72") : "Turn -"
+                // Store the label; renderSidePanel() writes the head badge (it belongs to the Race panel unless the Skills tab is active).
+                raceTurnLabel = hasRealSnapshot ? "Turn " + currentTurn + " / 72" : "Turn -"
 
                 // Index results by turn for O(1) lookup during cell rendering.
                 var resultsByTurn = {}
@@ -3522,6 +4124,7 @@
                 }
 
                 container.innerHTML = html
+                renderSidePanel()
             }
 
             /**
@@ -3604,14 +4207,11 @@
              * @param {boolean} enabled True when SRS is enabled for the current run.
              */
             function setSmartRaceSolverEnabled(enabled) {
+                srsEnabled = enabled
                 var section = document.getElementById("raceHistorySection")
-                if (!section) return
-                if (enabled) {
-                    section.classList.remove("srs-disabled")
-                } else {
-                    section.classList.add("srs-disabled")
-                    resetCalendar()
-                }
+                if (section) section.classList.toggle("srs-disabled", !enabled)
+                if (!enabled) resetCalendar()
+                renderSidePanel()
             }
 
             /**
@@ -3937,7 +4537,7 @@
                     stateTarget.energy = info.to + "%"
                     if (info.moodTo) stateTarget.mood = info.moodTo
                 } else {
-                    document.getElementById("dashboardEnergy").textContent = info.to + "%"
+                    setEnergy(info.to + "%")
                     if (info.moodTo) updateMoodBadge(info.moodTo)
                 }
             }
@@ -4006,13 +4606,17 @@
                     document.getElementById("dashboardName").textContent = state.name
                 }
                 if (state.energy) {
-                    document.getElementById("dashboardEnergy").textContent = state.energy
+                    setEnergy(state.energy)
                 }
                 if (state.fans) {
                     document.getElementById("dashboardFans").textContent = formatNumberWithCommas(state.fans)
                 }
                 if (state.skillPoints) {
                     document.getElementById("dashboardSkillPoints").textContent = formatNumberWithCommas(state.skillPoints)
+                }
+                if (state.estRank) {
+                    const estMatch = state.estRank.match(/^(\S+)\s*\((\d+)\)/)
+                    if (estMatch) setEstRank(estMatch[1], estMatch[2])
                 }
                 if (state.mood !== null && state.mood !== undefined) {
                     updateMoodBadge(state.mood)
@@ -4033,10 +4637,7 @@
                 // Batch update stats.
                 for (const [key, val] of Object.entries(state.stats)) {
                     const elId = { Spd: "statSpeed", Sta: "statStamina", Pow: "statPower", Gut: "statGuts", Wit: "statWit" }[key]
-                    if (elId) {
-                        const el = document.getElementById(elId)
-                        if (el && el.textContent !== val) el.textContent = val
-                    }
+                    if (elId) setStatMeter(elId, val)
                 }
                 
                 // Batch update aptitudes.
@@ -4177,7 +4778,7 @@
                     if (stateTarget) {
                         stateTarget.energy = data.trim()
                     } else {
-                        document.getElementById("dashboardEnergy").textContent = data.trim()
+                        setEnergy(data.trim())
                     }
                 } else if (category === "Fans") {
                     if (stateTarget) {
@@ -4191,6 +4792,13 @@
                     } else {
                         document.getElementById("dashboardSkillPoints").textContent = formatNumberWithCommas(data.trim())
                     }
+                } else if (category === "Estimated Rank") {
+                    if (stateTarget) {
+                        stateTarget.estRank = data.trim()
+                    } else {
+                        const m = data.trim().match(/^(\S+)\s*\((\d+)\)/)
+                        if (m) setEstRank(m[1], m[2])
+                    }
                 } else if (category === "Stats") {
                     const stats = data.split(", ")
                     stats.forEach((s) => {
@@ -4199,7 +4807,7 @@
                             stateTarget.stats[key] = val
                         } else {
                             const elId = { Spd: "statSpeed", Sta: "statStamina", Pow: "statPower", Gut: "statGuts", Wit: "statWit" }[key]
-                            if (elId) document.getElementById(elId).textContent = val
+                            if (elId) setStatMeter(elId, val)
                         }
                     })
                 } else {
@@ -5471,6 +6079,94 @@
                 analyticDownloadCsv(who + "_" + chartSlug + "_" + analyticLogTimestamp() + ".csv", analyticChartCsvRows(chart, id))
             }
 
+            // //////////////////////////////////////////////////////////////////////////////////////////////////
+            // //////////////////////////////////////////////////////////////////////////////////////////////////
+            // Mobile bottom peek-sheet
+
+            let peekSyncScheduled = false
+
+            /**
+             * Copies the trainee glance (name, turn, estimated rank badge + score) from the dashboard into the collapsed peek bar. Driven by a MutationObserver so the glance stays
+             * in sync without hooking every dashboard setter.
+             */
+            function syncPeek() {
+                const nameEl = document.getElementById("dashboardName")
+                const peekName = document.getElementById("peekName")
+                if (peekName) {
+                    const n = nameEl ? nameEl.textContent.trim() : ""
+                    peekName.textContent = n && n !== "-" ? n : "No trainee"
+                }
+                const turnEl = document.getElementById("dashboardTurn")
+                const peekTurn = document.getElementById("peekTurn")
+                if (peekTurn) {
+                    const t = turnEl ? turnEl.textContent.trim() : ""
+                    peekTurn.textContent = t && t !== "-" ? "Turn " + t : "Turn -"
+                }
+                const scoreEl = document.getElementById("estRankScore")
+                const peekScore = document.getElementById("peekScore")
+                if (peekScore) peekScore.textContent = scoreEl ? scoreEl.textContent.trim() : ""
+                const estImg = document.getElementById("estRankImg")
+                const peekImg = document.getElementById("peekRankImg")
+                if (peekImg) {
+                    const src = estImg && estImg.getAttribute("src")
+                    if (src) peekImg.src = src
+                    else peekImg.removeAttribute("src")
+                }
+            }
+
+            /**
+             * Opens or closes the mobile peek-sheet and its backdrop.
+             * @param {boolean} open - True to expand the full dashboard, false to collapse back to the glance bar.
+             */
+            function setSheet(open) {
+                const sheet = document.getElementById("mobileSheet")
+                const backdrop = document.getElementById("sheetBackdrop")
+                if (sheet) sheet.classList.toggle("open", open)
+                if (backdrop) backdrop.classList.toggle("show", open)
+            }
+
+            /** Toggles the mobile peek-sheet between collapsed and expanded. */
+            function toggleSheet() {
+                const sheet = document.getElementById("mobileSheet")
+                setSheet(!(sheet && sheet.classList.contains("open")))
+            }
+
+            /**
+             * Wires the mobile peek-sheet: a tap on the glance bar toggles it, a vertical swipe opens (up) or closes (down), the backdrop collapses it, and a MutationObserver keeps
+             * the glance in sync with the live dashboard.
+             */
+            function initMobileSheet() {
+                const peek = document.getElementById("sheetPeek")
+                const backdrop = document.getElementById("sheetBackdrop")
+                const dash = document.getElementById("dashboard")
+                if (backdrop) backdrop.addEventListener("click", () => setSheet(false))
+                if (peek) {
+                    // A tap toggles (touch taps synthesize a click, so this covers all devices).
+                    peek.addEventListener("click", () => toggleSheet())
+                    // A clear vertical drag is a swipe: open on up, close on down, and suppress the synthesized click so it does not also toggle.
+                    let startY = null
+                    peek.addEventListener("touchstart", (e) => { startY = e.touches[0].clientY }, { passive: true })
+                    peek.addEventListener("touchend", (e) => {
+                        if (startY === null) return
+                        const dy = e.changedTouches[0].clientY - startY
+                        startY = null
+                        if (Math.abs(dy) >= 24) {
+                            e.preventDefault()
+                            setSheet(dy < 0)
+                        }
+                    })
+                }
+                if (dash) {
+                    const observer = new MutationObserver(() => {
+                        if (peekSyncScheduled) return
+                        peekSyncScheduled = true
+                        requestAnimationFrame(() => { peekSyncScheduled = false; syncPeek() })
+                    })
+                    observer.observe(dash, { subtree: true, childList: true, characterData: true, attributes: true, attributeFilter: ["src"] })
+                }
+                syncPeek()
+            }
+
             // Initiate the connection and settings when the page loads.
             initFontSize()
             initToolbar()
@@ -5479,6 +6175,10 @@
             // Paint an empty Race History grid so the panel takes its full layout immediately,
             // before any CAL: snapshot arrives.
             renderCalendar(null)
+            // Paint the Skills panel placeholder and the right-zone rail's initial state (Race panel active, SRS off until SRS_STATE arrives).
+            renderSkills(null)
+            renderSidePanel()
+            initMobileSheet()
             connect()
         </script>
     </body>

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Campaign.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Campaign.kt
@@ -1688,26 +1688,22 @@ abstract class Campaign(game: Game) : Task(game) {
     }
 
     /**
-     * Classifies the trainee's owned skills by pill type (unique / gold / negative / normal) and pushes the list to the Remote Log Viewer's Skills panel. The type comes from
-     * each skill's icon id via SkillData, and the unique skill carries its level. Safe to call whenever the owned-skill set changes.
+     * Sends the trainee's owned skills to the Remote Log Viewer's Skills panel, each with its in-game category color (green/blue/yellow/red) plus gold / unique / negative flags
+     * derived from the skill's icon id via SkillData, and the unique skill's level. Safe to call whenever the owned-skill set changes.
      */
     fun broadcastOwnedSkills() {
         val skills = org.json.JSONArray()
         for (name in trainee.ownedSkillNames) {
             val data = game.skillDatabase.getSkillData(name)
-            val type =
-                when {
-                    data == null -> "normal"
-                    data.bIsUnique -> "unique"
-                    data.bIsNegative -> "negative"
-                    data.bIsGold -> "gold"
-                    else -> "normal"
-                }
             val obj = org.json.JSONObject()
             obj.put("name", name)
-            obj.put("type", type)
+            // Category color (green/blue/yellow/red) drives the pill's bullet; the flags below layer the unique/negative/gold treatment on top on the frontend.
+            obj.put("color", data?.type?.name?.lowercase() ?: "")
+            obj.put("gold", data?.bIsGold ?: false)
+            obj.put("unique", data?.bIsUnique ?: false)
+            obj.put("negative", data?.bIsNegative ?: false)
             obj.put("evalPt", data?.evalPt ?: 0)
-            if (type == "unique" && trainee.uniqueSkillLevel > 0) obj.put("level", trainee.uniqueSkillLevel)
+            if (data?.bIsUnique == true && trainee.uniqueSkillLevel > 0) obj.put("level", trainee.uniqueSkillLevel)
             skills.put(obj)
         }
         val json = org.json.JSONObject()

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Campaign.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Campaign.kt
@@ -635,6 +635,9 @@ abstract class Campaign(game: Game) : Task(game) {
                 if (ownedSkills.starLevel > 0) trainee.starLevel = ownedSkills.starLevel
                 broadcastOwnedSkills()
 
+                // Recompute the estimated rank from the final stats, aptitudes, and owned skills so the end-of-run log reflects the completed career.
+                updateEstimatedRank()
+
                 result.dialog.close(game.imageUtils)
             }
 

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Campaign.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Campaign.kt
@@ -632,7 +632,6 @@ abstract class Campaign(game: Game) : Task(game) {
                 trainee.ownedSkillNames.clear()
                 trainee.ownedSkillNames.addAll(ownedSkills.skillNames)
                 trainee.uniqueSkillLevel = ownedSkills.uniqueLevel
-                if (ownedSkills.starLevel > 0) trainee.starLevel = ownedSkills.starLevel
                 broadcastOwnedSkills()
 
                 // Recompute the estimated rank from the final stats, aptitudes, and owned skills so the end-of-run log reflects the completed career.
@@ -1685,7 +1684,6 @@ abstract class Campaign(game: Game) : Task(game) {
                 trainee.stats.wit,
                 skillInputs,
                 aptitudes,
-                trainee.starLevel,
                 trainee.uniqueSkillLevel,
             )
     }
@@ -1711,7 +1709,6 @@ abstract class Campaign(game: Game) : Task(game) {
         }
         val json = org.json.JSONObject()
         json.put("skills", skills)
-        json.put("stars", trainee.starLevel)
         LogStreamServer.broadcastSkillsSnapshot(json.toString())
     }
 

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Campaign.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Campaign.kt
@@ -1690,7 +1690,7 @@ abstract class Campaign(game: Game) : Task(game) {
 
     /**
      * Sends the trainee's owned skills to the Remote Log Viewer's Skills panel, each with its in-game category color (green/blue/yellow/red) plus gold / unique / negative flags
-     * derived from the skill's icon id via SkillData, and the unique skill's level. Safe to call whenever the owned-skill set changes.
+     * derived from the skill's icon id via SkillData, the unique skill's level, and its description and icon id for the panel's hover tooltip. Safe to call whenever the owned-skill set changes.
      */
     fun broadcastOwnedSkills() {
         val skills = org.json.JSONArray()
@@ -1704,6 +1704,9 @@ abstract class Campaign(game: Game) : Task(game) {
             obj.put("unique", data?.bIsUnique ?: false)
             obj.put("negative", data?.bIsNegative ?: false)
             obj.put("evalPt", data?.evalPt ?: 0)
+            // Description and icon id feed the frontend hover tooltip (name + desc_en + GameTora-hosted icon).
+            obj.put("desc", data?.description ?: "")
+            obj.put("iconId", data?.iconId ?: 0)
             if (data?.bIsUnique == true && trainee.uniqueSkillLevel > 0) obj.put("level", trainee.uniqueSkillLevel)
             skills.put(obj)
         }

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Campaign.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Campaign.kt
@@ -66,9 +66,16 @@ import com.steve1316.uma_android_automation.types.GameDate
 import com.steve1316.uma_android_automation.types.Mood
 import com.steve1316.uma_android_automation.types.RaceGrade
 import com.steve1316.uma_android_automation.types.RunningStyle
+import com.steve1316.uma_android_automation.types.SkillList
 import com.steve1316.uma_android_automation.types.StatName
+import com.steve1316.uma_android_automation.types.TrackDistance
+import com.steve1316.uma_android_automation.types.TrackSurface
 import com.steve1316.uma_android_automation.types.Trainee
+import com.steve1316.uma_android_automation.utils.LogStreamServer
 import com.steve1316.uma_android_automation.utils.ScrollList
+import com.steve1316.uma_scoring.RankAptitudes
+import com.steve1316.uma_scoring.SkillScoreInput
+import com.steve1316.uma_scoring.estimateRank
 import org.opencv.core.Point
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
@@ -616,9 +623,18 @@ abstract class Campaign(game: Game) : Task(game) {
                     trainee.bHasSetRunningStyle = false
                 }
 
-                // Read the trainee's active conditions from the Conditions sublist, scrolling if the list overflows.
+                // Read the trainee's active conditions from the Conditions sublist (default tab) before switching to the Skills tab.
                 val conditions = ConditionList(game).parseDetailsConditionsTab()
                 trainee.setConditions(conditions.positive, conditions.negative)
+
+                // Read the currently-owned skills from the Skills tab to feed the estimated rank.
+                val ownedSkills = SkillList(game, this).parseDetailsSkillsTab()
+                trainee.ownedSkillNames.clear()
+                trainee.ownedSkillNames.addAll(ownedSkills.skillNames)
+                trainee.uniqueSkillLevel = ownedSkills.uniqueLevel
+                if (ownedSkills.starLevel > 0) trainee.starLevel = ownedSkills.starLevel
+                broadcastOwnedSkills()
+
                 result.dialog.close(game.imageUtils)
             }
 
@@ -1633,6 +1649,74 @@ abstract class Campaign(game: Game) : Task(game) {
     }
 
     /**
+     * Computes the trainee's estimated overall rank from the latest stats, aptitudes, and owned skills, and stores it on the trainee for logging and the dashboard. Skips
+     * computation until stats have been read at least once. Each owned skill is scored via its `eval_pt` and an aptitude checkType derived from its condition. This mirrors the
+     * UmaTools calculator, so the result is an estimate.
+     */
+    fun updateEstimatedRank() {
+        if (!trainee.bHasUpdatedStats) return
+        val aptitudes =
+            RankAptitudes(
+                turf = trainee.trackSurfaceAptitudes[TrackSurface.TURF]?.name ?: "G",
+                dirt = trainee.trackSurfaceAptitudes[TrackSurface.DIRT]?.name ?: "G",
+                sprint = trainee.trackDistanceAptitudes[TrackDistance.SPRINT]?.name ?: "G",
+                mile = trainee.trackDistanceAptitudes[TrackDistance.MILE]?.name ?: "G",
+                medium = trainee.trackDistanceAptitudes[TrackDistance.MEDIUM]?.name ?: "G",
+                long = trainee.trackDistanceAptitudes[TrackDistance.LONG]?.name ?: "G",
+                front = trainee.runningStyleAptitudes[RunningStyle.FRONT_RUNNER]?.name ?: "G",
+                pace = trainee.runningStyleAptitudes[RunningStyle.PACE_CHASER]?.name ?: "G",
+                late = trainee.runningStyleAptitudes[RunningStyle.LATE_SURGER]?.name ?: "G",
+                end = trainee.runningStyleAptitudes[RunningStyle.END_CLOSER]?.name ?: "G",
+            )
+        val skillInputs =
+            trainee.ownedSkillNames.toList().mapNotNull { skillName ->
+                val data = game.skillDatabase.getSkillData(skillName) ?: return@mapNotNull null
+                SkillScoreInput(data.evalPt, SkillDatabase.deriveCheckType(data.condition, data.precondition))
+            }
+        trainee.estimatedRank =
+            estimateRank(
+                trainee.stats.speed,
+                trainee.stats.stamina,
+                trainee.stats.power,
+                trainee.stats.guts,
+                trainee.stats.wit,
+                skillInputs,
+                aptitudes,
+                trainee.starLevel,
+                trainee.uniqueSkillLevel,
+            )
+    }
+
+    /**
+     * Classifies the trainee's owned skills by pill type (unique / gold / negative / normal) and pushes the list to the Remote Log Viewer's Skills panel. The type comes from
+     * each skill's icon id via SkillData, and the unique skill carries its level. Safe to call whenever the owned-skill set changes.
+     */
+    fun broadcastOwnedSkills() {
+        val skills = org.json.JSONArray()
+        for (name in trainee.ownedSkillNames) {
+            val data = game.skillDatabase.getSkillData(name)
+            val type =
+                when {
+                    data == null -> "normal"
+                    data.bIsUnique -> "unique"
+                    data.bIsNegative -> "negative"
+                    data.bIsGold -> "gold"
+                    else -> "normal"
+                }
+            val obj = org.json.JSONObject()
+            obj.put("name", name)
+            obj.put("type", type)
+            obj.put("evalPt", data?.evalPt ?: 0)
+            if (type == "unique" && trainee.uniqueSkillLevel > 0) obj.put("level", trainee.uniqueSkillLevel)
+            skills.put(obj)
+        }
+        val json = org.json.JSONObject()
+        json.put("skills", skills)
+        json.put("stars", trainee.starLevel)
+        LogStreamServer.broadcastSkillsSnapshot(json.toString())
+    }
+
+    /**
      * Opens the Umamusume Class dialog to update trainee fan count.
      *
      * This function only opens the dialog - the actual fan count update is performed
@@ -1880,7 +1964,8 @@ abstract class Campaign(game: Game) : Task(game) {
             return true
         }
 
-        // Print the trainee info after all turn-start updates and potential fan count updates.
+        // Compute the estimated overall rank, then print the trainee info after all turn-start updates and potential fan count updates.
+        updateEstimatedRank()
         trainee.logInfo()
 
         // Surface analytics right after the trainee scan, before the scenario item/shop pass, so a restart shows the resumed run promptly.

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/RunAnalytics.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/RunAnalytics.kt
@@ -565,6 +565,9 @@ object RunAnalytics {
         val negativeStatuses = JSONArray()
         trainee.currentNegativeStatuses.forEach { negativeStatuses.put(it) }
 
+        val ownedSkills = JSONArray()
+        trainee.ownedSkillNames.forEach { ownedSkills.put(it) }
+
         return JSONObject()
             .put("name", trainee.name.ifEmpty { rememberedName })
             .put(
@@ -582,6 +585,9 @@ object RunAnalytics {
             .put("fans", trainee.fans)
             .put("skillPoints", trainee.skillPoints)
             .put("negativeStatuses", negativeStatuses)
+            .put("ownedSkills", ownedSkills)
+            .put("uniqueSkillLevel", trainee.uniqueSkillLevel)
+            .put("starLevel", trainee.starLevel)
     }
 
     /**

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/RunAnalytics.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/RunAnalytics.kt
@@ -587,7 +587,6 @@ object RunAnalytics {
             .put("negativeStatuses", negativeStatuses)
             .put("ownedSkills", ownedSkills)
             .put("uniqueSkillLevel", trainee.uniqueSkillLevel)
-            .put("starLevel", trainee.starLevel)
     }
 
     /**

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/SkillDatabase.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/SkillDatabase.kt
@@ -73,6 +73,42 @@ class SkillDatabase(private val game: Game) {
 
         /** The threshold for fuzzy string matching (0.0 to 1.0). */
         private const val SIMILARITY_THRESHOLD = 0.7
+
+        /** Maps a `running_style` condition value to its running-style affinity role. */
+        private val STYLE_ROLES = mapOf("1" to "Front", "2" to "Pace", "3" to "Late", "4" to "End")
+
+        /** Maps a `distance_type` condition value to its distance affinity role. */
+        private val DISTANCE_ROLES = mapOf("1" to "Sprint", "2" to "Mile", "3" to "Medium", "4" to "Long")
+
+        /** Maps a `ground_type` condition value to its surface affinity role. */
+        private val GROUND_ROLES = mapOf("1" to "Turf", "2" to "Dirt")
+
+        /** Matches the `variable==value` affinity tokens in a skill's condition text. */
+        private val CHECK_TYPE_PATTERN = Regex("(running_style|distance_type|ground_type)==(\\d+)")
+
+        /**
+         * Derives a skill's aptitude affinity ("checkType") from its activation condition, used by the estimated-rank skill scoring. Collects the `running_style`,
+         * `distance_type`, and `ground_type` equality tokens across the condition and precondition and maps them to affinity roles, ordered surface/distance/style and joined
+         * with "/". This reproduces UmaTools' `affinity_role` for ~97% of skills. Returns "" when the skill has no aptitude affinity, in which case it scores its flat base.
+         *
+         * @param condition The skill's activation condition text.
+         * @param precondition The skill's precondition text.
+         * @return The affinity role string, e.g. "Late" or "Medium/Long", or "" when there is none.
+         */
+        fun deriveCheckType(condition: String, precondition: String): String {
+            val surface = LinkedHashSet<String>()
+            val distance = LinkedHashSet<String>()
+            val style = LinkedHashSet<String>()
+            for (match in CHECK_TYPE_PATTERN.findAll("$condition&$precondition")) {
+                val (variable, value) = match.destructured
+                when (variable) {
+                    "ground_type" -> GROUND_ROLES[value]?.let { surface.add(it) }
+                    "distance_type" -> DISTANCE_ROLES[value]?.let { distance.add(it) }
+                    "running_style" -> STYLE_ROLES[value]?.let { style.add(it) }
+                }
+            }
+            return (surface + distance + style).joinToString("/")
+        }
     }
 
     // //////////////////////////////////////////////////////////////////////////////////////////////////

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/SkillPlan.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/SkillPlan.kt
@@ -879,6 +879,22 @@ class SkillPlan(private val game: Game, private val campaign: Campaign) {
     }
 
     /**
+     * Buys a single skill, logs the purchase, and records it in the trainee's owned-skill set
+     * so the Remote Log Viewer's Skills panel can update without waiting for a Details read.
+     *
+     * @param name The canonical name of the skill to buy.
+     * @param point The screen location of the skill's purchase button.
+     * @param skillList The [SkillList] managing the current scan.
+     * @return True if the skill was purchased, false otherwise.
+     */
+    private fun buyAndTrackSkill(name: String, point: Point, skillList: SkillList): Boolean {
+        val purchaseResult: SkillListEntry = skillList.buySkill(name, point) ?: return false
+        MessageLog.i(TAG, "[INFO] Buying \"${purchaseResult.name}\" for ${purchaseResult.price} pts")
+        campaign.trainee.ownedSkillNames.add(purchaseResult.name)
+        return true
+    }
+
+    /**
      * Log the details of a detected skill list entry and handle its purchase if planned.
      *
      * @param entry The detected [SkillListEntry].
@@ -896,24 +912,16 @@ class SkillPlan(private val game: Game, private val campaign: Campaign) {
             return false
         }
 
-        // Determine if there are other in-place versions of this skill that need to be purchased.
-        if (entry.bIsInPlace) {
-            val namesToBuy: List<String> =
-                listOf(entry.name) +
-                    entry.getUpgradeNames().filter { it in skillsToBuy }
+        // Buy the base skill plus any in-place upgrade versions that are also planned.
+        val namesToBuy: List<String> = if (entry.bIsInPlace) listOf(entry.name) + entry.getUpgradeNames().filter { it in skillsToBuy } else listOf(entry.name)
 
-            for (name in namesToBuy) {
-                val purchaseResult: SkillListEntry? = skillList.buySkill(name, point)
-                if (purchaseResult != null) {
-                    MessageLog.i(TAG, "[INFO] Buying \"${purchaseResult.name}\" for ${purchaseResult.price} pts")
-                }
-            }
-        } else {
-            val purchaseResult: SkillListEntry? = skillList.buySkill(entry.name, point)
-            if (purchaseResult != null) {
-                MessageLog.i(TAG, "[INFO] Buying \"${purchaseResult.name}\" for ${purchaseResult.price} pts")
-            }
+        var boughtAny = false
+        for (name in namesToBuy) {
+            if (buyAndTrackSkill(name, point, skillList)) boughtAny = true
         }
+
+        // Push the freshly-owned skills to the Remote Log Viewer's Skills panel now instead of waiting for the next Details tab read.
+        if (boughtAny) campaign.broadcastOwnedSkills()
 
         // Check if all planned skills have been purchased to allow for an early exit.
         val obtained: Map<String, SkillListEntry> = skillList.getObtainedSkills()

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/types/SkillList.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/types/SkillList.kt
@@ -67,9 +67,8 @@ private const val MAX_SKILL_SCROLLS = 10
  *
  * @property skillNames The canonical database names of the trainee's currently-owned skills.
  * @property uniqueLevel The unique skill's level read from the first cell, or 0 when unread.
- * @property starLevel The trainee's star rarity, or 0 when unread (the estimated-rank unique bonus then defaults to the 3-star+ multiplier).
  */
-data class DetailsSkillsResult(val skillNames: List<String>, val uniqueLevel: Int, val starLevel: Int)
+data class DetailsSkillsResult(val skillNames: List<String>, val uniqueLevel: Int)
 
 /**
  * Handles all interactions with the skill list screen and manages the [Trainee]'s skill data.
@@ -441,7 +440,7 @@ class SkillList(private val game: Game, private val campaign: Campaign) {
      * default Conditions tab). Switches to the Skills tab, OCRs each cell of the 2-column grid, fuzzy-matches names to the skill database, scrolls for trainees with 10+ skills,
      * and reads the unique skill's level from the first cell. Cell geometry is fractions of the display, measured from a 1080x1920 capture.
      *
-     * @return The owned skill names, the unique level, and the star count (0 when unread).
+     * @return The owned skill names and the unique level.
      */
     fun parseDetailsSkillsTab(): DetailsSkillsResult {
         // Switch from the default Conditions tab to the Skills tab (a fixed position in the modal).
@@ -469,7 +468,7 @@ class SkillList(private val game: Game, private val campaign: Campaign) {
         }
 
         MessageLog.i(TAG, "[INFO] Read ${ownedNames.size} owned skills (unique Lvl $uniqueLevel): ${ownedNames.joinToString(", ")}")
-        return DetailsSkillsResult(ownedNames.toList(), uniqueLevel, 0)
+        return DetailsSkillsResult(ownedNames.toList(), uniqueLevel)
     }
 
     /**

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/types/SkillList.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/types/SkillList.kt
@@ -56,6 +56,21 @@ fun stripTrailingGlyphNoise(name: String): String {
     return s
 }
 
+/** Number of skill rows visible at once on the Umamusume Details "Skills" tab before it scrolls. */
+private const val VISIBLE_SKILL_ROWS = 5
+
+/** Maximum number of scroll passes when reading the Skills tab (bounds trainees with many skills). */
+private const val MAX_SKILL_SCROLLS = 6
+
+/**
+ * The result of reading the Umamusume Details "Skills" tab.
+ *
+ * @property skillNames The canonical database names of the trainee's currently-owned skills.
+ * @property uniqueLevel The unique skill's level read from the first cell, or 0 when unread.
+ * @property starLevel The trainee's star rarity, or 0 when unread (the estimated-rank unique bonus then defaults to the 3-star+ multiplier).
+ */
+data class DetailsSkillsResult(val skillNames: List<String>, val uniqueLevel: Int, val starLevel: Int)
+
 /**
  * Handles all interactions with the skill list screen and manages the [Trainee]'s skill data.
  *
@@ -415,6 +430,160 @@ class SkillList(private val game: Game, private val campaign: Campaign) {
         }
 
         return skillName
+    }
+
+    // //////////////////////////////////////////////////////////////////////////////////////////////////
+    // //////////////////////////////////////////////////////////////////////////////////////////////////
+    // Umamusume Details "Skills" tab reader (owned skills for the estimated rank)
+
+    /**
+     * Reads the trainee's currently-owned skills from the Umamusume Details dialog's "Skills" tab. Assumes the dialog is already open (header stats and aptitudes were read on the
+     * default Conditions tab). Switches to the Skills tab, OCRs each cell of the 2-column grid, fuzzy-matches names to the skill database, scrolls for trainees with 10+ skills,
+     * and reads the unique skill's level from the first cell. Cell geometry is fractions of the display, measured from a 1080x1920 capture.
+     *
+     * @return The owned skill names, the unique level, and the star count (0 when unread).
+     */
+    fun parseDetailsSkillsTab(): DetailsSkillsResult {
+        // Switch from the default Conditions tab to the Skills tab (a fixed position in the modal).
+        game.tap(SharedData.displayWidth * 0.736, SharedData.displayHeight * 0.496, "details_skills_tab")
+        game.wait(0.5, skipWaitingForLoading = true)
+
+        val ownedNames = LinkedHashSet<String>()
+        var uniqueLevel = 0
+        for (pass in 0..MAX_SKILL_SCROLLS) {
+            val bitmap = game.imageUtils.getSourceBitmap()
+            var newFound = 0
+            for (row in 0 until VISIBLE_SKILL_ROWS) {
+                for (col in 0 until 2) {
+                    val name = readDetailsSkillCell(bitmap, row, col) ?: continue
+                    if (ownedNames.add(name)) newFound++
+                }
+            }
+            if (pass == 0) uniqueLevel = readUniqueSkillLevel(bitmap)
+            // Short lists never scroll past the first page, so a pass that reveals nothing new means we are done.
+            if (pass > 0 && newFound == 0) break
+            scrollSkillsPanel()
+        }
+
+        MessageLog.i(TAG, "[INFO] Read ${ownedNames.size} owned skills (unique Lvl $uniqueLevel): ${ownedNames.joinToString(", ")}")
+        return DetailsSkillsResult(ownedNames.toList(), uniqueLevel, 0)
+    }
+
+    /**
+     * OCRs and database-matches one skill cell of the Details "Skills" tab.
+     *
+     * @param bitmap The current screen bitmap.
+     * @param row The 0-indexed grid row.
+     * @param col The grid column (0 = left, 1 = right).
+     * @return The canonical skill name, or null when the cell is empty or unmatched.
+     */
+    private fun readDetailsSkillCell(bitmap: Bitmap, row: Int, col: Int): String? {
+        val w = SharedData.displayWidth.toDouble()
+        val h = SharedData.displayHeight.toDouble()
+        val x0 = if (col == 0) 128 else 632
+        // The unique skill (row 0, col 0) shows "Lvl N" on the right, so its name region stops short to avoid reading the level.
+        val x1 =
+            when {
+                col == 0 && row == 0 -> 410
+                col == 0 -> 505
+                else -> 1010
+            }
+        val yTop = 1036 + row * 112
+        val bbox =
+            BoundingBox(
+                x = (w * x0 / 1080.0).toInt(),
+                y = (h * yTop / 1920.0).toInt(),
+                w = (w * (x1 - x0) / 1080.0).toInt(),
+                h = (h * 78 / 1920.0).toInt(),
+            )
+        val crop = game.imageUtils.createSafeBitmap(bitmap, bbox, "detailsSkill_${row}_$col") ?: return null
+        if (game.debugMode) game.imageUtils.saveBitmap(crop, "detailsSkill_${row}_$col")
+
+        val text = extractText(crop).trim().replace(Regex("\\bl\\b"), "I")
+        if (text.length < 2) return null
+        val base = stripTrailingGlyphNoise(text.replace(Regex("[○◎×]"), " ").trim())
+        if (base.length < 2) return null
+        var name = game.skillDatabase.checkSkillName(base, fuzzySearch = true) ?: return null
+        // The database stores +/-/upgraded variants as "<name> ○ / ◎ / ×". A skill on the Skills tab is positive unless it sits on a purple (negative) tile, so a non-purple
+        // tile must never resolve to the "×" (negative) variant just because the base fuzzy-matched it. Default the positive correction to the base "○" (upgraded "◎" is rarer).
+        if (name.trimEnd().endsWith("×") && !isNegativeSkillCell(bitmap, row, col)) {
+            name = game.skillDatabase.checkSkillName("$base ○", fuzzySearch = true)
+                ?: game.skillDatabase.checkSkillName("$base ◎", fuzzySearch = true)
+                ?: name
+        }
+        return name
+    }
+
+    /**
+     * Detects whether a Skills-tab cell holds a negative skill, identified by its purple tile (positive skills use gold / silver / rainbow tiles).
+     *
+     * @param bitmap The current screen bitmap.
+     * @param row The 0-indexed grid row.
+     * @param col The grid column (0 = left, 1 = right).
+     * @return True when the cell background reads as purple.
+     */
+    private fun isNegativeSkillCell(bitmap: Bitmap, row: Int, col: Int): Boolean {
+        val w = SharedData.displayWidth.toDouble()
+        val h = SharedData.displayHeight.toDouble()
+        val sx = (w * (if (col == 0) 470 else 990) / 1080.0).toInt()
+        val sy = (h * (1050 + row * 112) / 1920.0).toInt()
+        val patchW = (w * 40 / 1080.0).toInt()
+        val patchH = (h * 40 / 1920.0).toInt()
+        var r = 0L
+        var g = 0L
+        var b = 0L
+        var n = 0
+        for (y in 0 until patchH step 3) {
+            for (x in 0 until patchW step 3) {
+                if (sx + x < bitmap.width && sy + y < bitmap.height) {
+                    val px = bitmap.getPixel(sx + x, sy + y)
+                    r += (px shr 16) and 0xFF
+                    g += (px shr 8) and 0xFF
+                    b += px and 0xFF
+                    n++
+                }
+            }
+        }
+        if (n == 0) return false
+        val avgR = (r / n).toInt()
+        val avgG = (g / n).toInt()
+        val avgB = (b / n).toInt()
+        // A negative tile is violet: blue and red both sit clearly above green. Gold, silver, and rainbow positive tiles do not.
+        return avgB > avgR && avgR > avgG && (avgB - avgG) > 45
+    }
+
+    /**
+     * OCRs the unique skill's level from the "Lvl N" region of the first Skills-tab cell.
+     *
+     * @param bitmap The current screen bitmap.
+     * @return The unique skill level, or 0 when unread.
+     */
+    private fun readUniqueSkillLevel(bitmap: Bitmap): Int {
+        val w = SharedData.displayWidth.toDouble()
+        val h = SharedData.displayHeight.toDouble()
+        // The unique level is a single digit shown as "Lvl N"; crop tightly on just the number and read it at high scale so ML Kit does not drop it.
+        val text =
+            game.imageUtils.performOCROnRegion(
+                bitmap,
+                (w * 478 / 1080.0).toInt(),
+                (h * 1052 / 1920.0).toInt(),
+                (w * 46 / 1080.0).toInt(),
+                (h * 48 / 1920.0).toInt(),
+                useThreshold = false,
+                useGrayscale = true,
+                scale = 3.0,
+                ocrEngine = "mlKit",
+                debugName = "detailsUniqueLevel",
+            )
+        // Levels are 1-6, so take the last digit to shrug off any stray "Lvl" characters that bled into the crop.
+        return text.filter { it.isDigit() }.lastOrNull()?.digitToIntOrNull() ?: 0
+    }
+
+    /** Swipes up within the skills panel to reveal the next page of skills (for trainees with 10+ skills). */
+    private fun scrollSkillsPanel() {
+        val cx = (SharedData.displayWidth / 2).toFloat()
+        game.gestureUtils.swipe(cx, (SharedData.displayHeight * 0.78).toFloat(), cx, (SharedData.displayHeight * 0.55).toFloat(), 500L)
+        game.wait(0.4, skipWaitingForLoading = true)
     }
 
     /**

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/types/SkillList.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/types/SkillList.kt
@@ -60,7 +60,7 @@ fun stripTrailingGlyphNoise(name: String): String {
 private const val VISIBLE_SKILL_ROWS = 5
 
 /** Maximum number of scroll passes when reading the Skills tab (bounds trainees with many skills). */
-private const val MAX_SKILL_SCROLLS = 6
+private const val MAX_SKILL_SCROLLS = 10
 
 /**
  * The result of reading the Umamusume Details "Skills" tab.
@@ -450,18 +450,21 @@ class SkillList(private val game: Game, private val campaign: Campaign) {
 
         val ownedNames = LinkedHashSet<String>()
         var uniqueLevel = 0
+        var emptyPasses = 0
         for (pass in 0..MAX_SKILL_SCROLLS) {
             val bitmap = game.imageUtils.getSourceBitmap()
             var newFound = 0
             for (row in 0 until VISIBLE_SKILL_ROWS) {
                 for (col in 0 until 2) {
-                    val name = readDetailsSkillCell(bitmap, row, col) ?: continue
+                    val name = readDetailsSkillCell(bitmap, row, col, pass) ?: continue
                     if (ownedNames.add(name)) newFound++
                 }
             }
             if (pass == 0) uniqueLevel = readUniqueSkillLevel(bitmap)
-            // Short lists never scroll past the first page, so a pass that reveals nothing new means we are done.
-            if (pass > 0 && newFound == 0) break
+            // Stop only after two consecutive passes reveal nothing new, so a single fling that settles mid-row (its cells straddle the grid and read as empty) does not end the scan
+            // early and drop the rows still below it.
+            emptyPasses = if (newFound == 0) emptyPasses + 1 else 0
+            if (pass > 0 && emptyPasses >= 2) break
             scrollSkillsPanel()
         }
 
@@ -477,10 +480,10 @@ class SkillList(private val game: Game, private val campaign: Campaign) {
      * @param col The grid column (0 = left, 1 = right).
      * @return The canonical skill name, or null when the cell is empty or unmatched.
      */
-    private fun readDetailsSkillCell(bitmap: Bitmap, row: Int, col: Int): String? {
+    private fun readDetailsSkillCell(bitmap: Bitmap, row: Int, col: Int, pass: Int): String? {
         val w = SharedData.displayWidth.toDouble()
         val h = SharedData.displayHeight.toDouble()
-        val x0 = if (col == 0) 128 else 632
+        val x0 = if (col == 0) 118 else 622
         // The unique skill (row 0, col 0) shows "Lvl N" on the right, so its name region stops short to avoid reading the level.
         val x1 =
             when {
@@ -488,18 +491,22 @@ class SkillList(private val game: Game, private val campaign: Campaign) {
                 col == 0 -> 505
                 else -> 1010
             }
-        val yTop = 1036 + row * 112
+        // Page 0 sits on the grid, but after a swipe the list settles ~40px low, so shift only the scrolled passes down to pull a wrapped name's second line into the crop without
+        // clipping the tops of the aligned first-page rows.
+        val yTop = 1036 + row * 112 + (if (pass == 0) 0 else 40)
         val bbox =
             BoundingBox(
                 x = (w * x0 / 1080.0).toInt(),
                 y = (h * yTop / 1920.0).toInt(),
                 w = (w * (x1 - x0) / 1080.0).toInt(),
-                h = (h * 78 / 1920.0).toInt(),
+                // Tall enough to capture a name that wraps to two lines (e.g. "Pace Chaser Straightaways").
+                h = (h * 100 / 1920.0).toInt(),
             )
         val crop = game.imageUtils.createSafeBitmap(bitmap, bbox, "detailsSkill_${row}_$col") ?: return null
         if (game.debugMode) game.imageUtils.saveBitmap(crop, "detailsSkill_${row}_$col")
 
-        val text = extractText(crop).trim().replace(Regex("\\bl\\b"), "I")
+        // Collapse the newline between wrapped lines into a single space so a two-line name matches its one-line database key.
+        val text = extractText(crop).trim().replace(Regex("\\s+"), " ").replace(Regex("\\bl\\b"), "I")
         if (text.length < 2) return null
         val base = stripTrailingGlyphNoise(text.replace(Regex("[○◎×]"), " ").trim())
         if (base.length < 2) return null
@@ -511,6 +518,11 @@ class SkillList(private val game: Game, private val campaign: Campaign) {
                 ?: game.skillDatabase.checkSkillName("$base ◎", fuzzySearch = true)
                 ?: name
         }
+        // Reject a truncated read: if the OCR base is a strict prefix of a longer matched skill (5+ chars shorter), the cell's wrapped second line was clipped and the fuzzy match
+        // grabbed a shorter same-prefix skill (e.g. "Pace Chaser" -> "Pace Chaser Savvy"). Returning null lets a better-aligned scroll pass read the full name instead of locking in
+        // the wrong one.
+        val matchedBase = stripTrailingGlyphNoise(name.replace(Regex("[○◎×]"), " ").trim())
+        if (base.length + 5 <= matchedBase.length && matchedBase.startsWith(base, ignoreCase = true)) return null
         return name
     }
 
@@ -565,7 +577,7 @@ class SkillList(private val game: Game, private val campaign: Campaign) {
         val text =
             game.imageUtils.performOCROnRegion(
                 bitmap,
-                (w * 478 / 1080.0).toInt(),
+                (w * 493 / 1080.0).toInt(),
                 (h * 1052 / 1920.0).toInt(),
                 (w * 46 / 1080.0).toInt(),
                 (h * 48 / 1920.0).toInt(),
@@ -582,8 +594,10 @@ class SkillList(private val game: Game, private val campaign: Campaign) {
     /** Swipes up within the skills panel to reveal the next page of skills (for trainees with 10+ skills). */
     private fun scrollSkillsPanel() {
         val cx = (SharedData.displayWidth / 2).toFloat()
-        game.gestureUtils.swipe(cx, (SharedData.displayHeight * 0.78).toFloat(), cx, (SharedData.displayHeight * 0.55).toFloat(), 500L)
-        game.wait(0.4, skipWaitingForLoading = true)
+        // A short, slow swipe (~1.7 rows) reduces fling and heavily overlaps the previous page, so every skill passes through the visible area at several sub-row offsets across
+        // passes - on at least one of which a two-line name is aligned enough to read fully rather than clipped.
+        game.gestureUtils.swipe(cx, (SharedData.displayHeight * 0.66).toFloat(), cx, (SharedData.displayHeight * 0.56).toFloat(), 700L)
+        game.wait(0.5, skipWaitingForLoading = true)
     }
 
     /**

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/types/Trainee.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/types/Trainee.kt
@@ -154,9 +154,6 @@ class Trainee {
     /** Names of skills the trainee currently owns, used to score the estimated rank. Seeded from the Details "Skills" tab and augmented as the bot buys skills. */
     val ownedSkillNames: MutableSet<String> = mutableSetOf()
 
-    /** The trainee's star rarity (1-5), or 0 when unknown. Drives the unique-skill bonus multiplier in the estimated rank. */
-    var starLevel: Int = 0
-
     /** The trainee's unique-skill level read from the Skills tab, or 0 when unknown. */
     var uniqueSkillLevel: Int = 0
 

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/types/Trainee.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/types/Trainee.kt
@@ -49,6 +49,12 @@ class Trainee {
     companion object {
         const val TAG: String = "[${MainActivity.loggerTag}]Trainee"
 
+        /** Reference (1080p) width of a single aptitude grade cell crop. */
+        const val APTITUDE_CELL_REF_WIDTH: Int = 176
+
+        /** Reference (1080p) height of a single aptitude grade cell crop. */
+        const val APTITUDE_CELL_REF_HEIGHT: Int = 52
+
         /** Mapping of [Aptitude] levels to their corresponding UI label components. */
         val aptitudeComponentMap: Map<Aptitude, ComponentInterface> =
             mapOf(
@@ -450,19 +456,19 @@ class Trainee {
                     bitmap,
                     imageUtils.relX(point.x, 108 + (index * 190)),
                     imageUtils.relY(point.y, -25),
-                    imageUtils.relWidth(176),
-                    imageUtils.relHeight(52),
+                    imageUtils.relWidth(APTITUDE_CELL_REF_WIDTH),
+                    imageUtils.relHeight(APTITUDE_CELL_REF_HEIGHT),
                     "findAptitudesInBitmap:: crop bitmap.",
                 )
             if (croppedBitmap == null) {
                 MessageLog.e(TAG, "[ERROR] findAptitudesInBitmap:: Failed to create cropped bitmap: $option.")
                 return@forEachIndexed
             }
-            for ((aptitude, component) in aptitudeComponentMap.entries) {
-                if (component.check(imageUtils, sourceBitmap = croppedBitmap)) {
-                    result[option] = aptitude
-                    break
-                }
+
+            // Score every letter template and take the best match rather than the first to clear the floor, so a lower-ranked letter (e.g. B) can't shadow the true grade (e.g. D or E).
+            val best: Aptitude? = imageUtils.findBestTemplateMatch(croppedBitmap, aptitudeComponentMap, APTITUDE_CELL_REF_WIDTH, APTITUDE_CELL_REF_HEIGHT)
+            if (best != null) {
+                result[option] = best
             }
         }
 

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/types/Trainee.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/types/Trainee.kt
@@ -31,6 +31,7 @@ import com.steve1316.uma_android_automation.types.StatName
 import com.steve1316.uma_android_automation.types.TrackDistance
 import com.steve1316.uma_android_automation.types.TrackSurface
 import com.steve1316.uma_android_automation.utils.CustomImageUtils
+import com.steve1316.uma_scoring.RankResult
 import org.opencv.core.Point
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CountDownLatch
@@ -149,6 +150,18 @@ class Trainee {
 
     /** The trainee's current pool of skill points. */
     var skillPoints: Int = 120
+
+    /** Names of skills the trainee currently owns, used to score the estimated rank. Seeded from the Details "Skills" tab and augmented as the bot buys skills. */
+    val ownedSkillNames: MutableSet<String> = mutableSetOf()
+
+    /** The trainee's star rarity (1-5), or 0 when unknown. Drives the unique-skill bonus multiplier in the estimated rank. */
+    var starLevel: Int = 0
+
+    /** The trainee's unique-skill level read from the Skills tab, or 0 when unknown. */
+    var uniqueSkillLevel: Int = 0
+
+    /** The most recently computed estimated overall rank, or null before the first computation. */
+    var estimatedRank: RankResult? = null
 
     /** The trainee's current total fan count. Starts at 0 until the first fan-count OCR reading. */
     var fans: Int = 0
@@ -830,6 +843,7 @@ class Trainee {
         MessageLog.v(TAG, "[TRAINEE] Mood: ${mood.name}")
         MessageLog.v(TAG, "[TRAINEE] Fans: $fans")
         MessageLog.v(TAG, "[TRAINEE] Skill Points: $skillPoints")
+        estimatedRank?.let { MessageLog.v(TAG, "[TRAINEE] Estimated Rank: ${it.rankLabel} (${it.totalScore})") }
         val trackString = "Turf=${trackSurfaceAptitudes[TrackSurface.TURF]}, Dirt=${trackSurfaceAptitudes[TrackSurface.DIRT]}"
         val distanceString =
             "Sprint=${trackDistanceAptitudes[TrackDistance.SPRINT]}, Mile=${trackDistanceAptitudes[TrackDistance.MILE]}, Medium=${trackDistanceAptitudes[TrackDistance.MEDIUM]}, Long=${trackDistanceAptitudes[TrackDistance.LONG]}"

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/utils/CustomImageUtils.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/utils/CustomImageUtils.kt
@@ -80,6 +80,23 @@ private const val RAINBOW_SUPPORT_REGION_HEIGHT_FRACTION = 0.75
 internal fun rainbowHuesPresent(greenFraction: Double, cyanFraction: Double, pinkFraction: Double, minFraction: Double = 0.03): Int =
     listOf(greenFraction, cyanFraction, pinkFraction).count { it > minFraction }
 
+// //////////////////////////////////////////////////////////////////////////////////////////////////
+// //////////////////////////////////////////////////////////////////////////////////////////////////
+// Template argmax helper
+
+/**
+ * Returns the key with the highest score, but only if that score clears the floor. This is the argmax that replaces the old first-match-wins loop for aptitude letter detection, so a lower-ranked
+ * letter that merely clears the confidence floor can no longer win over the true best match. Pure so it is unit-testable without OpenCV.
+ *
+ * @param scores Map of candidate keys to their template-match correlation scores.
+ * @param floor The minimum score the winner must reach to be accepted.
+ * @return The key with the highest score at or above [floor], or null if the map is empty or the best score is below the floor.
+ */
+internal fun <K> argMaxAboveFloor(scores: Map<K, Double>, floor: Double): K? {
+    val best = scores.maxByOrNull { it.value } ?: return null
+    return if (best.value >= floor) best.key else null
+}
+
 /** Utility functions for image processing via CV like OpenCV. */
 class CustomImageUtils(context: Context, private val game: Game) : ImageUtils(context) {
     /** OCR threshold for text recognition. */
@@ -290,6 +307,47 @@ class CustomImageUtils(context: Context, private val game: Game) : ImageUtils(co
             return matchLocation
         }
         return null
+    }
+
+    /**
+     * Finds the best-matching candidate template within a cropped cell by argmax over correlation scores.
+     *
+     * Unlike the first-match-wins loop it replaces, this scores every candidate template and returns the one with the highest TM_CCOEFF_NORMED correlation, so a lower-ranked template that merely
+     * clears the confidence floor can no longer shadow the true best match. The cell is normalized to the 1080p reference crop size so the reference-sized templates match at scale 1.0 on any device.
+     *
+     * @param sourceBitmap The cropped cell bitmap containing a single glyph.
+     * @param candidates Map of candidate keys to the [ComponentInterface] whose template represents each.
+     * @param referenceWidth The 1080p reference width of the crop, used to normalize the cell before matching.
+     * @param referenceHeight The 1080p reference height of the crop, used to normalize the cell before matching.
+     * @param minConfidence The minimum correlation the winner must reach. Defaults to the global template-match confidence.
+     * @return The best-matching key, or null if no candidate template reached [minConfidence].
+     */
+    fun <K> findBestTemplateMatch(sourceBitmap: Bitmap, candidates: Map<K, ComponentInterface>, referenceWidth: Int, referenceHeight: Int, minConfidence: Double = confidence): K? {
+        // Normalize the cell to the reference crop size so the fixed reference-sized templates match at scale 1.0 regardless of device resolution.
+        val normalizedCell: Bitmap =
+            if (sourceBitmap.width != referenceWidth || sourceBitmap.height != referenceHeight) sourceBitmap.scale(referenceWidth, referenceHeight) else sourceBitmap
+
+        val sourceMat: Mat = normalizedCell.toMat()
+        Imgproc.cvtColor(sourceMat, sourceMat, Imgproc.COLOR_BGR2GRAY)
+
+        val scores = mutableMapOf<K, Double>()
+        for ((key, component) in candidates) {
+            val templateBitmap: Bitmap = component.template.getBitmap(this) ?: continue
+            val templateMat: Mat = templateBitmap.toMat()
+            Imgproc.cvtColor(templateMat, templateMat, Imgproc.COLOR_BGR2GRAY)
+
+            // Skip templates larger than the cell to avoid an invalid matchTemplate call.
+            if (templateMat.cols() <= sourceMat.cols() && templateMat.rows() <= sourceMat.rows()) {
+                val resultMat = Mat()
+                Imgproc.matchTemplate(sourceMat, templateMat, resultMat, Imgproc.TM_CCOEFF_NORMED)
+                scores[key] = Core.minMaxLoc(resultMat).maxVal
+                resultMat.release()
+            }
+            templateMat.release()
+        }
+        sourceMat.release()
+
+        return argMaxAboveFloor(scores, minConfidence)
     }
 
     // //////////////////////////////////////////////////////////////////////////////////////////////////

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/utils/CustomImageUtils.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/utils/CustomImageUtils.kt
@@ -1176,13 +1176,13 @@ class CustomImageUtils(context: Context, private val game: Game) : ImageUtils(co
                         relHeight(height),
                         useThreshold = false,
                         useGrayscale = true,
-                        scale = 1.0,
+                        scale = 2.0,
                         ocrEngine = "tesseract_digits",
                         debugName = "${statName}StatValue",
                     )
 
                 // Parse the text.
-                Log.d(TAG, "[DEBUG] determineStatValues:: Raw OCR text for $statName: '$text' (length: ${text.length})")
+                MessageLog.d(TAG, "[DEBUG] determineStatValues:: Raw OCR text for $statName: '$text' (length: ${text.length})")
 
                 if (text.lowercase().contains("max") || text.lowercase().contains("ax")) {
                     Log.d(TAG, "[DEBUG] determineStatValues:: $statName seems to be maxed out. Setting it to $manualStatCap.")

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/utils/CustomImageUtils.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/utils/CustomImageUtils.kt
@@ -1191,13 +1191,18 @@ class CustomImageUtils(context: Context, private val game: Game) : ImageUtils(co
                     try {
                         // Extract all numbers from the text
                         val numbers = Regex("\\d+").findAll(text).map { it.value.toInt() }.toList()
-                        val cap = if (manualStatCap > 0) manualStatCap else 1200
 
                         if (numbers.isEmpty()) {
                             MessageLog.w(TAG, "[WARN] determineStatValues:: No numbers found in '$text' for $statName")
                             result[statName] = -1
+                        } else if (isAptitudeDialog) {
+                            // The value box holds only the value (no cap or rank badge), but OCR can split the digits (e.g. "1279" -> "1 279"), so rebuild the value by
+                            // concatenating every digit in reading order rather than treating the pieces as separate numbers. The 2500 ceiling drops a clearly-bogus read.
+                            val value = text.replace(Regex("[^0-9]"), "").toIntOrNull() ?: -1
+                            result[statName] = if (value in 1..2500) value else -1
                         } else {
-                            // Filter to values within the valid stat range. Values exceeding the cap are OCR misreads.
+                            // The Main screen shows only the value, so anything over the cap is an OCR misread.
+                            val cap = if (manualStatCap > 0) manualStatCap else 1200
                             val validNumbers = numbers.filter { it in 0..cap }
                             if (validNumbers.isNotEmpty()) {
                                 result[statName] = validNumbers.max()

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/utils/LogStreamServer.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/utils/LogStreamServer.kt
@@ -157,6 +157,10 @@ object LogStreamServer {
      *  immediately on connect. Null until the first snapshot arrives this run. */
     @Volatile private var latestAnalyticsSnapshot: String? = null
 
+    /** Latest owned-skills snapshot pushed after the Skills tab is read. Replayed to each new client after the log history flush so the Skills panel paints
+     *  immediately on connect. Null until the first snapshot arrives this run. */
+    @Volatile private var latestSkillsSnapshot: String? = null
+
     /**
      * Represents a parsed log entry for structured transmission.
      *
@@ -240,6 +244,13 @@ object LogStreamServer {
          * @property json Pre-serialized analytics snapshot JSON sent verbatim to clients with an `ANALYTICS:` prefix.
          */
         data class BroadcastAnalytics(val json: String) : LogAction()
+
+        /**
+         * Broadcasts an owned-skills snapshot to all connected clients. Distinct from [Broadcast] so the framing message never lands in the log replay buffer.
+         *
+         * @property json Pre-serialized skills snapshot JSON sent verbatim to clients with a `SKILLS:` prefix.
+         */
+        data class BroadcastSkills(val json: String) : LogAction()
     }
 
     // //////////////////////////////////////////////////////////////////////////////////////////////////
@@ -456,6 +467,15 @@ object LogStreamServer {
                     session.send(Frame.Text("ANALYTICS:$snapshot"))
                 } catch (e: Exception) {
                     Log.w(TAG, "[WARN] handleNewClientAction:: Failed to replay analytics snapshot: ${e.message}")
+                }
+            }
+
+            // Replay the most recent owned-skills snapshot (if any) so the Skills panel paints immediately on a mid-run browser refresh.
+            latestSkillsSnapshot?.let { snapshot ->
+                try {
+                    session.send(Frame.Text("SKILLS:$snapshot"))
+                } catch (e: Exception) {
+                    Log.w(TAG, "[WARN] handleNewClientAction:: Failed to replay skills snapshot: ${e.message}")
                 }
             }
 
@@ -873,6 +893,9 @@ object LogStreamServer {
         // Drop the cached analytics snapshot so the new run starts with no replay.
         latestAnalyticsSnapshot = null
 
+        // Drop the cached skills snapshot so the new run starts with no replay.
+        latestSkillsSnapshot = null
+
         // Ensure we are unmuted for the new run.
         isMuted = false
 
@@ -980,6 +1003,19 @@ object LogStreamServer {
     }
 
     /**
+     * Caches and broadcasts an owned-skills snapshot to all connected clients and replays it to clients that connect later. Called after the Skills tab is read.
+     *
+     * @param json Pre-serialized skills snapshot JSON.
+     */
+    fun broadcastSkillsSnapshot(json: String) {
+        latestSkillsSnapshot = json
+        if (!isRunning) return
+        serverScope?.launch {
+            actionChannel?.send(LogAction.BroadcastSkills(json))
+        }
+    }
+
+    /**
      * Sends the Smart Race Solver state to all currently connected clients with the `SRS_STATE:`
      * framing prefix. Payload is the lowercase boolean (`true` or `false`).
      *
@@ -1006,6 +1042,23 @@ object LogStreamServer {
     private suspend fun handleAnalyticsBroadcast(json: String) {
         if (clients.isEmpty()) return
         val frame = "ANALYTICS:$json"
+        for (client in clients) {
+            try {
+                client.send(Frame.Text(frame))
+            } catch (_: Exception) {
+            }
+        }
+    }
+
+    /**
+     * Sends an owned-skills snapshot to all currently connected clients with the `SKILLS:` framing prefix the viewer uses to route the payload to its Skills panel.
+     * Skipped silently when no clients are connected.
+     *
+     * @param json The pre-serialized skills snapshot JSON.
+     */
+    private suspend fun handleSkillsBroadcast(json: String) {
+        if (clients.isEmpty()) return
+        val frame = "SKILLS:$json"
         for (client in clients) {
             try {
                 client.send(Frame.Text(frame))
@@ -1100,6 +1153,10 @@ object LogStreamServer {
 
                             is LogAction.BroadcastAnalytics -> {
                                 handleAnalyticsBroadcast(action.json)
+                            }
+
+                            is LogAction.BroadcastSkills -> {
+                                handleSkillsBroadcast(action.json)
                             }
                         }
                     }

--- a/android/app/src/test/java/com/steve1316/uma_android_automation/bot/DeriveCheckTypeTest.kt
+++ b/android/app/src/test/java/com/steve1316/uma_android_automation/bot/DeriveCheckTypeTest.kt
@@ -1,0 +1,44 @@
+package com.steve1316.uma_android_automation.bot
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+/**
+ * Verifies that [SkillDatabase.deriveCheckType] maps a skill's activation condition to the correct aptitude affinity role(s) used by the estimated-rank skill scoring.
+ */
+class DeriveCheckTypeTest {
+    @Test
+    @DisplayName("A skill with no affinity token has an empty checkType")
+    fun emptyWhenNoAffinityToken() {
+        assertEquals("", SkillDatabase.deriveCheckType("", ""))
+        assertEquals("", SkillDatabase.deriveCheckType("is_lastspurt==1", ""))
+        // track_id and rotation are not affinity roles and must be ignored.
+        assertEquals("", SkillDatabase.deriveCheckType("track_id==10001&rotation==1", ""))
+    }
+
+    @Test
+    @DisplayName("A single running_style / distance_type / ground_type token maps to one role")
+    fun singleRole() {
+        assertEquals("Late", SkillDatabase.deriveCheckType("running_style==3&up_slope_random==1", ""))
+        assertEquals("Medium", SkillDatabase.deriveCheckType("distance_type==3", ""))
+        assertEquals("Dirt", SkillDatabase.deriveCheckType("ground_type==2", ""))
+        assertEquals("Front", SkillDatabase.deriveCheckType("running_style==1", ""))
+        assertEquals("Long", SkillDatabase.deriveCheckType("distance_type==4", ""))
+    }
+
+    @Test
+    @DisplayName("The precondition contributes affinity tokens too")
+    fun preconditionContributes() {
+        assertEquals("End", SkillDatabase.deriveCheckType("", "running_style==4"))
+    }
+
+    @Test
+    @DisplayName("Multiple tokens combine, ordered surface then distance then style")
+    fun multiRoleOrdering() {
+        assertEquals("Long/Front", SkillDatabase.deriveCheckType("distance_type==4&running_style==1", ""))
+        assertEquals("Dirt/Mile", SkillDatabase.deriveCheckType("ground_type==2&distance_type==2", ""))
+        // Two styles collapse into a single ordered pair.
+        assertEquals("Pace/Late", SkillDatabase.deriveCheckType("running_style==2|running_style==3", ""))
+    }
+}

--- a/android/app/src/test/java/com/steve1316/uma_android_automation/utils/AptitudeMatchTest.kt
+++ b/android/app/src/test/java/com/steve1316/uma_android_automation/utils/AptitudeMatchTest.kt
@@ -1,0 +1,37 @@
+package com.steve1316.uma_android_automation.utils
+
+import com.steve1316.uma_android_automation.types.Aptitude
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit tests for the pure argmax decision behind aptitude letter detection. The OpenCV pixel matching in `findBestTemplateMatch` needs native OpenCV and is validated on-device, but the
+ * "highest score wins, not the first to clear the floor" rule that fixes the E/D-read-as-B misreads is pure and covered here.
+ */
+@DisplayName("Aptitude argmax decision")
+class AptitudeMatchTest {
+    @Test
+    @DisplayName("The highest-scoring letter wins even when a lower-ranked letter also clears the floor")
+    fun testHighestScoreWins() {
+        // Sprint is truly E: E scores highest, but B also clears 0.8. The old first-match-wins loop returned B; argmax must return E.
+        assertEquals(Aptitude.E, argMaxAboveFloor(mapOf(Aptitude.B to 0.83, Aptitude.E to 0.91), 0.8), "E outscores B on an E cell")
+        // End is truly D: same shape of failure, D must win over B.
+        assertEquals(Aptitude.D, argMaxAboveFloor(mapOf(Aptitude.B to 0.84, Aptitude.D to 0.90), 0.8), "D outscores B on a D cell")
+    }
+
+    @Test
+    @DisplayName("A clear single winner is returned; a score exactly at the floor is accepted")
+    fun testWinnerSelection() {
+        assertEquals(Aptitude.A, argMaxAboveFloor(mapOf(Aptitude.A to 0.95), 0.8), "The only candidate wins")
+        assertEquals(Aptitude.C, argMaxAboveFloor(mapOf(Aptitude.C to 0.8, Aptitude.B to 0.79), 0.8), "A score exactly at the floor is accepted")
+    }
+
+    @Test
+    @DisplayName("Nothing is returned when no candidate reaches the floor or the map is empty")
+    fun testNoMatch() {
+        assertNull(argMaxAboveFloor(mapOf(Aptitude.B to 0.6, Aptitude.E to 0.7), 0.8), "All below the floor means no match, so the cell keeps its default")
+        assertNull(argMaxAboveFloor(emptyMap<Aptitude, Double>(), 0.8), "An empty score map means no match")
+    }
+}

--- a/android/scoring-shared/src/commonMain/kotlin/com/steve1316/uma_scoring/RankEstimate.kt
+++ b/android/scoring-shared/src/commonMain/kotlin/com/steve1316/uma_scoring/RankEstimate.kt
@@ -1,0 +1,371 @@
+package com.steve1316.uma_scoring
+
+import kotlin.math.floor
+
+// //////////////////////////////////////////////////////////////////////////////////////////////////
+// //////////////////////////////////////////////////////////////////////////////////////////////////
+// Estimated overall trainee rank
+
+/**
+ * Estimated overall trainee rank, ported from the open-source daftuyda/UmaTools calculator (js/rating-shared.js and js/calculator.js). The total is
+ * `sum(statScore) + uniqueBonus + sum(skillScore)` mapped onto a rank tier. This mirrors UmaTools' output - an approximation of the game's unpublished formula - so results are
+ * labeled "Est." in the UI and are not the exact in-game number. Unlike the rest of this module it is consumed by the JVM bot only, so it is not `@JsExport`-ed.
+ *
+ * Skill scoring is data-free: the bot supplies each owned skill's base evaluation points (`eval_pt` from our own skill database) and a `checkType` derived from the skill's
+ * activation condition. UmaTools' per-skill values equal `base x {S/A 1.1, B/C 0.9, D/E/F 0.8, else 0.7}` for the vast majority of skills, so we apply that multiplier here
+ * against the base rather than shipping a bundled dataset.
+ */
+
+// Per-point stat-score rates for the 1-1200 range, in 50-value blocks. Ported verbatim from UmaTools rating-shared.js STAT_SCORES (R1).
+private val STAT_RATE_LOW =
+    intArrayOf(
+        5, 8, 10, 13, 16, 18, 21, 24, 26, 28, 29, 30, 31, 33, 34, 35, 39, 41, 42, 43, 52, 55, 66, 68, 68,
+    )
+
+// Per-point stat-score rates for the 1201-2000 range, in 10-value blocks. Ported verbatim from UmaTools rating-shared.js STAT_SCORES (R2).
+private val STAT_RATE_MID =
+    intArrayOf(
+        79, 80, 81, 83, 84, 85, 86, 88, 89, 90, 92, 93, 94, 96, 97, 98, 100, 101, 102, 103, 105, 106, 107, 109, 110, 111, 113, 114, 115, 117, 118, 119, 121, 122, 123, 124,
+        126, 127, 128, 130, 131, 132, 134, 135, 136, 138, 139, 140, 141, 143, 144, 145, 147, 148, 149, 151, 152, 153, 155, 156, 157, 159, 160, 161, 162, 164, 165, 166, 168,
+        169, 170, 172, 173, 174, 176, 177, 178, 179, 181, 182, 182,
+    )
+
+// Highest stat value the score curve is defined for. Values above this are clamped down to it, values below 0 up to 0.
+private const val MAX_STAT_VALUE = 2500
+
+// Aptitude-bucket multipliers applied to a skill's base evaluation points, keyed off the trainee's aptitude grade for the skill's checkType.
+private const val MULT_GOOD = 1.1
+private const val MULT_AVERAGE = 0.9
+private const val MULT_BAD = 0.8
+private const val MULT_TERRIBLE = 0.7
+
+// Which aptitude group each affinity role belongs to. A multi-role skill takes the best multiplier per group, then multiplies the groups together.
+private val ROLE_GROUP =
+    mapOf(
+        "turf" to "surface", "dirt" to "surface",
+        "sprint" to "distance", "mile" to "distance", "medium" to "distance", "long" to "distance",
+        "front" to "style", "pace" to "style", "late" to "style", "end" to "style",
+    )
+
+// Minimum total score for each rank tier, index-aligned with RANK_LABELS. Ported verbatim from UmaTools RATING_BADGE_MINIMA (298 tiers, G..LS24).
+private val RANK_MINS =
+    intArrayOf(
+        0, 300, 600, 900, 1300, 1800, 2300, 2900, 3500, 4900, 6500, 8200,
+        10000, 12100, 14500, 15900, 17500, 19200, 19600, 20000, 20400, 20800, 21200, 21600,
+        22100, 22500, 23000, 23400, 23900, 24300, 24800, 25300, 25800, 26300, 26800, 27300,
+        27800, 28300, 28800, 29400, 29900, 30400, 31000, 31500, 32100, 32700, 33200, 33800,
+        34400, 35000, 35600, 36200, 36800, 37500, 38100, 38700, 39400, 40000, 40700, 41300,
+        42000, 42700, 43400, 44000, 44700, 45400, 46200, 46900, 47600, 48300, 49000, 49800,
+        50500, 51300, 52000, 52800, 53600, 54400, 55200, 55900, 56700, 57500, 58400, 59200,
+        60000, 60800, 61700, 62500, 63400, 64200, 65100, 66400, 67700, 69000, 70300, 71600,
+        72900, 74400, 76000, 76600, 77200, 77800, 78500, 79100, 79700, 80400, 81000, 81700,
+        82300, 83000, 83600, 84300, 84900, 85600, 86200, 86700, 87300, 87900, 88500, 89100,
+        89700, 90300, 90900, 91400, 92000, 92600, 93200, 93800, 94400, 95000, 95600, 96300,
+        96900, 97500, 98000, 98500, 99000, 99600, 100100, 100600, 101100, 101700, 102200, 102700,
+        103200, 103800, 104300, 104800, 105400, 105900, 106400, 106900, 107500, 108000, 108500, 109100,
+        109600, 110100, 110700, 111200, 111800, 112300, 112800, 113400, 113900, 114400, 115000, 115500,
+        116100, 116600, 117100, 117700, 118200, 118800, 119300, 119900, 120400, 121000, 121500, 122000,
+        122600, 123100, 123700, 124200, 124800, 125300, 125900, 126400, 127000, 127500, 128100, 128700,
+        129200, 129800, 130300, 130900, 131400, 132000, 132500, 133100, 133700, 134200, 134800, 135300,
+        135900, 136500, 137000, 137600, 138100, 138700, 139300, 139800, 140400, 141000, 141500, 142100,
+        142700, 143200, 143800, 144400, 144900, 145500, 146100, 146600, 147200, 147800, 148400, 148900,
+        149500, 150100, 150700, 151200, 151800, 152400, 153000, 153500, 154100, 154700, 155300, 155900,
+        156400, 157000, 157600, 158200, 158800, 159300, 159900, 160500, 161100, 161700, 162300, 162900,
+        163400, 164000, 164600, 165200, 165800, 166400, 167000, 167600, 168200, 168700, 169300, 169900,
+        170500, 171100, 171700, 172300, 172900, 173500, 174100, 174700, 175300, 175900, 176500, 177100,
+        177700, 178300, 178900, 179500, 180100, 180700, 181300, 181900, 182500, 183100, 183700, 184300,
+        184900, 185500, 186200, 186800, 187400, 188000, 188600, 189200, 189800, 190400,
+    )
+
+// Rank labels, index-aligned with RANK_MINS. The array index is also the utx_txt_rank image number (index 0 = plain "G", which has no badge image).
+private val RANK_LABELS =
+    arrayOf(
+        "G", "G+", "F", "F+", "E", "E+", "D", "D+", "C", "C+", "B", "B+",
+        "A", "A+", "S", "S+", "SS", "SS+", "UG", "UG1", "UG2", "UG3", "UG4", "UG5",
+        "UG6", "UG7", "UG8", "UG9", "UF", "UF1", "UF2", "UF3", "UF4", "UF5", "UF6", "UF7",
+        "UF8", "UF9", "UE", "UE1", "UE2", "UE3", "UE4", "UE5", "UE6", "UE7", "UE8", "UE9",
+        "UD", "UD1", "UD2", "UD3", "UD4", "UD5", "UD6", "UD7", "UD8", "UD9", "UC", "UC1",
+        "UC2", "UC3", "UC4", "UC5", "UC6", "UC7", "UC8", "UC9", "UB", "UB1", "UB2", "UB3",
+        "UB4", "UB5", "UB6", "UB7", "UB8", "UB9", "UA", "UA1", "UA2", "UA3", "UA4", "UA5",
+        "UA6", "UA7", "UA8", "UA9", "US", "US1", "US2", "US3", "US4", "US5", "US6", "US7",
+        "US8", "US9", "LG", "LG1", "LG2", "LG3", "LG4", "LG5", "LG6", "LG7", "LG8", "LG9",
+        "LG10", "LG11", "LG12", "LG13", "LG14", "LG15", "LG16", "LG17", "LG18", "LG19", "LG20", "LG21",
+        "LG22", "LG23", "LG24", "LF", "LF1", "LF2", "LF3", "LF4", "LF5", "LF6", "LF7", "LF8",
+        "LF9", "LF10", "LF11", "LF12", "LF13", "LF14", "LF15", "LF16", "LF17", "LF18", "LF19", "LF20",
+        "LF21", "LF22", "LF23", "LF24", "LE", "LE1", "LE2", "LE3", "LE4", "LE5", "LE6", "LE7",
+        "LE8", "LE9", "LE10", "LE11", "LE12", "LE13", "LE14", "LE15", "LE16", "LE17", "LE18", "LE19",
+        "LE20", "LE21", "LE22", "LE23", "LE24", "LD", "LD1", "LD2", "LD3", "LD4", "LD5", "LD6",
+        "LD7", "LD8", "LD9", "LD10", "LD11", "LD12", "LD13", "LD14", "LD15", "LD16", "LD17", "LD18",
+        "LD19", "LD20", "LD21", "LD22", "LD23", "LD24", "LC", "LC1", "LC2", "LC3", "LC4", "LC5",
+        "LC6", "LC7", "LC8", "LC9", "LC10", "LC11", "LC12", "LC13", "LC14", "LC15", "LC16", "LC17",
+        "LC18", "LC19", "LC20", "LC21", "LC22", "LC23", "LC24", "LB", "LB1", "LB2", "LB3", "LB4",
+        "LB5", "LB6", "LB7", "LB8", "LB9", "LB10", "LB11", "LB12", "LB13", "LB14", "LB15", "LB16",
+        "LB17", "LB18", "LB19", "LB20", "LB21", "LB22", "LB23", "LB24", "LA", "LA1", "LA2", "LA3",
+        "LA4", "LA5", "LA6", "LA7", "LA8", "LA9", "LA10", "LA11", "LA12", "LA13", "LA14", "LA15",
+        "LA16", "LA17", "LA18", "LA19", "LA20", "LA21", "LA22", "LA23", "LA24", "LS", "LS1", "LS2",
+        "LS3", "LS4", "LS5", "LS6", "LS7", "LS8", "LS9", "LS10", "LS11", "LS12", "LS13", "LS14",
+        "LS15", "LS16", "LS17", "LS18", "LS19", "LS20", "LS21", "LS22", "LS23", "LS24",
+    )
+
+// Precomputed stat-value -> score table for 0..MAX_STAT_VALUE, built once from the rate arrays above.
+private val STAT_SCORES = buildStatScores()
+
+/**
+ * The trainee's aptitude letter grade (`G`..`S`) for each of the ten skill-affinity roles. Used to pick the bucket multiplier for an aptitude-linked skill.
+ *
+ * @property turf Aptitude grade for turf-affinity skills.
+ * @property dirt Aptitude grade for dirt-affinity skills.
+ * @property sprint Aptitude grade for sprint-affinity skills.
+ * @property mile Aptitude grade for mile-affinity skills.
+ * @property medium Aptitude grade for medium-affinity skills.
+ * @property long Aptitude grade for long-affinity skills.
+ * @property front Aptitude grade for front-runner-affinity skills.
+ * @property pace Aptitude grade for pace-chaser-affinity skills.
+ * @property late Aptitude grade for late-surger-affinity skills.
+ * @property end Aptitude grade for end-closer-affinity skills.
+ */
+data class RankAptitudes(
+    val turf: String,
+    val dirt: String,
+    val sprint: String,
+    val mile: String,
+    val medium: String,
+    val long: String,
+    val front: String,
+    val pace: String,
+    val late: String,
+    val end: String,
+)
+
+/**
+ * One owned skill's scoring inputs.
+ *
+ * @property evalPt The skill's base evaluation points (our `eval_pt`).
+ * @property checkType The skill's aptitude affinity, e.g. "Late", "Medium/Long", or "" when the skill scores flat regardless of aptitude.
+ */
+data class SkillScoreInput(
+    val evalPt: Int,
+    val checkType: String,
+)
+
+/**
+ * The result of an estimated-rank computation.
+ *
+ * @property totalScore The full estimated evaluation score.
+ * @property statScore The summed stat-score contribution.
+ * @property skillScore The summed skill-score contribution.
+ * @property uniqueBonus The unique-skill bonus contribution.
+ * @property rankLabel The rank tier label, e.g. "S" or "SS+".
+ * @property rankImageIndex The utx_txt_rank image number for the label (0 = plain "G", which has no image).
+ */
+data class RankResult(
+    val totalScore: Int,
+    val statScore: Int,
+    val skillScore: Int,
+    val uniqueBonus: Int,
+    val rankLabel: String,
+    val rankImageIndex: Int,
+)
+
+/**
+ * Builds the stat-value -> score lookup, ported from UmaTools rating-shared.js. Three ranges accumulate a running raw total at accelerating per-point rates, and each stored
+ * score is the raw total divided by 10 and rounded to the nearest integer (integer `(raw + 5) / 10` matches JS `Math.round(raw / 10)` for non-negative raw).
+ *
+ * @return An array indexed by stat value in 0..MAX_STAT_VALUE giving each value's score.
+ */
+private fun buildStatScores(): IntArray {
+    val sc = IntArray(MAX_STAT_VALUE + 1)
+    var raw = 0
+    var idx = 0
+    for (c in 1..1200) {
+        idx =
+            when {
+                c <= 49 -> 0
+                c <= 99 -> 1
+                c % 50 == 0 -> idx + 1
+                else -> idx
+            }
+        raw += STAT_RATE_LOW[idx]
+        sc[c] = (raw + 5) / 10
+    }
+    raw = 38413
+    idx = 0
+    for (c in 1201..2000) {
+        idx =
+            when {
+                c <= 1209 -> 0
+                c <= 1219 -> 1
+                c % 10 == 0 -> idx + 1
+                else -> idx
+            }
+        raw += STAT_RATE_MID[idx]
+        sc[c] = (raw + 5) / 10
+    }
+    raw = 142796
+    idx = 0
+    var rate = 183
+    for (c in 2001..MAX_STAT_VALUE) {
+        if (idx >= 25) {
+            rate++
+            idx = 0
+        }
+        raw += rate
+        idx++
+        sc[c] = (raw + 5) / 10
+    }
+    return sc
+}
+
+/** Rounds like JS `Math.round` (ties toward positive infinity) for non-negative inputs, which the ported multipliers always produce. */
+private fun jsRound(x: Double): Int = floor(x + 0.5).toInt()
+
+/** Maps an aptitude letter grade to its bucket multiplier, following UmaTools `getBucketForGrade`. */
+private fun gradeMultiplier(grade: String): Double =
+    when (grade.uppercase()) {
+        "S", "A" -> MULT_GOOD
+        "B", "C" -> MULT_AVERAGE
+        "D", "E", "F" -> MULT_BAD
+        else -> MULT_TERRIBLE
+    }
+
+/** Returns the trainee's aptitude grade for one affinity role, or null when the role is not one of the ten known roles. */
+private fun gradeForRole(role: String, apt: RankAptitudes): String? =
+    when (role) {
+        "turf" -> apt.turf
+        "dirt" -> apt.dirt
+        "sprint" -> apt.sprint
+        "mile" -> apt.mile
+        "medium" -> apt.medium
+        "long" -> apt.long
+        "front" -> apt.front
+        "pace" -> apt.pace
+        "late" -> apt.late
+        "end" -> apt.end
+        else -> null
+    }
+
+/** Returns the bucket multiplier for one affinity role given the trainee's aptitudes, or null when the role is unknown. */
+private fun roleMultiplier(role: String, apt: RankAptitudes): Double? {
+    val grade = gradeForRole(role, apt) ?: return null
+    return gradeMultiplier(grade)
+}
+
+/** Finds the highest rank tier whose minimum the score meets. RANK_MINS is ascending, so this scans until the score drops below a tier's minimum. */
+private fun rankIndexForScore(totalScore: Int): Int {
+    if (totalScore <= 0) return 0
+    var idx = 0
+    for (i in RANK_MINS.indices) {
+        if (totalScore >= RANK_MINS[i]) idx = i else break
+    }
+    return idx
+}
+
+/**
+ * The evaluation-score contribution of a single stat value.
+ *
+ * @param value The raw stat value (clamped to 0..MAX_STAT_VALUE).
+ * @return The stat's score contribution.
+ */
+fun statScore(value: Int): Int = STAT_SCORES[value.coerceIn(0, MAX_STAT_VALUE)]
+
+/**
+ * The unique-skill bonus, following UmaTools `calcUniqueBonus`. One- and two-star trainees use a x120 multiplier, all others (including an unknown star count) use x170.
+ *
+ * @param starLevel The trainee's star rarity.
+ * @param uniqueLevel The unique skill's level.
+ * @return The bonus points, or 0 when the unique level is not positive.
+ */
+fun uniqueBonus(starLevel: Int, uniqueLevel: Int): Int {
+    if (uniqueLevel <= 0) return 0
+    val multiplier = if (starLevel == 1 || starLevel == 2) 120 else 170
+    return multiplier * uniqueLevel
+}
+
+/**
+ * The rank tier label for a total evaluation score.
+ *
+ * @param totalScore The total evaluation score.
+ * @return The rank label, e.g. "S" or "SS+".
+ */
+fun scoreToRankLabel(totalScore: Int): String = RANK_LABELS[rankIndexForScore(totalScore)]
+
+/**
+ * The utx_txt_rank image number for a rank label.
+ *
+ * @param label The rank label, e.g. "B+".
+ * @return The image index (0 = plain "G", which has no image), or -1 when the label is unknown.
+ */
+fun rankLabelToImageIndex(label: String): Int = RANK_LABELS.indexOf(label)
+
+/**
+ * The evaluation-score contribution of one owned skill, following UmaTools `evaluateSkillScore`. A skill with no checkType scores its flat base. A single-role skill scores
+ * `base x bucketMultiplier` for the trainee's aptitude grade in that role. A multi-role skill (e.g. "Medium/Long") takes the best multiplier per group (surface/distance/style)
+ * and multiplies the groups together.
+ *
+ * @param baseEvalPt The skill's base evaluation points.
+ * @param checkType The skill's affinity, e.g. "Late" or "Medium/Long", or "" for none.
+ * @param aptitudes The trainee's aptitude grades.
+ * @return The skill's rounded score contribution.
+ */
+fun evaluateSkillScore(baseEvalPt: Int, checkType: String, aptitudes: RankAptitudes): Int {
+    val ct = checkType.trim().lowercase()
+    if (ct.isEmpty()) return baseEvalPt
+    if (ct.contains("/")) {
+        val groupMax = HashMap<String, Double>()
+        for (part in ct.split("/")) {
+            val role = part.trim()
+            if (role.isEmpty()) continue
+            val mult = roleMultiplier(role, aptitudes) ?: continue
+            val group = ROLE_GROUP[role] ?: role
+            val prev = groupMax[group]
+            if (prev == null || mult > prev) groupMax[group] = mult
+        }
+        if (groupMax.isEmpty()) return baseEvalPt
+        var factor = 1.0
+        for (m in groupMax.values) factor *= m
+        return jsRound(baseEvalPt * factor)
+    }
+    val mult = roleMultiplier(ct, aptitudes) ?: return baseEvalPt
+    return jsRound(baseEvalPt * mult)
+}
+
+/**
+ * Estimates the trainee's overall rank from stats, owned skills, aptitudes, and the unique skill. `total = sum(statScore) + sum(skillScore) + uniqueBonus`.
+ *
+ * @param speed The Speed stat.
+ * @param stamina The Stamina stat.
+ * @param power The Power stat.
+ * @param guts The Guts stat.
+ * @param wit The Wit stat.
+ * @param skills The owned skills' scoring inputs.
+ * @param aptitudes The trainee's aptitude grades.
+ * @param starLevel The trainee's star rarity (drives the unique bonus multiplier).
+ * @param uniqueLevel The unique skill's level.
+ * @return The estimated rank, score, and per-component breakdown.
+ */
+fun estimateRank(
+    speed: Int,
+    stamina: Int,
+    power: Int,
+    guts: Int,
+    wit: Int,
+    skills: List<SkillScoreInput>,
+    aptitudes: RankAptitudes,
+    starLevel: Int,
+    uniqueLevel: Int,
+): RankResult {
+    val statTotal = statScore(speed) + statScore(stamina) + statScore(power) + statScore(guts) + statScore(wit)
+    var skillTotal = 0
+    for (s in skills) skillTotal += evaluateSkillScore(s.evalPt, s.checkType, aptitudes)
+    val bonus = uniqueBonus(starLevel, uniqueLevel)
+    val total = statTotal + skillTotal + bonus
+    val idx = rankIndexForScore(total)
+    return RankResult(
+        totalScore = total,
+        statScore = statTotal,
+        skillScore = skillTotal,
+        uniqueBonus = bonus,
+        rankLabel = RANK_LABELS[idx],
+        rankImageIndex = idx,
+    )
+}

--- a/android/scoring-shared/src/commonMain/kotlin/com/steve1316/uma_scoring/RankEstimate.kt
+++ b/android/scoring-shared/src/commonMain/kotlin/com/steve1316/uma_scoring/RankEstimate.kt
@@ -269,16 +269,14 @@ private fun rankIndexForScore(totalScore: Int): Int {
 fun statScore(value: Int): Int = STAT_SCORES[value.coerceIn(0, MAX_STAT_VALUE)]
 
 /**
- * The unique-skill bonus, following UmaTools `calcUniqueBonus`. One- and two-star trainees use a x120 multiplier, all others (including an unknown star count) use x170.
+ * The unique-skill bonus, following UmaTools `calcUniqueBonus`. The app does not read star rarity, so it always uses the x170 multiplier.
  *
- * @param starLevel The trainee's star rarity.
  * @param uniqueLevel The unique skill's level.
  * @return The bonus points, or 0 when the unique level is not positive.
  */
-fun uniqueBonus(starLevel: Int, uniqueLevel: Int): Int {
+fun uniqueBonus(uniqueLevel: Int): Int {
     if (uniqueLevel <= 0) return 0
-    val multiplier = if (starLevel == 1 || starLevel == 2) 120 else 170
-    return multiplier * uniqueLevel
+    return 170 * uniqueLevel
 }
 
 /**
@@ -339,7 +337,6 @@ fun evaluateSkillScore(baseEvalPt: Int, checkType: String, aptitudes: RankAptitu
  * @param wit The Wit stat.
  * @param skills The owned skills' scoring inputs.
  * @param aptitudes The trainee's aptitude grades.
- * @param starLevel The trainee's star rarity (drives the unique bonus multiplier).
  * @param uniqueLevel The unique skill's level.
  * @return The estimated rank, score, and per-component breakdown.
  */
@@ -351,13 +348,12 @@ fun estimateRank(
     wit: Int,
     skills: List<SkillScoreInput>,
     aptitudes: RankAptitudes,
-    starLevel: Int,
     uniqueLevel: Int,
 ): RankResult {
     val statTotal = statScore(speed) + statScore(stamina) + statScore(power) + statScore(guts) + statScore(wit)
     var skillTotal = 0
     for (s in skills) skillTotal += evaluateSkillScore(s.evalPt, s.checkType, aptitudes)
-    val bonus = uniqueBonus(starLevel, uniqueLevel)
+    val bonus = uniqueBonus(uniqueLevel)
     val total = statTotal + skillTotal + bonus
     val idx = rankIndexForScore(total)
     return RankResult(

--- a/android/scoring-shared/src/commonTest/kotlin/com/steve1316/uma_scoring/RankEstimateTest.kt
+++ b/android/scoring-shared/src/commonTest/kotlin/com/steve1316/uma_scoring/RankEstimateTest.kt
@@ -1,0 +1,126 @@
+package com.steve1316.uma_scoring
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Verifies the estimated-rank math against reference values computed independently from the UmaTools calculator source (rating-shared.js / calculator.js). If these drift, the
+ * port no longer matches the reference calculator.
+ */
+class RankEstimateTest {
+    // Aptitudes matching the reference trainee used to compute the expected values.
+    private val referenceAptitudes =
+        RankAptitudes(
+            turf = "A",
+            dirt = "G",
+            sprint = "E",
+            mile = "A",
+            medium = "A",
+            long = "B",
+            front = "F",
+            pace = "A",
+            late = "A",
+            end = "A",
+        )
+
+    @Test
+    fun statScoreMatchesReferenceCurve() {
+        assertEquals(0, statScore(0))
+        assertEquals(0, statScore(-50))
+        assertEquals(66, statScore(100))
+        assertEquals(181, statScore(200))
+        assertEquals(352, statScore(300))
+        assertEquals(847, statScore(500))
+        assertEquals(1773, statScore(790))
+        assertEquals(1957, statScore(838))
+        assertEquals(2635, statScore(1000))
+        assertEquals(3841, statScore(1200))
+        assertEquals(3849, statScore(1201))
+        assertEquals(6773, statScore(1500))
+        assertEquals(14280, statScore(2000))
+        assertEquals(23905, statScore(2500))
+        // Values above the max clamp down to the 2500 score.
+        assertEquals(23905, statScore(3000))
+    }
+
+    @Test
+    fun oguriStatSumMatchesReference() {
+        val sum = statScore(790) + statScore(378) + statScore(838) + statScore(312) + statScore(752)
+        assertEquals(6271, sum)
+    }
+
+    @Test
+    fun uniqueBonusUsesStarBasedMultiplier() {
+        assertEquals(850, uniqueBonus(3, 5))
+        assertEquals(600, uniqueBonus(2, 5))
+        assertEquals(360, uniqueBonus(1, 3))
+        assertEquals(0, uniqueBonus(5, 0))
+        // Unknown star (0) defaults to the x170 multiplier.
+        assertEquals(680, uniqueBonus(0, 4))
+    }
+
+    @Test
+    fun scoreToRankLabelHitsTierBoundaries() {
+        assertEquals("G", scoreToRankLabel(0))
+        assertEquals("G", scoreToRankLabel(299))
+        assertEquals("G+", scoreToRankLabel(300))
+        assertEquals("B", scoreToRankLabel(6500))
+        assertEquals("B", scoreToRankLabel(8199))
+        assertEquals("B+", scoreToRankLabel(8200))
+        assertEquals("A", scoreToRankLabel(10000))
+        assertEquals("SS", scoreToRankLabel(19199))
+        assertEquals("SS+", scoreToRankLabel(19200))
+        assertEquals("UG", scoreToRankLabel(19600))
+        assertEquals("UG1", scoreToRankLabel(20000))
+        // Above the top tier clamps to the highest label.
+        assertEquals("LS24", scoreToRankLabel(500000))
+    }
+
+    @Test
+    fun rankLabelToImageIndexMatchesLadderPosition() {
+        assertEquals(0, rankLabelToImageIndex("G"))
+        assertEquals(1, rankLabelToImageIndex("G+"))
+        assertEquals(7, rankLabelToImageIndex("D+"))
+        assertEquals(11, rankLabelToImageIndex("B+"))
+        assertEquals(12, rankLabelToImageIndex("A"))
+        assertEquals(14, rankLabelToImageIndex("S"))
+        assertEquals(16, rankLabelToImageIndex("SS"))
+        assertEquals(17, rankLabelToImageIndex("SS+"))
+        assertEquals(18, rankLabelToImageIndex("UG"))
+        assertEquals(19, rankLabelToImageIndex("UG1"))
+        assertEquals(88, rankLabelToImageIndex("US"))
+        assertEquals(-1, rankLabelToImageIndex("nonsense"))
+    }
+
+    @Test
+    fun evaluateSkillScoreAppliesBucketMultipliers() {
+        // No checkType -> flat base.
+        assertEquals(200, evaluateSkillScore(200, "", referenceAptitudes))
+        assertEquals(217, evaluateSkillScore(217, "", referenceAptitudes))
+        // Single role scales by the trainee's aptitude bucket.
+        assertEquals(220, evaluateSkillScore(200, "Late", referenceAptitudes))
+        assertEquals(180, evaluateSkillScore(200, "Late", referenceAptitudes.copy(late = "C")))
+        assertEquals(140, evaluateSkillScore(200, "Late", referenceAptitudes.copy(late = "G")))
+        // Multi-role in the same group takes the best multiplier (Medium A = 1.1 beats Long B = 0.9).
+        assertEquals(220, evaluateSkillScore(200, "Medium/Long", referenceAptitudes))
+        // Multi-role across groups multiplies the best per group (Mile A 1.1 x Turf A 1.1 = 1.21).
+        assertEquals(242, evaluateSkillScore(200, "Mile/Turf", referenceAptitudes))
+    }
+
+    @Test
+    fun estimateRankMatchesReferenceTrainee() {
+        val skills =
+            listOf(
+                SkillScoreInput(200, "Late"),
+                SkillScoreInput(217, ""),
+                SkillScoreInput(508, "Late"),
+            )
+        val result = estimateRank(790, 378, 838, 312, 752, skills, referenceAptitudes, starLevel = 3, uniqueLevel = 3)
+        assertEquals(6271, result.statScore)
+        assertEquals(996, result.skillScore)
+        assertEquals(510, result.uniqueBonus)
+        assertEquals(7777, result.totalScore)
+        assertEquals("B", result.rankLabel)
+        assertEquals(10, result.rankImageIndex)
+    }
+}

--- a/android/scoring-shared/src/commonTest/kotlin/com/steve1316/uma_scoring/RankEstimateTest.kt
+++ b/android/scoring-shared/src/commonTest/kotlin/com/steve1316/uma_scoring/RankEstimateTest.kt
@@ -50,13 +50,11 @@ class RankEstimateTest {
     }
 
     @Test
-    fun uniqueBonusUsesStarBasedMultiplier() {
-        assertEquals(850, uniqueBonus(3, 5))
-        assertEquals(600, uniqueBonus(2, 5))
-        assertEquals(360, uniqueBonus(1, 3))
-        assertEquals(0, uniqueBonus(5, 0))
-        // Unknown star (0) defaults to the x170 multiplier.
-        assertEquals(680, uniqueBonus(0, 4))
+    fun uniqueBonusScalesWithLevel() {
+        assertEquals(850, uniqueBonus(5))
+        assertEquals(680, uniqueBonus(4))
+        assertEquals(510, uniqueBonus(3))
+        assertEquals(0, uniqueBonus(0))
     }
 
     @Test
@@ -115,7 +113,7 @@ class RankEstimateTest {
                 SkillScoreInput(217, ""),
                 SkillScoreInput(508, "Late"),
             )
-        val result = estimateRank(790, 378, 838, 312, 752, skills, referenceAptitudes, starLevel = 3, uniqueLevel = 3)
+        val result = estimateRank(790, 378, 838, 312, 752, skills, referenceAptitudes, uniqueLevel = 3)
         assertEquals(6271, result.statScore)
         assertEquals(996, result.skillScore)
         assertEquals(510, result.uniqueBonus)


### PR DESCRIPTION
## Description
- This PR redesigns the `Remote Log Viewer` into a dashboard with stat meters, an estimated overall rank, and an owned-skills panel that updates live as the bot buys skills.
- It adds an estimated-rank score derived from the trainee's final stats, aptitudes, and skills, and improves the accuracy of the stat, aptitude, and owned-skill reads that feed it.

