### PR TITLE
Fix mandatory races running against the wrong turn, misreading the race, and cancelling their own retries

### DIFF
--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Campaign.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Campaign.kt
@@ -1167,6 +1167,7 @@ abstract class Campaign(game: Game) : Task(game) {
         return if (IconRaceDayRibbon.check(game.imageUtils, sourceBitmap = sourceBitmap)) {
             MessageLog.v(TAG, "[INFO] Bot is at the preparation screen with a mandatory race ready to be completed.")
             if (game.scenario == "Unity Cup") game.wait(1.0)
+            refreshDateForMandatoryRace()
             true
         } else if (IconGoalRibbon.check(game.imageUtils, sourceBitmap = sourceBitmap)) {
             // Most likely the user started the bot here so a delay will need to be placed to allow the start banner of the Service to disappear.
@@ -1175,8 +1176,11 @@ abstract class Campaign(game: Game) : Task(game) {
             // Walk back to the preparation screen.
             ButtonBack.click(game.imageUtils, sourceBitmap = sourceBitmap)
             game.wait(1.0)
+            refreshDateForMandatoryRace()
             true
         } else if (game.scenario == "Unity Cup" && ButtonUnityCupRace.check(game.imageUtils, sourceBitmap = sourceBitmap)) {
+            // The date is deliberately not refreshed here. The opponent-selection screen carries neither the Main screen nor the Race List anchor that the
+            // date OCR needs, and the Unity Cup race handling does not look a race up by turn anyway.
             MessageLog.v(TAG, "[INFO] Bot is awaiting opponent selection for a Unity Cup race.")
             true
         } else {
@@ -1389,6 +1393,9 @@ abstract class Campaign(game: Game) : Task(game) {
      *
      * A training or rest action advances the game into the mandatory race screens, bypassing the Main screen where [updateDate] normally runs.
      * Without this, the race name is looked up against the previous turn, which matches the wrong race and gets the wrong per-distance running style.
+     *
+     * Only call this from a screen the date OCR can actually read, which means one that carries the Main screen or the Race List anchor.
+     * The Unity Cup opponent-selection screen carries neither, so [checkMandatoryRacePrepScreen] skips it.
      */
     private fun refreshDateForMandatoryRace() {
         if (bHasCheckedDateThisTurn) return
@@ -2572,7 +2579,6 @@ abstract class Campaign(game: Game) : Task(game) {
                 // If the bot is at the Training Event screen, that means there are selectable options for rewards.
                 handleTrainingEvent()
             } else if (checkMandatoryRacePrepScreen()) {
-                refreshDateForMandatoryRace()
                 // If the bot is at the Main screen with the button to select a race visible, that means the bot needs to handle a mandatory race.
                 if (!handleRaceEvents() && racing.detectedMandatoryRaceCheck) {
                     return TaskResult.Success(

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Campaign.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Campaign.kt
@@ -114,6 +114,10 @@ enum class MainScreenAction {
 private const val GROUP_PROGRESS_GAP_X = 15
 private const val GROUP_PROGRESS_WIDTH = 120
 
+// Number of half-second polls to wait for the Try Again dialog to leave the screen after clicking it.
+// It normally goes within a poll or two, so this is just headroom for a slow tap or a laggy transition.
+private const val TRY_AGAIN_DIALOG_CLOSE_ATTEMPTS = 20
+
 /**
  * Whether mood recovery should be skipped because the finale is underway. Recovering mood with at most three turns left wastes one of them, so from the first finale turn (day 73, the
  * same boundary as GameDate.bIsFinaleSeason's day > 72) the bot should train or race instead. Pure so it is unit-testable without a live Campaign.
@@ -880,15 +884,30 @@ abstract class Campaign(game: Game) : Task(game) {
      * @return True if the retry was initiated (button clicked), false to close the dialog without retrying.
      */
     open fun shouldRetryRace(dialog: DialogInterface, args: Map<String, Any>): Boolean {
-        if (racing.raceRetries > 0 && racing.retriesThisRace < racing.maxRetriesPerRace) {
+        if (Racing.canRetryRace(racing.raceRetries, racing.retriesThisRace, racing.maxRetriesPerRace, racing.bRetryUntilFirst)) {
             MessageLog.i(TAG, "[RACE] Retrying the race. Retries remaining: ${racing.raceRetries}")
             racing.raceRetries--
             racing.retriesThisRace++
             game.wait(0.5)
             ButtonTryAgain.click(game.imageUtils)
+            waitForTryAgainDialogToClose()
             return true
         }
         return false
+    }
+
+    /**
+     * Waits for the Try Again dialog to leave the screen after its button was clicked.
+     *
+     * The [Racing.runRaceWithRetries] loop handles dialogs at the start of every iteration, and the dialog does not vanish the instant it is tapped.
+     * Returning while it is still up lets the same dialog get handled a second time, which closes it and cancels the retry that was just started.
+     */
+    private fun waitForTryAgainDialogToClose() {
+        repeat(TRY_AGAIN_DIALOG_CLOSE_ATTEMPTS) {
+            game.wait(0.5)
+            if (!ButtonTryAgain.check(game.imageUtils)) return
+        }
+        MessageLog.w(TAG, "[WARN] waitForTryAgainDialogToClose:: The Try Again dialog is still on screen after clicking it.")
     }
 
     /**
@@ -979,7 +998,10 @@ abstract class Campaign(game: Game) : Task(game) {
         if (shouldRetryRace(dialog, args)) {
             // Retry was initiated by the hook.
         } else {
-            MessageLog.w(TAG, "[WARN] handleDialogs:: No retries remaining but Try Again dialog detected. Closing dialog...")
+            MessageLog.w(
+                TAG,
+                "[WARN] handleDialogs:: Out of retries for this race (pool: ${racing.raceRetries}, used on this race: ${racing.retriesThisRace}/${racing.maxRetriesPerRace}). Closing dialog...",
+            )
             dialog.close(game.imageUtils)
         }
 
@@ -1360,6 +1382,20 @@ abstract class Campaign(game: Game) : Task(game) {
             MessageLog.v(TAG, "[DATE] New date: $date")
             return true
         }
+    }
+
+    /**
+     * Refreshes the date before a mandatory race when the Main screen was skipped on the way in.
+     *
+     * A training or rest action advances the game into the mandatory race screens, bypassing the Main screen where [updateDate] normally runs.
+     * Without this, the race name is looked up against the previous turn, which matches the wrong race and gets the wrong per-distance running style.
+     */
+    private fun refreshDateForMandatoryRace() {
+        if (bHasCheckedDateThisTurn) return
+
+        // Only the date is refreshed, so bHasCheckedDateThisTurn is left alone and the remaining turn-start updates still run at the Main screen.
+        // Passing isOnMainScreen = false makes the OCR try the Race List anchor before falling back to the Main screen one.
+        updateDate(isOnMainScreen = false)
     }
 
     /**
@@ -2536,6 +2572,7 @@ abstract class Campaign(game: Game) : Task(game) {
                 // If the bot is at the Training Event screen, that means there are selectable options for rewards.
                 handleTrainingEvent()
             } else if (checkMandatoryRacePrepScreen()) {
+                refreshDateForMandatoryRace()
                 // If the bot is at the Main screen with the button to select a race visible, that means the bot needs to handle a mandatory race.
                 if (!handleRaceEvents() && racing.detectedMandatoryRaceCheck) {
                     return TaskResult.Success(

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Racing.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Racing.kt
@@ -228,6 +228,12 @@ class Racing(private val game: Game, private val campaign: Campaign) {
     /** Retries used on the current race. Shared by the button-based and dialog-based retry paths so both honor the per-race limit. */
     var retriesThisRace: Int = 0
 
+    /**
+     * Whether the race being run is retried until 1st place (mandatory races and Unity Cup).
+     * Set by [runRaceWithRetries] so the dialog-based retry path can see it too.
+     */
+    var bRetryUntilFirst: Boolean = false
+
     /** Whether to stop the bot when a mandatory race is detected. */
     internal val enableStopOnMandatoryRace: Boolean = SettingsHelper.getBooleanSetting("racing", "enableStopOnMandatoryRaces")
 
@@ -357,6 +363,72 @@ class Racing(private val game: Game, private val campaign: Campaign) {
 
         /** The threshold for fuzzy string matching (0.0 to 1.0). */
         private const val SIMILARITY_THRESHOLD = 0.7
+
+        /** Matches the distance token of a formatted race name (e.g. "3000m"), tolerating the letter O that OCR reads in place of a zero. */
+        private val DISTANCE_TOKEN_REGEX = Regex("""\b[0-9Oo]{3,4}m\b""")
+
+        /** Matches the parenthesized distance category of a formatted race name (e.g. "(Long)"). */
+        private val DISTANCE_CATEGORY_REGEX = Regex("""\((sprint|mile|med|long)\)""", RegexOption.IGNORE_CASE)
+
+        /**
+         * Repairs the distance token of an OCR'd race name by turning the letter O back into a zero.
+         *
+         * ML Kit reads "3000m" as "300Om" often enough to derail the lookup.
+         * Only the distance token is rewritten so letters elsewhere in the name are left alone.
+         *
+         * @param detectedName The race name as read from the screen.
+         * @return The race name with its distance token repaired.
+         */
+        fun normalizeRaceName(detectedName: String): String {
+            return DISTANCE_TOKEN_REGEX.replace(detectedName) { match -> match.value.replace('O', '0').replace('o', '0') }
+        }
+
+        /**
+         * Parses the distance category out of a formatted race name.
+         *
+         * @param detectedName The race name as read from the screen.
+         * @return The distance category, or null if the name does not spell one out.
+         */
+        fun distanceCategoryFromRaceName(detectedName: String): TrackDistance? {
+            val category = DISTANCE_CATEGORY_REGEX.find(detectedName)?.groupValues?.get(1)?.lowercase() ?: return null
+            // The race name abbreviates Medium to "Med". Every other category is spelled the same as its enum entry.
+            return if (category == "med") TrackDistance.MEDIUM else TrackDistance.fromName(category)
+        }
+
+        /**
+         * Checks that a candidate race's distance does not contradict the distance category spelled out in the detected name.
+         *
+         * Whole-string fuzzy matching scores a 3000m Long race against an 1800m Mile race at 0.9 because they share a track name and most tokens.
+         * The winning candidate needs this sanity check. A name with no category cannot contradict anything, so every candidate is accepted.
+         *
+         * @param detectedName The race name as read from the screen.
+         * @param candidateDistance The distance of the candidate race from the database.
+         * @return True if the candidate is consistent with the detected name.
+         */
+        fun matchesDetectedDistance(detectedName: String, candidateDistance: TrackDistance): Boolean {
+            val detectedDistance = distanceCategoryFromRaceName(detectedName) ?: return true
+            return detectedDistance == candidateDistance
+        }
+
+        /**
+         * Decides whether the retry budgets still allow another retry of the current race.
+         *
+         * The Try Again prompt appears as a dialog or as an on-screen button, each with its own handler. This is the budget check both apply.
+         *
+         * The dialog surface (`Campaign.shouldRetryRace`) passes `retryUntilFirst`, so mandatory and Unity Cup races skip the per-race cap.
+         * The button surface ([canRetryGrade]) does not, since [runRaceWithRetries] already gives those races their own uncapped fallback branch.
+         * Exempting them here as well would drain the run-wide pool before they ever reach that branch. The pool bounds both surfaces either way.
+         *
+         * @param raceRetries The retries left in the run-wide pool.
+         * @param retriesThisRace The retries already used on the current race.
+         * @param maxRetriesPerRace The per-race retry cap.
+         * @param retryUntilFirst Whether the current race is exempt from the per-race cap.
+         * @return True if the race may be retried again.
+         */
+        fun canRetryRace(raceRetries: Int, retriesThisRace: Int, maxRetriesPerRace: Int, retryUntilFirst: Boolean): Boolean {
+            if (raceRetries <= 0) return false
+            return retryUntilFirst || retriesThisRace < maxRetriesPerRace
+        }
     }
 
     // //////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1075,8 +1147,7 @@ class Racing(private val game: Game, private val campaign: Campaign) {
         !disableRaceRetries &&
             lastRaceGrade != null &&
             retryEligibleGrades.contains(lastRaceGrade) &&
-            raceRetries > 0 &&
-            retriesThisRace < maxRetriesPerRace &&
+            canRetryRace(raceRetries, retriesThisRace, maxRetriesPerRace, retryUntilFirst = false) &&
             ButtonTryAgainAlt.checkDisabled(game.imageUtils, sourceBitmap = sourceBitmap) == false
 
     /**
@@ -1114,6 +1185,7 @@ class Racing(private val game: Game, private val campaign: Campaign) {
         // Flag used to prevent us from attempting to select a running style after we've already successfully selected a running style once.
         var bDidSelectRaceStrategy = false
         retriesThisRace = 0
+        bRetryUntilFirst = retryUntilFirst
 
         // Safety counter to prevent infinite loop.
         var loopCount = 0
@@ -1320,6 +1392,12 @@ class Racing(private val game: Game, private val campaign: Campaign) {
         return try {
             MessageLog.i(TAG, "[RACE] Looking up race for turn $turnNumber with detected name: \"$detectedName\".")
 
+            // Repair the distance token before matching. OCR reads "3000m" as "300Om" often enough to derail both the exact and the fuzzy match.
+            val normalizedName = normalizeRaceName(detectedName)
+            if (normalizedName != detectedName) {
+                MessageLog.i(TAG, "[RACE] Repaired the detected name to: \"$normalizedName\".")
+            }
+
             val database = settingsManager.readableDatabase
             if (database == null) {
                 MessageLog.e(TAG, "[ERROR] lookupRaceInDatabase:: Database not available for race lookup.")
@@ -1342,7 +1420,7 @@ class Racing(private val game: Game, private val campaign: Campaign) {
                         RACES_COLUMN_TURN_NUMBER,
                     ),
                     "$RACES_COLUMN_TURN_NUMBER = ? AND $RACES_COLUMN_NAME_FORMATTED = ?",
-                    arrayOf(turnNumber.toString(), detectedName),
+                    arrayOf(turnNumber.toString(), normalizedName),
                     null,
                     null,
                     null,
@@ -1410,7 +1488,7 @@ class Racing(private val game: Game, private val campaign: Campaign) {
 
             do {
                 val nameFormatted = fuzzyCursor.getString(3)
-                val similarity = similarityService.score(detectedName, nameFormatted)
+                val similarity = similarityService.score(normalizedName, nameFormatted)
 
                 if (similarity >= SIMILARITY_THRESHOLD) {
                     val race =
@@ -1423,6 +1501,17 @@ class Racing(private val game: Game, private val campaign: Campaign) {
                             trackDistance = fuzzyCursor.getString(5),
                             turnNumber = fuzzyCursor.getInt(6),
                         )
+
+                    // Jaro-Winkler scores races that share a track name and most tokens very highly.
+                    // A candidate that contradicts the detected distance must be dropped.
+                    if (!matchesDetectedDistance(normalizedName, race.trackDistance)) {
+                        MessageLog.i(
+                            TAG,
+                            "[RACE] Rejected fuzzy match \"${race.name}\" AKA \"$nameFormatted\": its distance (${race.trackDistance}) contradicts the detected name.",
+                        )
+                        continue
+                    }
+
                     fuzzyMatches.add(Pair(race, similarity))
                     if (similarity > bestScore) bestScore = similarity
                     if (game.debugMode) {

--- a/android/app/src/test/java/com/steve1316/uma_android_automation/bot/RaceNameMatchingTest.kt
+++ b/android/app/src/test/java/com/steve1316/uma_android_automation/bot/RaceNameMatchingTest.kt
@@ -1,0 +1,66 @@
+package com.steve1316.uma_android_automation.bot
+
+import com.steve1316.uma_android_automation.types.TrackDistance
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit tests for the race name normalization and distance sanity check in `Racing`.
+ * OCR read Hanshin Daishoten as "Hanshin Turf 300Om (Long) Right / Inner", with a letter O in place of the zero.
+ * The whole-string fuzzy match then picked an 1800m Mile race at 0.9 similarity, so the bot raced a 3000m Long race with the Mile running style.
+ */
+@DisplayName("Race name matching")
+class RaceNameMatchingTest {
+    @Test
+    @DisplayName("The letter O inside a distance token is corrected back to a zero")
+    fun testNormalizesLetterOInDistanceToken() {
+        assertEquals("Hanshin Turf 3000m (Long) Right / Inner", Racing.normalizeRaceName("Hanshin Turf 300Om (Long) Right / Inner"))
+        assertEquals("Kyoto Turf 3000m (Long) Right / Outer", Racing.normalizeRaceName("Kyoto Turf 300Om (Long) Right / Outer"))
+        assertEquals("Nakayama Turf 1200m (Sprint) Right / Outer", Racing.normalizeRaceName("Nakayama Turf 12OOm (Sprint) Right / Outer"))
+    }
+
+    @Test
+    @DisplayName("A cleanly read name is left untouched")
+    fun testLeavesCleanNamesUnchanged() {
+        // The distance token is already correct, and no letter elsewhere in the name may be rewritten.
+        assertEquals("Tokyo Turf 2400m (Med) Left", Racing.normalizeRaceName("Tokyo Turf 2400m (Med) Left"))
+        assertEquals("Osakajo Stakes", Racing.normalizeRaceName("Osakajo Stakes"))
+    }
+
+    @Test
+    @DisplayName("The distance category is parsed out of the formatted name")
+    fun testParsesDistanceCategory() {
+        assertEquals(TrackDistance.LONG, Racing.distanceCategoryFromRaceName("Hanshin Turf 3000m (Long) Right / Inner"))
+        assertEquals(TrackDistance.MILE, Racing.distanceCategoryFromRaceName("Hanshin Turf 1800m (Mile) Right / Outer"))
+        assertEquals(TrackDistance.MEDIUM, Racing.distanceCategoryFromRaceName("Tokyo Turf 2400m (Med) Left"))
+        assertEquals(TrackDistance.SPRINT, Racing.distanceCategoryFromRaceName("Nakayama Turf 1200m (Sprint) Right / Outer"))
+    }
+
+    @Test
+    @DisplayName("A name with no category token yields no category")
+    fun testNoCategoryTokenYieldsNull() {
+        assertNull(Racing.distanceCategoryFromRaceName("Hanshin Turf Right / Inner"))
+    }
+
+    @Test
+    @DisplayName("A candidate whose distance contradicts the detected name is rejected")
+    fun testRejectsContradictingDistance() {
+        // The exact reported failure: a "(Long)" name must never match the Mile race that Jaro-Winkler scored at 0.9.
+        val detected = "Hanshin Turf 3000m (Long) Right / Inner"
+        assertFalse(Racing.matchesDetectedDistance(detected, TrackDistance.MILE), "An 1800m Mile candidate must be rejected for a (Long) name")
+        assertTrue(Racing.matchesDetectedDistance(detected, TrackDistance.LONG), "The genuine Long candidate must still be accepted")
+    }
+
+    @Test
+    @DisplayName("Every candidate is accepted when the category could not be parsed")
+    fun testAcceptsAllWhenCategoryUnknown() {
+        // Without a category token there is nothing to contradict, so the check must not filter anything out.
+        for (distance in TrackDistance.entries) {
+            assertTrue(Racing.matchesDetectedDistance("Hanshin Turf Right / Inner", distance), "$distance must be accepted when the name has no category")
+        }
+    }
+}

--- a/android/app/src/test/java/com/steve1316/uma_android_automation/bot/RaceRetryGatingTest.kt
+++ b/android/app/src/test/java/com/steve1316/uma_android_automation/bot/RaceRetryGatingTest.kt
@@ -1,0 +1,38 @@
+package com.steve1316.uma_android_automation.bot
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit tests for the retry budget check shared by the dialog-based and button-based race retry paths in `Racing`.
+ * A lost Tenno Sho Spring was accepted as a career-ending failure because the dialog path applied the per-race cap of 1 to a mandatory race,
+ * even though that race is meant to be retried until it is won.
+ */
+@DisplayName("Race retry gating")
+class RaceRetryGatingTest {
+    @Test
+    @DisplayName("A retry-until-1st race is not bound by the per-race cap")
+    fun testRetryUntilFirstIgnoresPerRaceCap() {
+        // The exact reported failure: one retry had already been used on a mandatory race
+        // (retriesThisRace == maxRetriesPerRace == 1) while 3 pool retries remained.
+        assertTrue(Racing.canRetryRace(raceRetries = 3, retriesThisRace = 1, maxRetriesPerRace = 1, retryUntilFirst = true))
+        assertTrue(Racing.canRetryRace(raceRetries = 1, retriesThisRace = 5, maxRetriesPerRace = 1, retryUntilFirst = true))
+    }
+
+    @Test
+    @DisplayName("A normal race is still bound by the per-race cap")
+    fun testNormalRaceHonorsPerRaceCap() {
+        assertTrue(Racing.canRetryRace(raceRetries = 3, retriesThisRace = 0, maxRetriesPerRace = 1, retryUntilFirst = false))
+        assertFalse(Racing.canRetryRace(raceRetries = 3, retriesThisRace = 1, maxRetriesPerRace = 1, retryUntilFirst = false))
+    }
+
+    @Test
+    @DisplayName("The run-wide retry pool still bounds a retry-until-1st race")
+    fun testPoolStillBoundsRetryUntilFirst() {
+        // Exempting mandatory races from the per-race cap must not make retries unbounded.
+        assertFalse(Racing.canRetryRace(raceRetries = 0, retriesThisRace = 0, maxRetriesPerRace = 1, retryUntilFirst = true))
+        assertFalse(Racing.canRetryRace(raceRetries = -1, retriesThisRace = 0, maxRetriesPerRace = 1, retryUntilFirst = true))
+    }
+}


### PR DESCRIPTION
## Description
- This PR resolves #391 by fixing the three separate faults that combined to brick that career: the bot ran the race for the wrong turn, then misread that race's distance and looked up a different race entirely, and then failed to retry when it lost.
- The bot was running a mandatory race against the previous turn's race. Going straight from a training or rest action into the race skips the screen where the bot reads the current date, so it still believed the turn was `Senior Year Early April` when the race was actually Late April - and so chose the running style for the wrong race's distance.
- The bot misread the race's distance and then matched a completely different race. `Hanshin Turf 3000m` was read as `Hanshin Turf 300Om`, which fuzzy-matched to `Osakajo Stakes`. The distance is now repaired before the lookup, and a race whose distance contradicts the one spelled out in the name is rejected.
- The bot cancelled its own retry. After pressing `Try Again` the dialog stays on screen for a moment, so the bot saw it a second time and closed it, then reported that no retries were left and ended the career. Mandatory races and Unity Cup races are now retried until 1st place without the per-race retry limit cutting them short, while the overall retry pool still caps how many retries a run can spend.

The original failure, with all three faults visible - the wrong turn, the misread distance, and the retry being refused:

```
[INFO] [RACE] Starting Racing process on SENIOR YEAR EARLY APRIL (Turn 55).
[INFO] [RACE] Extracted race name: "Hanshin Turf 300Om (Long) Right / Inner"
[WARN] No retries remaining but Try Again dialog detected. Closing dialog...
```
