### PR TITLE
Improve how leftover skill points are spent at the end of a career

### DIFF
--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/SkillPlan.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/SkillPlan.kt
@@ -94,7 +94,11 @@ class SkillPlan(private val game: Game, private val campaign: Campaign) {
 
     /** The strategy used for spending skill points. */
     enum class SpendingStrategy {
-        /** Default spending strategy. Currently synonymous with OPTIMIZE_RANK. */
+        /**
+         * Default spending strategy. Buys nothing beyond the common checks, so points left after the user's planned skills are kept.
+         *
+         * This is overridden on the final purchase of a career, where the leftover drain spends the remainder regardless. See [getLeftoverDrainSkills].
+         */
         DEFAULT,
 
         /** Prioritize skills that match the trainee's aptitudes and community-tier rankings. */
@@ -145,6 +149,15 @@ class SkillPlan(private val game: Game, private val campaign: Campaign) {
 
         /** The double-circle (double-O) marker found in double-circle skill names. */
         private const val DOUBLE_CIRCLE_CHAR: Char = '\u25CE'
+
+        /** The name of the skill plan that runs on the final purchase of a career, once the run is over. */
+        private const val PLAN_CAREER_COMPLETE: String = "careerComplete"
+
+        /** Upper bound on the budget the leftover drain will run its knapsack over. Real skill point totals never come close, so a larger value means OCR returned garbage. */
+        private const val MAX_DRAIN_BUDGET: Int = 10000
+
+        /** How many times the leftover drain re-runs. Buying a skill can lower an upgrade's price or reveal a new row, which frees up budget for another pass. */
+        private const val MAX_DRAIN_ITERATIONS: Int = 5
 
         /**
          * Whether a skill is a recovery skill. Recovery skills describe restoring stamina/endurance, so their description contains "recover". Data-driven off the skill description, not a
@@ -281,6 +294,76 @@ class SkillPlan(private val game: Game, private val campaign: Campaign) {
             }
 
             return result
+        }
+
+        /**
+         * Pure calculation function that picks the subset of skills that spends as much of the budget as possible.
+         *
+         * This is used to drain skill points that would otherwise be lost at the end of a career. Since leftover points are worth nothing once the run is scored, the objective is to minimize the
+         * remainder rather than to maximize value per point. Ties on the amount spent are broken in favor of the subset worth the most evaluation points.
+         *
+         * Only the user's per-skill blacklist is honored here. Category exclusions and aptitude preferences are deliberately ignored because they exist to steer normal purchasing and would
+         * otherwise strand the very points this is meant to spend.
+         *
+         * @param candidates List of available skills for purchase.
+         * @param budget Available skill points to spend.
+         * @param alreadyPlanned Skills already planned for purchase (to avoid duplicates).
+         * @param blacklist Names of skills the user has explicitly blacklisted.
+         * @return Ordered list of (name, price) pairs representing skills to buy, cheapest first.
+         */
+        fun calculateLeftoverDrainPurchases(
+            candidates: List<SkillCandidate>,
+            budget: Int,
+            alreadyPlanned: List<String> = emptyList(),
+            blacklist: List<String> = emptyList(),
+        ): List<Pair<String, Int>> {
+            if (budget <= 0 || budget > MAX_DRAIN_BUDGET) {
+                return emptyList()
+            }
+
+            val plannedNames: Set<String> = alreadyPlanned.toSet()
+            val blacklistedNames: Set<String> = blacklist.toSet()
+            val affordable: List<SkillCandidate> =
+                candidates.filter { it.name !in plannedNames && it.name !in blacklistedNames && it.price in 1..budget }
+            if (affordable.isEmpty()) {
+                return emptyList()
+            }
+
+            // When everything on offer fits, the best subset is simply all of it, so skip the search.
+            if (affordable.sumOf { it.price } <= budget) {
+                return affordable.map { it.name to it.price }.sortedBy { it.second }
+            }
+
+            // 0/1 knapsack over the budget where a skill's weight and value are both its price, so the best subset is the one that spends the most without going over.
+            val bestSpend = IntArray(budget + 1)
+            val bestEvaluationPoints = IntArray(budget + 1)
+            val keep: Array<BooleanArray> = Array(affordable.size) { BooleanArray(budget + 1) }
+
+            for ((index, skill) in affordable.withIndex()) {
+                for (remaining in budget downTo skill.price) {
+                    val spend: Int = bestSpend[remaining - skill.price] + skill.price
+                    val evaluationPoints: Int = bestEvaluationPoints[remaining - skill.price] + skill.evaluationPoints
+                    if (spend > bestSpend[remaining] || (spend == bestSpend[remaining] && evaluationPoints > bestEvaluationPoints[remaining])) {
+                        bestSpend[remaining] = spend
+                        bestEvaluationPoints[remaining] = evaluationPoints
+                        keep[index][remaining] = true
+                    }
+                }
+            }
+
+            // Walk the keep table backwards to recover which skills made up the winning subset.
+            val result = mutableListOf<Pair<String, Int>>()
+            var remaining: Int = budget
+            for (index in affordable.indices.reversed()) {
+                if (!keep[index][remaining]) {
+                    continue
+                }
+                val skill: SkillCandidate = affordable[index]
+                result.add(skill.name to skill.price)
+                remaining -= skill.price
+            }
+
+            return result.sortedBy { it.second }
         }
 
         /**
@@ -854,14 +937,83 @@ class SkillPlan(private val game: Game, private val campaign: Campaign) {
     }
 
     /**
+     * Retrieve additional skills to buy purely to spend skill points that would otherwise go to waste.
+     *
+     * This runs as the final pass of the career-complete purchase. Leftover points are lost once the run is scored, so anything bought here is free rank, even skills the bot would never pick
+     * during the career. Only the user's per-skill blacklist still applies. See [calculateLeftoverDrainPurchases] for the selection itself.
+     *
+     * @param skillPlanSettings The [SkillPlanSettings] to follow.
+     * @param skillList The [SkillList] to analyze.
+     * @param skillsToBuy The list of skills already planned for purchase.
+     * @param availableSkillPoints The current amount of available skill points.
+     * @return A map of skill names to their prices for the identified leftover skills.
+     */
+    private fun getLeftoverDrainSkills(skillPlanSettings: SkillPlanSettings, skillList: SkillList, skillsToBuy: List<String>, availableSkillPoints: Int): Map<String, Int> {
+        val result: MutableMap<String, Int> = mutableMapOf()
+        val plannedNames: MutableSet<String> = skillsToBuy.toMutableSet()
+        var remainingSkillPoints: Int = availableSkillPoints
+
+        // A skill that belongs to an upgrade chain drops the price of its upgrade when bought, which frees up budget the previous pass could not see. Re-run only when that actually happened.
+        for (iteration in 0 until MAX_DRAIN_ITERATIONS) {
+            val entries: Map<String, SkillListEntry> = skillList.getAvailableSkills()
+            val candidates: List<SkillCandidate> =
+                entries.values.map { entry -> SkillCandidate(name = entry.name, price = entry.screenPrice, evaluationPoints = entry.evaluationPoints) }
+
+            val picks: List<Pair<String, Int>> =
+                calculateLeftoverDrainPurchases(
+                    candidates = candidates,
+                    budget = remainingSkillPoints,
+                    alreadyPlanned = plannedNames.toList(),
+                    blacklist = skillPlanSettings.skillBlacklist,
+                )
+            if (picks.isEmpty()) {
+                break
+            }
+
+            var bPricesMayHaveShifted = false
+            for ((name, _) in picks) {
+                // Re-read the price off the entry since an earlier pick in this same batch may have shifted it.
+                val entry: SkillListEntry = entries[name] ?: continue
+                if (!entry.bIsAvailable || entry.screenPrice > remainingSkillPoints) {
+                    continue
+                }
+
+                result[name] = entry.screenPrice
+                plannedNames.add(name)
+                remainingSkillPoints -= entry.screenPrice
+                if (entry.next != null) {
+                    bPricesMayHaveShifted = true
+                }
+                entry.buy()
+            }
+
+            // Nothing bought in this pass can have shifted another skill's price, so another pass would just recompute the same empty answer.
+            if (!bPricesMayHaveShifted) {
+                break
+            }
+        }
+
+        if (result.isNotEmpty()) {
+            MessageLog.i(TAG, "[SKILLS] Spending ${availableSkillPoints - remainingSkillPoints} leftover skill points that would be lost at career end.")
+            for ((name, price) in result) {
+                MessageLog.i(TAG, "\t- $name: $price pts")
+            }
+        }
+
+        return result.toMap()
+    }
+
+    /**
      * Retrieve all available skills to purchase based on the specified spending strategy.
      *
      * @param skillPlanSettings The [SkillPlanSettings] to follow.
      * @param skillList The [SkillList] to analyze.
      * @param availableSkillPoints The current amount of available skill points.
+     * @param bSpendLeftoverPoints Whether to spend any remaining points on extra skills afterwards. Set from the career-complete screen check, since that is the final purchase of the career and
+     *   any points left behind are lost.
      * @return A map of skill names to their prices for all skills to be purchased.
      */
-    fun getSkillsToBuy(skillPlanSettings: SkillPlanSettings, skillList: SkillList, availableSkillPoints: Int): Map<String, Int> {
+    fun getSkillsToBuy(skillPlanSettings: SkillPlanSettings, skillList: SkillList, availableSkillPoints: Int, bSpendLeftoverPoints: Boolean = false): Map<String, Int> {
         MessageLog.i(TAG, "[SKILLS] Beginning process of calculating skills to purchase...")
 
         if (!skillPlanSettings.bIsEnabled) {
@@ -910,6 +1062,17 @@ class SkillPlan(private val game: Game, private val campaign: Campaign) {
                     )
                 }
             }
+
+        // Drain whatever is left so the career does not end with unspent points.
+        if (bSpendLeftoverPoints) {
+            result +=
+                getLeftoverDrainSkills(
+                    skillPlanSettings = skillPlanSettings,
+                    skillList = skillList,
+                    skillsToBuy = result.keys.toList(),
+                    availableSkillPoints = availableSkillPoints - result.values.sum(),
+                )
+        }
 
         MessageLog.v(TAG, "================ Skills To Buy =================")
         for ((name, price) in result) {
@@ -1006,7 +1169,7 @@ class SkillPlan(private val game: Game, private val campaign: Campaign) {
         val skillPlanSettings: SkillPlanSettings =
             if (skillPlanName == null) {
                 if (bIsCareerComplete) {
-                    skillPlans["careerComplete"]!!
+                    skillPlans[PLAN_CAREER_COMPLETE]!!
                 } else {
                     skillPlans["preFinals"]!!
                 }
@@ -1019,8 +1182,9 @@ class SkillPlan(private val game: Game, private val campaign: Campaign) {
                 tmpPlan
             }
 
-        // If no purchasing options are enabled, exit early to avoid unnecessary scanning.
+        // If no purchasing options are enabled, exit early to avoid unnecessary scanning. The career-complete purchase always has work to do as it spends the leftover points regardless.
         if (
+            !bIsCareerComplete &&
             skillPlanSettings.skillNames.isEmpty() &&
             skillPlanSettings.strategy == SpendingStrategy.DEFAULT &&
             !skillPlanSettings.bEnableBuyNegativeSkills
@@ -1065,6 +1229,7 @@ class SkillPlan(private val game: Game, private val campaign: Campaign) {
                 skillPlanSettings = skillPlanSettings,
                 skillList = skillList,
                 availableSkillPoints = skillPoints,
+                bSpendLeftoverPoints = bIsCareerComplete,
             )
 
         // Exit if no skills were identified for purchase.

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/SkillPlan.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/SkillPlan.kt
@@ -512,29 +512,32 @@ class SkillPlan(private val game: Game, private val campaign: Campaign) {
         // Log a summary of all identified available skills.
         MessageLog.i(TAG, "[TEST] Summary of available skills:")
         availableSkills.forEach { (name, entry) ->
-            MessageLog.i(TAG, "\t- $name: ${entry.price} SP")
+            MessageLog.i(TAG, "\t- $name: ${entry.screenPrice} SP")
         }
 
-        // Calculate optimal purchases using a greedy heuristic to minimize remaining points.
-        val sortedSkills: List<SkillListEntry> = availableSkills.values.toList().sortedByDescending { it.price }
-
-        val skillsToBuy = mutableListOf<SkillListEntry>()
-        var remainingPoints = currentPoints
-
-        for (skill in sortedSkills) {
-            if (skill.price <= remainingPoints) {
-                skillsToBuy.add(skill)
-                remainingPoints -= skill.price
-            }
+        // Preview the drain by running the exact code path the career-complete purchase uses. Purchases here are simulated in memory since no button location is passed along, so nothing is bought.
+        val skillPlanSettings: SkillPlanSettings? = skillPlans[PLAN_CAREER_COMPLETE]
+        if (skillPlanSettings == null) {
+            MessageLog.e(TAG, "[ERROR] startSkillListBuyTest:: No CareerComplete skill plan is configured. Ending test.")
+            return
         }
+
+        val skillsToBuy: Map<String, Int> =
+            getLeftoverDrainSkills(
+                skillPlanSettings = skillPlanSettings,
+                skillList = skillList,
+                skillsToBuy = emptyList(),
+                availableSkillPoints = currentPoints,
+            )
+        val remainingPoints: Int = currentPoints - skillsToBuy.values.sum()
 
         // Log a summary of the skills that would be purchased.
         MessageLog.i(TAG, "[TEST] Identified skills that would be bought to bring SP close to zero:")
         if (skillsToBuy.isEmpty()) {
             MessageLog.i(TAG, "\t- No skills can be purchased with current SP.")
         } else {
-            skillsToBuy.forEach { skill ->
-                MessageLog.i(TAG, "\t- ${skill.name}: ${skill.price} SP")
+            skillsToBuy.forEach { (name, price) ->
+                MessageLog.i(TAG, "\t- $name: $price SP")
             }
         }
         MessageLog.i(TAG, "[TEST] Expected remaining Skill Points: $remainingPoints")

--- a/android/app/src/test/java/com/steve1316/uma_android_automation/bot/SkillPlanPurchasingTest.kt
+++ b/android/app/src/test/java/com/steve1316/uma_android_automation/bot/SkillPlanPurchasingTest.kt
@@ -2,6 +2,7 @@ package com.steve1316.uma_android_automation.bot
 
 import com.steve1316.uma_android_automation.bot.SkillPlan.Companion.SkillCandidate
 import com.steve1316.uma_android_automation.bot.SkillPlan.Companion.calculateCommonPurchases
+import com.steve1316.uma_android_automation.bot.SkillPlan.Companion.calculateLeftoverDrainPurchases
 import com.steve1316.uma_android_automation.bot.SkillPlan.Companion.calculateOptimizeRankPurchases
 import com.steve1316.uma_android_automation.bot.SkillPlan.Companion.calculateSkillPurchases
 import com.steve1316.uma_android_automation.bot.SkillPlan.Companion.isRecoverySkill
@@ -26,6 +27,7 @@ import kotlin.random.Random
  * - [SkillPlan.calculateOptimizeRankPurchases]: greedy rank-maximizing strategy.
  * - [SkillPlan.calculateCommonPurchases]: phased buying (negative, inherited unique, user-planned).
  * - [SkillPlan.calculateSkillPurchases]: full orchestrator combining common + strategy-specific logic.
+ * - [SkillPlan.calculateLeftoverDrainPurchases]: exact subset-sum that spends the points left over at career end.
  *
  * Includes randomized stress tests that generate dummy skill lists (10-100 skills) with
  * random prices, eval points, and flags, verifying budget and uniqueness invariants
@@ -702,6 +704,123 @@ class SkillPlanPurchasingTest {
             assertEquals(3.0, recoveryBoostedRatio(baseRatio = 2.0, isRecovery = true, staminaHeavy = true, boost = 1.5), 0.001, "Recovery skill on a stamina build is boosted")
             assertEquals(2.0, recoveryBoostedRatio(baseRatio = 2.0, isRecovery = false, staminaHeavy = true, boost = 1.5), 0.001, "A non-recovery skill is never boosted")
             assertEquals(2.0, recoveryBoostedRatio(baseRatio = 2.0, isRecovery = true, staminaHeavy = false, boost = 1.5), 0.001, "Recovery skill on a non-stamina build is not boosted")
+        }
+    }
+
+    // //////////////////////////////////////////////////////////////////////////////////////////////////
+    // //////////////////////////////////////////////////////////////////////////////////////////////////
+    // Leftover point drain
+
+    @Nested
+    @DisplayName("calculateLeftoverDrainPurchases()")
+    inner class LeftoverDrainTests {
+        /** The total price of a set of picks. */
+        private fun spend(picks: List<Pair<String, Int>>): Int = picks.sumOf { it.second }
+
+        @Test
+        fun `spends leftover points that the normal strategies would have stranded`() {
+            // The reported case: a career ended with 67 points unspent while a 66-point skill sat available in the list.
+            val candidates =
+                listOf(
+                    SkillCandidate(name = "Dodging Danger", price = 66, evaluationPoints = 103),
+                    SkillCandidate(name = "Long Corners", price = 70, evaluationPoints = 195),
+                    SkillCandidate(name = "Competitive Spirit", price = 72, evaluationPoints = 129),
+                )
+
+            val picks = calculateLeftoverDrainPurchases(candidates, budget = 67)
+
+            assertEquals(listOf("Dodging Danger" to 66), picks, "The only affordable skill is bought, leaving 1 point behind instead of 67")
+        }
+
+        @Test
+        fun `finds an exact-spend combination that a greedy pass would miss`() {
+            // A greedy "buy the biggest that fits" pass would take 99 and strand 1 point. The exact search takes 60 + 40 and strands nothing.
+            val candidates =
+                listOf(
+                    SkillCandidate(name = "Expensive", price = 99, evaluationPoints = 300),
+                    SkillCandidate(name = "Medium", price = 60, evaluationPoints = 100),
+                    SkillCandidate(name = "Cheap", price = 40, evaluationPoints = 80),
+                )
+
+            val picks = calculateLeftoverDrainPurchases(candidates, budget = 100)
+
+            assertEquals(100, spend(picks), "The budget is spent down to exactly zero")
+            assertEquals(listOf("Cheap", "Medium"), picks.map { it.first }, "The two cheaper skills are bought instead of the single expensive one")
+        }
+
+        @Test
+        fun `breaks ties on total evaluation points`() {
+            // Both "Rich" alone and "PoorA" + "PoorB" spend the full 100, so the more valuable subset wins.
+            val candidates =
+                listOf(
+                    SkillCandidate(name = "PoorA", price = 50, evaluationPoints = 10),
+                    SkillCandidate(name = "PoorB", price = 50, evaluationPoints = 10),
+                    SkillCandidate(name = "Rich", price = 100, evaluationPoints = 500),
+                )
+
+            val picks = calculateLeftoverDrainPurchases(candidates, budget = 100)
+
+            assertEquals(100, spend(picks), "Both subsets spend the whole budget")
+            assertEquals(listOf("Rich" to 100), picks, "The subset worth more evaluation points wins the tie")
+        }
+
+        @Test
+        fun `never buys a blacklisted skill even when it fits perfectly`() {
+            val candidates =
+                listOf(
+                    SkillCandidate(name = "Banned", price = 100, evaluationPoints = 500),
+                    SkillCandidate(name = "Allowed", price = 90, evaluationPoints = 50),
+                )
+
+            val picks = calculateLeftoverDrainPurchases(candidates, budget = 100, blacklist = listOf("Banned"))
+
+            assertEquals(listOf("Allowed" to 90), picks, "The blacklisted skill is skipped even though it would spend the budget exactly")
+        }
+
+        @Test
+        fun `does not re-buy a skill the plan already covers`() {
+            val candidates =
+                listOf(
+                    SkillCandidate(name = "Planned", price = 100, evaluationPoints = 500),
+                    SkillCandidate(name = "Extra", price = 90, evaluationPoints = 50),
+                )
+
+            val picks = calculateLeftoverDrainPurchases(candidates, budget = 100, alreadyPlanned = listOf("Planned"))
+
+            assertEquals(listOf("Extra" to 90), picks, "An already-planned skill is not bought a second time")
+        }
+
+        @Test
+        fun `never exceeds the budget`() {
+            val random = Random(1316)
+            repeat(200) {
+                val budget = random.nextInt(0, 2000)
+                val candidates =
+                    List(random.nextInt(1, 40)) { index ->
+                        SkillCandidate(name = "Skill$index", price = random.nextInt(1, 500), evaluationPoints = random.nextInt(0, 900))
+                    }
+
+                val picks = calculateLeftoverDrainPurchases(candidates, budget)
+
+                assertTrue(spend(picks) <= budget, "Spend stays within the budget")
+                assertEquals(picks.size, picks.map { it.first }.distinct().size, "No skill is bought twice")
+
+                // Nothing affordable may be left behind, otherwise the drain failed at its one job.
+                val remaining = budget - spend(picks)
+                val bought = picks.map { it.first }.toSet()
+                assertTrue(candidates.none { it.name !in bought && it.price <= remaining }, "No affordable skill is left unbought")
+            }
+        }
+
+        @Test
+        fun `returns nothing for degenerate inputs`() {
+            val candidates = listOf(SkillCandidate(name = "Skill", price = 100, evaluationPoints = 50))
+
+            assertTrue(calculateLeftoverDrainPurchases(candidates, budget = 0).isEmpty(), "A zero budget buys nothing")
+            assertTrue(calculateLeftoverDrainPurchases(candidates, budget = -50).isEmpty(), "A negative budget buys nothing")
+            assertTrue(calculateLeftoverDrainPurchases(emptyList(), budget = 500).isEmpty(), "An empty skill list buys nothing")
+            assertTrue(calculateLeftoverDrainPurchases(candidates, budget = 99).isEmpty(), "Nothing is bought when everything is too expensive")
+            assertTrue(calculateLeftoverDrainPurchases(candidates, budget = 999999).isEmpty(), "An implausible budget from a bad OCR read is rejected")
         }
     }
 }


### PR DESCRIPTION
## Description

- This PR improves how the bot handles skill points left over when a career ends. Previously the final purchase bought only the skills your plan called for and then stopped, so whatever remained was simply lost when the run was scored.
- After the normal selection runs, the bot now tries to buy extra affordable skills to bring the balance closer to zero - including skills it would never pick during the career, since the points are worthless at that point anyway. How close it actually gets depends on what happens to be affordable in the list, so some remainder is still expected.
- It looks for the best combination rather than just grabbing the most expensive skill that fits, which lets it spend down further than a simpler approach would. Ties are broken in favour of the skills worth the most rank.
- The `Start Skill List Buy Test` debug option now previews what this sweep would buy, so its behaviour can be checked on any skill screen without playing out a full career.