### PR TITLE
Add a minimum-energy rest floor and a Wit-specific training failure threshold

### DIFF
--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Campaign.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Campaign.kt
@@ -158,6 +158,20 @@ internal fun resolvePreSummerAction(energy: Int, mood: Mood, firstTrainingCheck:
     }
 
 /**
+ * Whether the trainee is below the user's minimum-energy-to-train floor and should rest. Without this, energy only ever forces a rest indirectly: a low-energy turn raises every failure
+ * chance until the whole training map is filtered out. The floor makes that an explicit choice. Summer camp and the finale are exempt because those turns are worth more than the energy
+ * they cost - the finale especially, where energy does not affect race performance and resting simply throws the turn away. Pure so the floor is unit-testable without a live Campaign.
+ *
+ * @param energy The trainee's current energy percentage.
+ * @param minEnergyToTrain The floor below which the bot rests. 0 disables the floor entirely.
+ * @param isSummer Whether it is currently a summer turn.
+ * @param isFinals Whether the finale is underway.
+ * @return True when the bot should rest purely because energy is too low.
+ */
+internal fun shouldRestForLowEnergy(energy: Int, minEnergyToTrain: Int, isSummer: Boolean, isFinals: Boolean): Boolean =
+    minEnergyToTrain > 0 && !isSummer && !isFinals && energy < minEnergyToTrain
+
+/**
  * Whether the G1-day preference should peek at the training screen this turn. On a G1 race day the bot would normally take the free race, so this runs only when the feature is enabled,
  * the trainee is past Junior year, it is not summer or the finale, energy clears the extra-racing floor, and a G1 race is actually available. Pure so the gate is unit-testable.
  *
@@ -231,6 +245,9 @@ abstract class Campaign(game: Game) : Task(game) {
 
     /** Whether the bot must rest before Summer. */
     protected val mustRestBeforeSummer: Boolean = SettingsHelper.getBooleanSetting("training", "mustRestBeforeSummer")
+
+    /** The energy percentage below which the bot rests instead of training, even when the failure chances are low enough to train. 0 (default) disables the floor. */
+    protected val minEnergyToTrain: Int = SettingsHelper.getIntSetting("training", "minEnergyToTrain", 0)
 
     /** The number of skill points required to trigger a check. */
     protected val skillPointsRequired: Int = SettingsHelper.getIntSetting("skills", "skillPointCheck")
@@ -2455,6 +2472,14 @@ abstract class Campaign(game: Game) : Task(game) {
             MessageLog.i(TAG, "[INFO] Bot has no injuries, mood is sufficient and extra races can be run today. Setting the action to RACE.")
             decisionTracer.recordActionChoice(MainScreenAction.RACE, "Extra-race eligible (no injury, sufficient mood, eligible day)")
             return MainScreenAction.RACE
+        }
+
+        // Checked last so it only ever replaces a training turn. Racing keeps its own energy floor (minEnergyForExtraRacing), and a mandatory race, an injury, or a bad mood all still
+        // take precedence above.
+        if (shouldRestForLowEnergy(trainee.energy, minEnergyToTrain, date.isSummer(), isFinals)) {
+            MessageLog.i(TAG, "[INFO] Energy (${trainee.energy}%) is below the minimum of $minEnergyToTrain% required to train. Resting instead.")
+            decisionTracer.recordActionChoice(MainScreenAction.REST, "Energy ${trainee.energy}% is below the $minEnergyToTrain% minimum-energy-to-train floor")
+            return MainScreenAction.REST
         }
 
         decisionTracer.recordActionChoice(MainScreenAction.TRAIN, "Default fallback after racing/mood/injury checks did not trigger")

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Training.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Training.kt
@@ -350,6 +350,10 @@ open class Training(protected val game: Game, protected val campaign: Campaign) 
         val mainStatGain: Int
             get() = statGains[name] ?: 0
 
+        /** Whether this training has a Unity Cup Spirit Explosion gauge ready to burst (normal or extreme), mirroring the same flag on the analysis result it was built from. */
+        val isBurstReady: Boolean
+            get() = (extras["spiritGaugesReadyToBurst"] as? Int ?: 0) > 0 || (extras["spiritGaugesReadyToExtremeBurst"] as? Int ?: 0) > 0
+
         override fun equals(other: Any?): Boolean {
             if (this === other) return true
             if (javaClass != other?.javaClass) return false
@@ -2494,7 +2498,19 @@ open class Training(protected val game: Game, protected val campaign: Campaign) 
             }
 
             if (selected.failureChance > maximumFailureChance) {
-                keyFactors.add("Selected despite ${selected.failureChance}% failure chance (Risky Training enabled or Finals).")
+                // Name the exemption that actually raised the ceiling for this training. Order follows how the gate resolves it: a ready burst raises it most, then Riskier Training, then
+                // the Wit exemption (which the gate checks after risky), then a Finals force-pick. The generic tail covers any remaining bypass such as an active Good-Luck Charm.
+                val riskyApplied = riskyExemptFromFailureChance(selected.mainStatGain, enableRiskyTraining, riskyTrainingMinStatGain)
+                val witApplied = witExemptFromFailureChance(selected.name, selected.mainStatGain, enableWitOverRest, witOverRestMinStatGain)
+                val reason =
+                    when {
+                        selected.isBurstReady -> "a ready Spirit Explosion gauge raised its failure-chance limit"
+                        riskyApplied -> "Riskier Training raised its limit to $riskyTrainingMaxFailureChance% for its main stat gain of ${selected.mainStatGain}"
+                        witApplied -> "the Wit exemption raised its limit to ${maxOf(maximumFailureChance, witOverRestMaxFailureChance)}%"
+                        campaign.checkFinals() -> "the Finals bypasses the failure-chance limit"
+                        else -> "an exemption raised the failure-chance limit"
+                    }
+                keyFactors.add("Selected despite ${selected.failureChance}% failure chance ($reason).")
             }
 
             // Output ranking reasoning if a runner-up exists.

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Training.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Training.kt
@@ -168,6 +168,18 @@ open class Training(protected val game: Game, protected val campaign: Campaign) 
     /** The maximum failure chance allowed for risky training. */
     private val riskyTrainingMaxFailureChance: Int = SettingsHelper.getIntSetting("training", "riskyTrainingMaxFailureChance")
 
+    /**
+     * Whether Wit gets its own, more lenient failure ceiling so a good Wit turn survives the gate instead of being rejected alongside the other stats. Wit's failure chance decays far
+     * more slowly with energy than the other four (see `estimateFailureChanceFromEnergy`), so the shared ceiling rejects Wit turns that are still worth taking over a rest.
+     */
+    private val enableWitOverRest: Boolean = SettingsHelper.getBooleanSetting("training", "enableWitOverRest", false)
+
+    /** The failure ceiling applied to Wit when [enableWitOverRest] is on. Kept separate from [maximumFailureChance] because Wit tolerates low energy far better. */
+    private val witOverRestMaxFailureChance: Int = SettingsHelper.getIntSetting("training", "witOverRestMaxFailureChance", 35)
+
+    /** The main-stat gain Wit must reach before its raised ceiling applies, so only a genuinely high-value Wit turn survives a failure chance the other stats could not. */
+    private val witOverRestMinStatGain: Int = SettingsHelper.getIntSetting("training", "witOverRestMinStatGain", 25)
+
     /** Whether the expected-value failure gate is active. When on, trainings whose total stat gain is poor value for their failure chance are skipped. */
     private val enableExpectedValueGate: Boolean = SettingsHelper.getBooleanSetting("training", "enableExpectedValueGate", true)
 
@@ -831,6 +843,51 @@ open class Training(protected val game: Game, protected val campaign: Campaign) 
             } else {
                 baseFailureChance
             }
+
+        /**
+         * The failure-chance ceiling a single training must clear, before any Unity Cup burst exemption raises it further. Risky training raises the ceiling for any high-gain training.
+         * The Wit exemption raises it for Wit alone, because Wit's failure chance decays far more slowly with energy than the other four (see `estimateFailureChanceFromEnergy`), so the
+         * shared ceiling otherwise rejects Wit turns that are still worth taking over a rest. Risky training is checked first, so it wins when a Wit training qualifies for both. The Wit
+         * branch takes the larger of the two ceilings so enabling it can never lower a ceiling the user already raised. Pure and unit-testable.
+         *
+         * @param maximumFailureChance The shared failure-chance ceiling from settings.
+         * @param riskyExempt Whether risky training opted into this training.
+         * @param riskyTrainingMaxFailureChance The risky-training ceiling from settings.
+         * @param witExempt Whether the Wit exemption opted into this training.
+         * @param witOverRestMaxFailureChance The Wit ceiling from settings.
+         * @return The failure-chance ceiling to apply to this training.
+         */
+        fun baseFailureChanceFor(maximumFailureChance: Int, riskyExempt: Boolean, riskyTrainingMaxFailureChance: Int, witExempt: Boolean, witOverRestMaxFailureChance: Int): Int =
+            when {
+                riskyExempt -> riskyTrainingMaxFailureChance
+                witExempt -> maxOf(maximumFailureChance, witOverRestMaxFailureChance)
+                else -> maximumFailureChance
+            }
+
+        /**
+         * Whether Riskier Training opts into this training, raising its failure ceiling for a high enough main stat gain. Pure so both the analysis gate and the selection log share one
+         * definition instead of respelling the predicate.
+         *
+         * @param mainStatGain The training's projected gain for its own stat.
+         * @param enableRiskyTraining Whether the user turned Riskier Training on.
+         * @param riskyTrainingMinStatGain The main stat gain the training must reach to qualify.
+         * @return True when this training gets the Riskier Training failure ceiling.
+         */
+        fun riskyExemptFromFailureChance(mainStatGain: Int, enableRiskyTraining: Boolean, riskyTrainingMinStatGain: Int): Boolean =
+            enableRiskyTraining && mainStatGain >= riskyTrainingMinStatGain
+
+        /**
+         * Whether the Wit failure-ceiling exemption opts into this training. Wit only, and only when its own gain clears the minimum, so a low-value Wit turn is never worth the extra
+         * risk the raised ceiling accepts. Pure and unit-testable.
+         *
+         * @param stat The training being gated.
+         * @param mainStatGain The training's projected gain for its own stat.
+         * @param enableWitOverRest Whether the user turned the exemption on.
+         * @param witOverRestMinStatGain The main stat gain the Wit training must reach to qualify.
+         * @return True when this training gets Wit's raised failure ceiling.
+         */
+        fun witExemptFromFailureChance(stat: StatName, mainStatGain: Int, enableWitOverRest: Boolean, witOverRestMinStatGain: Int): Boolean =
+            enableWitOverRest && stat == StatName.WIT && mainStatGain >= witOverRestMinStatGain
 
         /**
          * The additive Unity Cup Extreme Spirit Burst score bonus for `count` supports ready to extreme-burst. Shared by the Junior/Classic Unity scorer and the Senior-year path so the
@@ -1811,8 +1868,11 @@ open class Training(protected val game: Game, protected val campaign: Campaign) 
             // Whether risky training opted into this training. This one rule decides the raised failure ceiling, the burst exemption below, and the expected-value exemption further
             // down, so it is named once here rather than respelled at each use.
             val mainStatGain: Int = result.mainStatGain
-            val riskyExempt = enableRiskyTraining && mainStatGain >= riskyTrainingMinStatGain
-            val baseFailureChance = if (riskyExempt) riskyTrainingMaxFailureChance else maximumFailureChance
+            val riskyExempt = riskyExemptFromFailureChance(mainStatGain, enableRiskyTraining, riskyTrainingMinStatGain)
+            // Wit exemption: Wit's failure chance decays far more slowly with energy than the other four stats, so the shared ceiling rejects Wit turns that are still better than a rest.
+            // Giving Wit its own ceiling is what lets a low-energy Wit turn survive instead of emptying the map and forcing a recovery.
+            val witExempt = witExemptFromFailureChance(result.name, mainStatGain, enableWitOverRest, witOverRestMinStatGain)
+            val baseFailureChance = baseFailureChanceFor(maximumFailureChance, riskyExempt, riskyTrainingMaxFailureChance, witExempt, witOverRestMaxFailureChance)
 
             // Unity Cup burst exemption: a normal Spirit Explosion gauge ready to burst may be worth a higher failure chance than usual (tunable ceiling, no-op at the default 0). An
             // Extreme Spirit Burst is a guaranteed-success (0% fail) turn and the single best action, so it is never skipped for failure chance regardless of the setting.
@@ -1834,6 +1894,12 @@ open class Training(protected val game: Game, protected val campaign: Campaign) 
                             "[TRAINING] Skipping ${result.name} training due to failure chance (${result.failureChance}%) exceeding threshold ($effectiveFailureChance%) despite high main stat gain of $mainStatGain.",
                         )
                         "high failure chance (risky)"
+                    } else if (witExempt) {
+                        MessageLog.i(
+                            TAG,
+                            "[TRAINING] Skipping ${result.name} training due to failure chance (${result.failureChance}%) exceeding even the raised Wit threshold ($effectiveFailureChance%).",
+                        )
+                        "high failure chance (wit)"
                     } else {
                         MessageLog.i(TAG, "[TRAINING] Skipping ${result.name} training due to failure chance (${result.failureChance}%) exceeding threshold ($effectiveFailureChance%).")
                         "high failure chance"
@@ -1857,11 +1923,13 @@ open class Training(protected val game: Game, protected val campaign: Campaign) 
                 continue
             }
 
-            // Expected-value gate: skip trainings whose total stat gain is poor value for their failure chance. Exempt when risky training opted into this training, when a Unity Cup
-            // burst is ready (burst value is not captured by statGains), or for Good-Luck Charm flows (ignoreFailureChance). Unlike the failure-chance exemption above, this one reads
-            // isBurstReady directly and is deliberately not gated on the minimum main stat gain: it waives a value heuristic rather than a user-set risk ceiling.
+            // Expected-value gate: skip trainings whose total stat gain is poor value for their failure chance. Exempt when risky training opted into this training, when the Wit
+            // exemption opted into it, when a Unity Cup burst is ready (burst value is not captured by statGains), or for Good-Luck Charm flows (ignoreFailureChance). Unlike the
+            // failure-chance exemption above, the burst one reads isBurstReady directly and is deliberately not gated on the minimum main stat gain: it waives a value heuristic rather
+            // than a user-set risk ceiling. Wit is exempt here for the same reason it gets its own ceiling - this gate scales the required gain by the failure chance, which double-counts
+            // the very risk the Wit ceiling already accepted, and would otherwise re-reject every Wit turn the ceiling just let through.
             val burstExempt = result.isBurstReady
-            if (!test && !ignoreFailureChance && enableExpectedValueGate && !riskyExempt && !burstExempt) {
+            if (!test && !ignoreFailureChance && enableExpectedValueGate && !riskyExempt && !witExempt && !burstExempt) {
                 val totalStatGain = result.statGains.values.sum()
                 if (failsExpectedValueGate(totalStatGain, result.failureChance, expectedValueGainPerFailPercent, expectedValueMinFailureChance)) {
                     MessageLog.i(

--- a/android/app/src/test/java/com/steve1316/uma_android_automation/bot/LowEnergyPolicyTest.kt
+++ b/android/app/src/test/java/com/steve1316/uma_android_automation/bot/LowEnergyPolicyTest.kt
@@ -1,0 +1,110 @@
+package com.steve1316.uma_android_automation.bot
+
+import com.steve1316.uma_android_automation.types.StatName
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit tests for the low-energy training policy: the minimum-energy rest floor in Campaign and the Wit failure-ceiling exemption in Training. Both are pure, so they are verified here
+ * without a live Campaign or the Android-coupled analysis pipeline. The shipped defaults are the rest floor off (0), the Wit exemption off, its ceiling 35%, and its minimum gain 25.
+ */
+@DisplayName("Low-energy training policy")
+class LowEnergyPolicyTest {
+    /** Calls the rest floor with it disabled by default, so each test only states the values it actually cares about. */
+    private fun restForLowEnergy(energy: Int = 50, minEnergyToTrain: Int = 0, isSummer: Boolean = false, isFinals: Boolean = false) =
+        shouldRestForLowEnergy(energy = energy, minEnergyToTrain = minEnergyToTrain, isSummer = isSummer, isFinals = isFinals)
+
+    /** Calls the Wit exemption with the feature on and the shipped 25 gain minimum by default, so gain-path tests only state what they vary. */
+    private fun witExempt(stat: StatName = StatName.WIT, mainStatGain: Int = 30, enableWitOverRest: Boolean = true, witOverRestMinStatGain: Int = 25) =
+        Training.witExemptFromFailureChance(stat, mainStatGain, enableWitOverRest, witOverRestMinStatGain)
+
+    /** Resolves the failure ceiling a training must clear, wiring the two production helpers together exactly as `processAnalysisResults` does. */
+    private fun ceilingFor(
+        stat: StatName,
+        mainStatGain: Int,
+        maximumFailureChance: Int = 20,
+        enableRiskyTraining: Boolean = false,
+        riskyTrainingMinStatGain: Int = 50,
+        riskyTrainingMaxFailureChance: Int = 30,
+        enableWitOverRest: Boolean = false,
+        witOverRestMinStatGain: Int = 25,
+        witOverRestMaxFailureChance: Int = 35,
+    ): Int {
+        val riskyExempt = Training.riskyExemptFromFailureChance(mainStatGain, enableRiskyTraining, riskyTrainingMinStatGain)
+        val witExempt = Training.witExemptFromFailureChance(stat, mainStatGain, enableWitOverRest, witOverRestMinStatGain)
+        return Training.baseFailureChanceFor(maximumFailureChance, riskyExempt, riskyTrainingMaxFailureChance, witExempt, witOverRestMaxFailureChance)
+    }
+
+    @Test
+    @DisplayName("The rest floor is disabled by default, so nothing changes on upgrade")
+    fun testFloorDisabledByDefault() {
+        assertFalse(restForLowEnergy(energy = 5), "With the floor at 0, even 5% energy keeps training as long as a training survived the failure-chance gate")
+    }
+
+    @Test
+    @DisplayName("The rest floor fires below the threshold and never at or above it")
+    fun testFloorBoundary() {
+        assertTrue(restForLowEnergy(energy = 29, minEnergyToTrain = 30), "Energy below the floor rests even though a training was viable")
+        assertFalse(restForLowEnergy(energy = 30, minEnergyToTrain = 30), "Energy exactly at the floor is allowed to train")
+        assertFalse(restForLowEnergy(energy = 31, minEnergyToTrain = 30), "Energy above the floor trains")
+    }
+
+    @Test
+    @DisplayName("Summer camp and the finale are exempt from the rest floor")
+    fun testFloorExemptions() {
+        assertTrue(restForLowEnergy(energy = 10, minEnergyToTrain = 40), "A normal turn below the floor rests")
+        assertFalse(restForLowEnergy(energy = 10, minEnergyToTrain = 40, isSummer = true), "Summer turns are worth more than the energy they cost, so the floor never rests through one")
+        assertFalse(restForLowEnergy(energy = 10, minEnergyToTrain = 40, isFinals = true), "Energy does not affect race performance, so resting during the finale throws the turn away")
+    }
+
+    @Test
+    @DisplayName("The Wit exemption opts in only Wit, and only when its gain clears the minimum")
+    fun testWitExemptionQualifies() {
+        assertTrue(witExempt(mainStatGain = 25), "Gain exactly at the 25 minimum qualifies")
+        assertFalse(witExempt(mainStatGain = 24), "A gain just under the minimum does not qualify, so a lower-value Wit turn is not worth the risk")
+        assertFalse(witExempt(stat = StatName.SPEED, mainStatGain = 99), "The exemption is Wit-only; Speed never qualifies")
+        assertFalse(witExempt(mainStatGain = 99, enableWitOverRest = false), "Off by default, so nothing qualifies")
+    }
+
+    @Test
+    @DisplayName("The Wit exemption raises only Wit's failure ceiling")
+    fun testWitCeiling() {
+        assertEquals(20, ceilingFor(StatName.WIT, mainStatGain = 30), "With the exemption off, Wit is held to the same ceiling as everything else")
+        assertEquals(35, ceilingFor(StatName.WIT, mainStatGain = 30, enableWitOverRest = true), "A high-gain Wit turn gets its own, more lenient ceiling")
+        assertEquals(20, ceilingFor(StatName.WIT, mainStatGain = 24, enableWitOverRest = true), "A Wit turn under the 25 minimum keeps the shared ceiling")
+        assertEquals(20, ceilingFor(StatName.SPEED, mainStatGain = 30, enableWitOverRest = true), "The exemption is Wit-only; Speed keeps the shared ceiling")
+    }
+
+    @Test
+    @DisplayName("The Wit exemption never lowers a ceiling, and risky training still outranks it")
+    fun testWitCeilingPrecedence() {
+        assertEquals(
+            50,
+            ceilingFor(StatName.WIT, mainStatGain = 30, maximumFailureChance = 50, enableWitOverRest = true),
+            "A user whose shared ceiling already exceeds the Wit ceiling must not have it lowered by turning the exemption on",
+        )
+        assertEquals(
+            30,
+            ceilingFor(StatName.WIT, mainStatGain = 55, enableRiskyTraining = true, enableWitOverRest = true),
+            "Risky training is checked first, so its ceiling wins when a Wit turn qualifies for both",
+        )
+    }
+
+    @Test
+    @DisplayName("Issue #394: a high-value Wit turn survives the shared failure ceiling once the user tunes the threshold to reach it")
+    fun testIssue394HighValueWit() {
+        // Wit fails far less often at low energy than the other stats, so at low energy the map often empties with only Wit close to viable. The exemption lets a Wit turn the user
+        // considers high-value survive the gate instead of forcing a rest. A user targeting, say, a 20-gain Wit turn at 30% failure sets the minimum to 20 and the ceiling to 35.
+        val witFailureChance = 30
+        val witGain = 20
+
+        assertTrue(witFailureChance > ceilingFor(StatName.WIT, mainStatGain = witGain), "With the exemption off, Wit's 30% blows past the shared 20% ceiling and is skipped")
+        assertTrue(
+            witFailureChance <= ceilingFor(StatName.WIT, mainStatGain = witGain, enableWitOverRest = true, witOverRestMinStatGain = 20),
+            "With the exemption on and the minimum tuned to 20, the 20-gain Wit turn fits under its own 35% ceiling and is trained instead of rested",
+        )
+    }
+}

--- a/src/context/BotStateContext.tsx
+++ b/src/context/BotStateContext.tsx
@@ -138,6 +138,10 @@ export interface Settings {
         enableRiskyTraining: boolean
         riskyTrainingMinStatGain: number
         riskyTrainingMaxFailureChance: number
+        minEnergyToTrain: number
+        enableWitOverRest: boolean
+        witOverRestMaxFailureChance: number
+        witOverRestMinStatGain: number
         trainWitDuringFinale: boolean
         enablePrioritizeSkillHints: boolean
         enableTrainingLevelWeighting: boolean
@@ -432,6 +436,10 @@ export const defaultSettings: Settings = {
         enableRiskyTraining: false,
         riskyTrainingMinStatGain: 20,
         riskyTrainingMaxFailureChance: 30,
+        minEnergyToTrain: 0,
+        enableWitOverRest: false,
+        witOverRestMaxFailureChance: 35,
+        witOverRestMinStatGain: 25,
         trainWitDuringFinale: false,
         enablePrioritizeSkillHints: false,
         enableTrainingLevelWeighting: true,

--- a/src/context/searchConfig.ts
+++ b/src/context/searchConfig.ts
@@ -181,6 +181,32 @@ const searchConfig: SearchOption[] = [
         parentId: "enable-riskier-training",
     },
     {
+        id: "minimum-energy-to-train",
+        title: "Minimum Energy to Train",
+        description: "Rest instead of training when energy falls below this, even if the failure chances are low enough to train. 0 disables it. Summer Training and the Finale always ignore this.",
+        page: "TrainingSettings",
+    },
+    {
+        id: "enable-wit-over-rest",
+        title: "Train Wit Instead of Resting",
+        description: "When enabled, Wit gets its own custom failure chance threshold.",
+        page: "TrainingSettings",
+    },
+    {
+        id: "wit-over-rest-max-failure-chance",
+        title: "Wit Maximum Failure Chance",
+        description: "The maximum acceptable failure chance for Wit training before doing something else.",
+        page: "TrainingSettings",
+        parentId: "enable-wit-over-rest",
+    },
+    {
+        id: "wit-over-rest-min-stat-gain",
+        title: "Minimum Wit Main Stat Gain Threshold",
+        description: "When the Wit training's main stat gain meets or exceeds this value, Wit uses its higher maximum failure chance.",
+        page: "TrainingSettings",
+        parentId: "enable-wit-over-rest",
+    },
+    {
         id: "enable-prioritize-skill-hints",
         title: "Prioritize Skill Hints",
         description: "When enabled, the bot will prioritize acquiring skill hints, bypassing stat prioritization and blacklist, while still being constrained by the failure chance thresholds.",

--- a/src/lib/messageLog/buildSettingsBanner.ts
+++ b/src/lib/messageLog/buildSettingsBanner.ts
@@ -131,6 +131,12 @@ export function buildSettingsBanner(settings: Settings): string {
             ? `\n   📊 Minimum Main Stat Gain Threshold: ${settings.training.riskyTrainingMinStatGain}\n   🎯 Risky Training Maximum Failure Chance: ${settings.training.riskyTrainingMaxFailureChance}%`
             : ""
     }
+🔋 Minimum Energy to Train: ${settings.training.minEnergyToTrain === 0 ? "❌" : `${settings.training.minEnergyToTrain}%`}
+🧠 Train Wit Instead of Resting: ${settings.training.enableWitOverRest ? "✅" : "❌"}${
+        settings.training.enableWitOverRest
+            ? `\n   🎯 Wit Maximum Failure Chance: ${settings.training.witOverRestMaxFailureChance}%\n   📊 Minimum Wit Main Stat Gain Threshold: ${settings.training.witOverRestMinStatGain}`
+            : ""
+    }
 🔄 Disable Training on Maxed Stat: ${settings.training.disableTrainingOnMaxedStat ? "✅" : "❌"}
 📏 Preferred Distance Override: ${settings.training.preferredDistanceOverride === "Default" ? "Default" : settings.training.preferredDistanceOverride}
 🌈 Enable Rainbow Training Bonus: ${settings.training.enableRainbowTrainingBonus ? "✅" : "❌"}

--- a/src/pages/TrainingSettings/index.tsx
+++ b/src/pages/TrainingSettings/index.tsx
@@ -164,6 +164,10 @@ const TrainingSettings = () => {
         enableRiskyTraining,
         riskyTrainingMinStatGain,
         riskyTrainingMaxFailureChance,
+        minEnergyToTrain,
+        enableWitOverRest,
+        witOverRestMaxFailureChance,
+        witOverRestMinStatGain,
         trainWitDuringFinale,
         enablePrioritizeSkillHints,
         enableTrainingLevelWeighting,
@@ -710,6 +714,71 @@ const TrainingSettings = () => {
                                                 description="Set the maximum acceptable failure chance for risky training sessions with high main stat gains."
                                                 searchId="risky-training-max-failure-chance"
                                                 parentId="enable-riskier-training"
+                                            />
+                                        </View>
+                                    )}
+
+                                    <View style={styles.sliderShell}>
+                                        <CustomSlider
+                                            // No `|| defaultSettings...` fallback here on purpose: 0 means "floor disabled" and is a real value,
+                                            // so the usual fallback would snap it back to the default.
+                                            value={minEnergyToTrain}
+                                            placeholder={defaultSettings.training.minEnergyToTrain}
+                                            onValueChange={(value) => updateTrainingSetting("minEnergyToTrain", value)}
+                                            min={0}
+                                            max={95}
+                                            step={5}
+                                            label="Minimum Energy to Train"
+                                            labelUnit="%"
+                                            showValue={true}
+                                            showLabels={true}
+                                            description="Rest instead of training when energy falls below this, even if the failure chances are low enough to train. 0 disables it. Summer Training and the Finale always ignore this."
+                                            searchId="minimum-energy-to-train"
+                                        />
+                                    </View>
+
+                                    <ToggleSetting
+                                        id="enable-wit-over-rest"
+                                        title="Train Wit Instead of Resting"
+                                        description="When enabled, Wit gets its own custom failure chance threshold."
+                                        checked={enableWitOverRest}
+                                        onCheckedChange={(checked) => updateTrainingSetting("enableWitOverRest", checked)}
+                                    />
+                                    {enableWitOverRest && (
+                                        <View style={styles.sliderShell}>
+                                            <CustomSlider
+                                                value={witOverRestMaxFailureChance || defaultSettings.training.witOverRestMaxFailureChance}
+                                                placeholder={defaultSettings.training.witOverRestMaxFailureChance}
+                                                onValueChange={(value) => updateTrainingSetting("witOverRestMaxFailureChance", value)}
+                                                min={5}
+                                                max={95}
+                                                step={5}
+                                                label="Wit Maximum Failure Chance"
+                                                labelUnit="%"
+                                                showValue={true}
+                                                showLabels={true}
+                                                description="The maximum acceptable failure chance for Wit training before doing something else."
+                                                searchId="wit-over-rest-max-failure-chance"
+                                                parentId="enable-wit-over-rest"
+                                            />
+                                        </View>
+                                    )}
+                                    {enableWitOverRest && (
+                                        <View style={styles.sliderShell}>
+                                            <CustomSlider
+                                                value={witOverRestMinStatGain || defaultSettings.training.witOverRestMinStatGain}
+                                                placeholder={defaultSettings.training.witOverRestMinStatGain}
+                                                onValueChange={(value) => updateTrainingSetting("witOverRestMinStatGain", value)}
+                                                min={5}
+                                                max={100}
+                                                step={5}
+                                                label="Minimum Wit Main Stat Gain Threshold"
+                                                labelUnit=""
+                                                showValue={true}
+                                                showLabels={true}
+                                                description="When the Wit training's main stat gain meets or exceeds this value, Wit uses its higher maximum failure chance."
+                                                searchId="wit-over-rest-min-stat-gain"
+                                                parentId="enable-wit-over-rest"
                                             />
                                         </View>
                                     )}


### PR DESCRIPTION
## Description
- This PR adds two opt-in Training settings for how the bot behaves at low energy, both off by default so existing careers are unchanged.
- `Train Wit Instead of Resting` gives Wit training its own, more lenient failure-chance threshold, so a high-value Wit turn is taken instead of resting when every other stat is too risky to train (resolves #394).
- `Minimum Energy to Train` makes the bot rest below a chosen energy percentage even when failure chances are low enough to train, with Summer Training and the Finale always exempt.
- The message log now names which setting let a training run despite exceeding the normal failure limit, instead of always guessing "Risky Training or Finals".

Previously, at low energy the bot would rest even when a safe, valuable Wit turn was available, because Wit was held to the same failure limit as the far riskier stats:

    SPEED (REJECTED): fail=76%, high failure chance
    WIT  (REJECTED): fail=32%, gains=[... WIT:24], high failure chance
    No training was selected -> Recovery executed: RECOVER_ENERGY
