### PR TITLE
Retire the Farming Fans settings and surface Racing settings that override the Smart Race Solver

### DIFF
--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Campaign.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Campaign.kt
@@ -2514,8 +2514,8 @@ abstract class Campaign(game: Game) : Task(game) {
             return MainScreenAction.RACE
         }
 
-        // Checked last so it only ever replaces a training turn. Racing keeps its own energy floor (minEnergyForExtraRacing), and a mandatory race, an injury, or a bad mood all still
-        // take precedence above.
+        // Checked last so it only ever replaces a training turn. Every racing path above - mandatory, scheduled, requirement, force racing, and the solver's own schedule - already
+        // returned before this, as did an injury or a bad mood, so resting here never costs a planned race.
         if (shouldRestForLowEnergy(trainee.energy, minEnergyToTrain, date.isSummer(), isFinals)) {
             MessageLog.i(TAG, "[INFO] Energy (${trainee.energy}%) is below the minimum of $minEnergyToTrain% required to train. Resting instead.")
             decisionTracer.recordActionChoice(MainScreenAction.REST, "Energy ${trainee.energy}% is below the $minEnergyToTrain% minimum-energy-to-train floor")

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Racing.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Racing.kt
@@ -55,15 +55,6 @@ import org.json.JSONObject
 import org.opencv.core.Point
 
 /**
- * Whether the trainee has enough energy for a plain fan-farming extra race. A floor of 0 disables the check so it never blocks. Pure so it is unit-testable without a live Racing.
- *
- * @param energy The trainee's current energy percentage.
- * @param minEnergy The minimum energy floor for the fan-farming interval fallback.
- * @return True when energy is at or above the floor, or the floor is disabled.
- */
-internal fun hasEnoughEnergyForExtraRacing(energy: Int, minEnergy: Int): Boolean = minEnergy <= 0 || energy >= minEnergy
-
-/**
  * Whether the extra-race pick should defer to the Smart Race Solver instead of standard racing. Any mandatory career goal (fan, trophy, or goal-pts
  * requirement) forces standard racing, whose double-star and G1-only filtering actually satisfies the goal. The solver only optimizes fans and epithets
  * and never honors these goals, so routing a requirement to it silently drops it. Pure so it is unit-testable without a live Racing.
@@ -125,16 +116,10 @@ internal fun requirementForcesRacing(
  * @property campaign A reference to the current [Campaign] instance.
  */
 class Racing(private val game: Game, private val campaign: Campaign) {
-    /** Whether to enable farming fans through extra races. */
-    val enableFarmingFans = SettingsHelper.getBooleanSetting("racing", "enableFarmingFans")
-
     /** Whether to ignore the warning that appears when racing three times in a row. */
     val ignoreConsecutiveRaceWarning = SettingsHelper.getBooleanSetting("racing", "ignoreConsecutiveRaceWarning")
 
-    /** The number of days to wait between running extra races. */
-    private val daysToRunExtraRaces: Int = SettingsHelper.getIntSetting("racing", "daysToRunExtraRaces")
-
-    /** Minimum energy before the plain fan-farming interval fallback will race. 0 disables it. Gates only the standard cadence, never requirements, the solver, or scenario bypasses. */
+    /** Minimum energy before the G1-day pre-screen will peek at the trainings. Below the floor the bot skips the peek and takes the G1 race. 0 disables the floor. */
     internal val minEnergyForExtraRacing: Int = SettingsHelper.getIntSetting("racing", "minEnergyForExtraRacing", 30)
 
     /** Whether to prefer training over the free race on a G1 race day when a strong-enough rainbow training is available. Default off. */
@@ -856,14 +841,13 @@ class Racing(private val game: Game, private val campaign: Campaign) {
         )
 
     /**
-     * Determines if the extra racing process should be started now or later.
+     * Determines if the extra racing process should be started now or later. Discretionary extra races only ever come from the Smart Race Solver, so with it off this
+     * only stays true for force racing and the scenario bypass.
      *
      * @return True if the current date is okay to start the extra racing process and false otherwise.
      */
     fun checkEligibilityToStartExtraRacingProcess(): Boolean {
         MessageLog.i(TAG, "\n[RACE] Now determining eligibility to start the extra racing process...")
-        val turnsRemaining = game.imageUtils.determineTurnsRemainingBeforeNextGoal()
-        MessageLog.i(TAG, "[RACE] Current remaining number of days before the next mandatory race: $turnsRemaining.")
 
         // Don't bother looking for races on Junior Year Early July (Turn 13) since they only start showing up on Turn 14.
         if (campaign.date.day == 13) {
@@ -895,8 +879,8 @@ class Racing(private val game: Game, private val campaign: Campaign) {
         }
 
         // When the Smart Race Solver is enabled, its schedule is authoritative for extra races. If the solver did not plan a race for
-        // this turn, suppress every extra-race fallback (including the scenario fan-farm bypass and the racing-interval cadence) so the
-        // bot trains or rests instead of racing as filler. Hard requirements above still short-circuit to true before this guard.
+        // this turn, suppress every extra-race fallback (including the scenario bypass below) so the bot trains or rests instead of
+        // racing as filler. Hard requirements above still short-circuit to true before this guard.
         if (enableSmartRaceSolver) {
             val plannedKey = SmartRaceSolverIntegration.peekRaceKeyForTurn(currentTurn = campaign.date.day, scenario = game.scenario)
             if (plannedKey == null) {
@@ -934,19 +918,10 @@ class Racing(private val game: Game, private val campaign: Campaign) {
             return result
         }
 
-        // Standard racing fallback: race on every Nth day of the racing interval, but only when energy is above the fan-farming floor so filler races do not drain the trainee.
-        val hasEnoughEnergy = hasEnoughEnergyForExtraRacing(campaign.trainee.energy, minEnergyForExtraRacing)
-        val result = enableFarmingFans && (turnsRemaining % daysToRunExtraRaces == 0) && !raceRepeatWarningCheck && hasEnoughEnergy
-        val fallbackReason =
-            when {
-                !enableFarmingFans -> "Farming Fans setting is off"
-                (turnsRemaining % daysToRunExtraRaces) != 0 -> "Not a racing-interval day ($turnsRemaining turns remaining, every $daysToRunExtraRaces days)"
-                raceRepeatWarningCheck -> "Race repeat warning is active"
-                !hasEnoughEnergy -> "Energy ${campaign.trainee.energy}% is below the extra-racing floor of $minEnergyForExtraRacing%"
-                else -> "Standard fallback: every-$daysToRunExtraRaces-day racing window matched"
-            }
-        campaign.decisionTracer.recordRaceEligibility(eligible = result, reason = fallbackReason)
-        return result
+        // Every discretionary extra race now comes from the Smart Race Solver, so with it off there is nothing left to race for and the bot trains or rests instead.
+        MessageLog.i(TAG, "[RACE] The Smart Race Solver is off, so there is no source of extra races. Skipping the extra race check.")
+        campaign.decisionTracer.recordRaceEligibility(eligible = false, reason = "No extra-race source is active (Smart Race Solver is off)")
+        return false
     }
 
     /**
@@ -2431,8 +2406,8 @@ class Racing(private val game: Game, private val campaign: Campaign) {
 
                 if (g1Indices.isEmpty()) {
                     // No G1 races available. Cancel since trophy requirement specifically needs G1 races.
-                    // Trophy requirement is independent of racing plan and farming fans settings.
-                    MessageLog.i(TAG, "[RACE] Trophy requirement active but no G1 races available. Canceling racing process (independent of racing plan/farming fans).")
+                    // A trophy requirement can only be met by a G1, so with none listed this turn there is nothing to race for.
+                    MessageLog.i(TAG, "[RACE] Trophy requirement active but no G1 races available. Canceling racing process.")
                     return false
                 } else {
                     MessageLog.i(TAG, "[RACE] Trophy requirement active. Filtering to ${g1Indices.size} G1 races.")

--- a/android/app/src/test/java/com/steve1316/uma_android_automation/bot/RacingDecisionTest.kt
+++ b/android/app/src/test/java/com/steve1316/uma_android_automation/bot/RacingDecisionTest.kt
@@ -12,15 +12,6 @@ import org.junit.jupiter.api.Test
 @DisplayName("Racing decision helpers")
 class RacingDecisionTest {
     @Test
-    @DisplayName("Extra-racing energy gate blocks below the floor, allows at or above, and is disabled at 0")
-    fun testHasEnoughEnergyForExtraRacing() {
-        assertFalse(hasEnoughEnergyForExtraRacing(energy = 25, minEnergy = 30), "25% energy is below the 30% floor, so the fan-farming race should be skipped")
-        assertTrue(hasEnoughEnergyForExtraRacing(energy = 30, minEnergy = 30), "Exactly the floor is enough energy to race")
-        assertTrue(hasEnoughEnergyForExtraRacing(energy = 45, minEnergy = 30), "Above the floor is enough energy to race")
-        assertTrue(hasEnoughEnergyForExtraRacing(energy = 0, minEnergy = 0), "A floor of 0 disables the check entirely")
-    }
-
-    @Test
     @DisplayName("Any mandatory career goal always uses standard racing across every settings configuration")
     fun testMandatoryRequirementAlwaysUsesStandardRacing() {
         // Regression guard for the Senior-year trophy failure: a fan, trophy, or goal-pts requirement must never

--- a/src/context/BotStateContext.tsx
+++ b/src/context/BotStateContext.tsx
@@ -53,9 +53,7 @@ export interface Settings {
 
     // Racing settings
     racing: {
-        enableFarmingFans: boolean
         ignoreConsecutiveRaceWarning: boolean
-        daysToRunExtraRaces: number
         minEnergyForExtraRacing: number
         disableRaceRetries: boolean
         enableFreeRaceRetry: boolean
@@ -283,9 +281,7 @@ export const defaultSettings: Settings = {
         dialogWaitDelay: 0.5,
     },
     racing: {
-        enableFarmingFans: false,
         ignoreConsecutiveRaceWarning: false,
-        daysToRunExtraRaces: 5,
         minEnergyForExtraRacing: 30,
         disableRaceRetries: false,
         enableFreeRaceRetry: false,

--- a/src/context/searchConfig.ts
+++ b/src/context/searchConfig.ts
@@ -407,25 +407,6 @@ const searchConfig: SearchOption[] = [
     // Racing Settings
     // ============================================================
     {
-        id: "enable-farming-fans",
-        title: "Enable Farming Fans",
-        description: "When enabled, the bot will start running extra races to gain fans.",
-        page: "RacingSettings",
-    },
-    {
-        id: "days-to-run-extra-races",
-        title: "Days to Run Extra Races",
-        description: "Extra races are eligible only on days where current day % value == 0. For example, 5 means days 5, 10, 15, etc. Has no effect when Smart Race Solver is enabled.",
-        page: "RacingSettings",
-    },
-    {
-        id: "min-energy-for-extra-racing",
-        title: "Minimum Energy for Extra Races",
-        description:
-            "Skip the fan-farming extra race when energy is below this percentage. 0 disables the floor. Only gates the standard fan-farming cadence, never mandatory, scheduled, or solver races.",
-        page: "RacingSettings",
-    },
-    {
         id: "enable-g1-day-preference",
         title: "Prefer Training on G1 Days",
         description: "On a G1 race day (Classic/Senior years), peek at the trainings first and stay to train when a strong rainbow training is available instead of taking the race.",
@@ -435,6 +416,13 @@ const searchConfig: SearchOption[] = [
         id: "g1-day-min-rainbow-count",
         title: "Minimum Rainbows to Train Over G1",
         description: "The best training must have at least this many rainbow supports to train instead of racing the G1.",
+        page: "RacingSettings",
+        parentId: "enable-g1-day-preference",
+    },
+    {
+        id: "min-energy-for-g1-prescreen",
+        title: "Minimum Energy for G1 Pre-Screen",
+        description: "Skip the training peek and take the G1 race when energy is below this percentage. 0 disables the floor so the peek always runs.",
         page: "RacingSettings",
         parentId: "enable-g1-day-preference",
     },
@@ -545,7 +533,7 @@ const searchConfig: SearchOption[] = [
         id: "enable-user-in-game-race-agenda",
         title: "Enable User In-Game Race Agenda",
         description:
-            "When enabled, the bot will load your selected in-game race agenda instead of using the racing plan settings. Note that this will disable the farming fans and racing plan settings.",
+            "When enabled, the bot will load your selected in-game race agenda and race the turns it lists. Note that this will turn off the Smart Race Solver, since the two cannot both own the racing schedule.",
         page: "RacingSettings",
     },
     {

--- a/src/lib/messageLog/buildSettingsBanner.ts
+++ b/src/lib/messageLog/buildSettingsBanner.ts
@@ -159,9 +159,6 @@ ${mediumTargetsString}
 ${longTargetsString}${formatAdvancedScoringSection(settings.training)}
 
 ---------- Racing Options ----------
-👥 Prioritize Farming Fans: ${settings.racing.enableFarmingFans ? "✅" : "❌"}
-⏰ Modulo Days to Farm Fans: ${settings.racing.enableFarmingFans ? `${settings.racing.daysToRunExtraRaces} days` : "❌"}
-🔋 Minimum Energy for Extra Races: ${settings.racing.minEnergyForExtraRacing > 0 ? `${settings.racing.minEnergyForExtraRacing}%` : "❌"}
 🚫 Ignore Consecutive Race Warning: ${settings.racing.ignoreConsecutiveRaceWarning ? "✅" : "❌"}
 🔄 Disable Race Retries: ${settings.racing.disableRaceRetries ? "✅" : "❌"}
 \t🔄 Allow Daily Free Race Retry: ${settings.racing.enableFreeRaceRetry ? "✅" : "❌"}
@@ -169,6 +166,7 @@ ${longTargetsString}${formatAdvancedScoringSection(settings.training)}
 🏁 Stop on Mandatory Race: ${settings.racing.enableStopOnMandatoryRaces ? "✅" : "❌"}
 🏃 Force Racing Every Day: ${settings.racing.enableForceRacing ? "✅" : "❌"}
 🌈 Prefer Training on G1 Days: ${settings.racing.enableG1DayPreference ? `✅ (>= ${settings.racing.g1DayMinRainbowCount} rainbows)` : "❌"}
+\t🔋 Minimum Energy for G1 Pre-Screen: ${settings.racing.minEnergyForExtraRacing > 0 ? `${settings.racing.minEnergyForExtraRacing}%` : "❌"}
 🏁 Enable User In-Game Race Agenda: ${settings.racing.enableUserInGameRaceAgenda ? "✅" : "❌"}
 🏁 Limit Extra Races to Agenda: ${settings.racing.limitRacesToInGameAgenda ? "✅" : "❌"}
 🏁 Skip Summer Training for Agenda: ${settings.racing.skipSummerTrainingForAgenda ? "✅" : "❌"}

--- a/src/lib/settingsUtils.ts
+++ b/src/lib/settingsUtils.ts
@@ -192,6 +192,17 @@ export const applyMigrations = (settings: any, rawSettings?: any): { settings: a
         markMigrated("Dropped removed setting enablePopupCheck.")
     }
 
+    // Migration: Drop the removed fan-farming cadence settings. The Smart Race Solver is now the only source of discretionary extra races.
+    const racing = migratedSettings.racing as any
+    if (racing?.enableFarmingFans !== undefined) {
+        delete racing.enableFarmingFans
+        markMigrated("Dropped removed setting enableFarmingFans.")
+    }
+    if (racing?.daysToRunExtraRaces !== undefined) {
+        delete racing.daysToRunExtraRaces
+        markMigrated("Dropped removed setting daysToRunExtraRaces.")
+    }
+
     // Migration: Rename the Crane Game setting to Claw Machine.
     if (general?.enableCraneGameAttempt !== undefined) {
         migratedSettings.general.enableClawMachineAttempt = general.enableCraneGameAttempt

--- a/src/lib/solver/constants.ts
+++ b/src/lib/solver/constants.ts
@@ -24,7 +24,7 @@ export interface RaceEntry {
     distanceType: string
     /** Race distance in meters (e.g. 1600, 2400). */
     distanceMeters: number
-    /** Fans rewarded for winning, used by the Farming Fans flow. */
+    /** Fans rewarded for winning, weighted by the solver's `fanWeight`. */
     fans: number
     /** Race-track venue name (e.g. "Tokyo", "Hanshin"). */
     raceTrack: string

--- a/src/pages/RacingSettings/index.tsx
+++ b/src/pages/RacingSettings/index.tsx
@@ -43,7 +43,7 @@ type PerDistanceKey = "Short" | "Mile" | "Medium" | "Long"
 
 /**
  * The Racing Settings page.
- * Provides configuration for fan farming, race behavior, race strategies, force racing, and in-game race agenda.
+ * Provides configuration for race behavior, race strategies, force racing, and in-game race agenda.
  */
 const RacingSettings = () => {
     usePerformanceLogging("RacingSettings")
@@ -62,9 +62,7 @@ const RacingSettings = () => {
     // Merge current racing settings with defaults to handle missing properties.
     const racingSettings = { ...defaultSettings.racing, ...racing }
     const {
-        enableFarmingFans,
         ignoreConsecutiveRaceWarning,
-        daysToRunExtraRaces,
         minEnergyForExtraRacing,
         disableRaceRetries,
         enableFreeRaceRetry,
@@ -86,7 +84,7 @@ const RacingSettings = () => {
 
     /**
      * Update a racing setting with special handling for the in-game race agenda.
-     * When the in-game race agenda is enabled, it automatically disables the Farming Fans and Smart Race Solver settings to prevent conflicts.
+     * When the in-game race agenda is enabled, it automatically disables the Smart Race Solver setting to prevent conflicts.
      * @param key The key of the setting to update.
      * @param value The value to set the setting to.
      */
@@ -94,9 +92,8 @@ const RacingSettings = () => {
         (key: keyof Settings["racing"], value: any) => {
             if (key === "enableUserInGameRaceAgenda" && value) {
                 updateRacing((prev) => ({
-                    // Disable Farming Fans and the Smart Race Solver when User In Game Race Agenda is enabled.
+                    // Disable the Smart Race Solver when User In Game Race Agenda is enabled.
                     ...prev,
-                    enableFarmingFans: false,
                     enableUserInGameRaceAgenda: true,
                     enableSmartRaceSolver: false,
                 }))
@@ -176,43 +173,6 @@ const RacingSettings = () => {
                             Race Behavior */}
                         <Section label="Race Behavior">
                             <ToggleSetting
-                                id="enable-farming-fans"
-                                title="Enable Farming Fans"
-                                description="When enabled, the bot will start running extra races to gain fans."
-                                checked={enableFarmingFans}
-                                onCheckedChange={(checked) => updateRacingSetting("enableFarmingFans", checked)}
-                            />
-                            <View style={{ padding: SPACING.md }}>
-                                <CustomSlider
-                                    searchId="days-to-run-extra-races"
-                                    value={daysToRunExtraRaces}
-                                    placeholder={defaultSettings.racing.daysToRunExtraRaces}
-                                    onValueChange={(value) => updateRacingSetting("daysToRunExtraRaces", value)}
-                                    min={1}
-                                    max={15}
-                                    step={1}
-                                    label="Days to Run Extra Races"
-                                    showValue={true}
-                                    showLabels={true}
-                                    description="Extra races are eligible only on days where current day % value == 0. For example, 5 means days 5, 10, 15, etc. Has no effect when Smart Race Solver is enabled."
-                                />
-                            </View>
-                            <View style={{ padding: SPACING.md }}>
-                                <CustomSlider
-                                    searchId="min-energy-for-extra-racing"
-                                    value={minEnergyForExtraRacing}
-                                    placeholder={defaultSettings.racing.minEnergyForExtraRacing}
-                                    onValueChange={(value) => updateRacingSetting("minEnergyForExtraRacing", value)}
-                                    min={0}
-                                    max={100}
-                                    step={5}
-                                    label="Minimum Energy for Extra Races"
-                                    showValue={true}
-                                    showLabels={true}
-                                    description="Skip the fan-farming extra race when energy is below this percentage. 0 disables the floor. Only gates the standard fan-farming cadence, never mandatory, scheduled, or solver races."
-                                />
-                            </View>
-                            <ToggleSetting
                                 id="ignore-consecutive-race-warning"
                                 title="Ignore Consecutive Race Warning"
                                 description="When enabled, the bot will ignore the warning popup about consecutive races and continue racing."
@@ -278,6 +238,19 @@ const RacingSettings = () => {
                                         showValue={true}
                                         showLabels={true}
                                         description="The best training must have at least this many rainbow supports to train instead of racing the G1."
+                                    />
+                                    <CustomSlider
+                                        searchId="min-energy-for-g1-prescreen"
+                                        value={minEnergyForExtraRacing}
+                                        placeholder={defaultSettings.racing.minEnergyForExtraRacing}
+                                        onValueChange={(value) => updateRacingSetting("minEnergyForExtraRacing", value)}
+                                        min={0}
+                                        max={100}
+                                        step={5}
+                                        label="Minimum Energy for G1 Pre-Screen"
+                                        showValue={true}
+                                        showLabels={true}
+                                        description="Skip the training peek and take the G1 race when energy is below this percentage. 0 disables the floor so the peek always runs."
                                     />
                                 </View>
                             )}
@@ -384,7 +357,7 @@ const RacingSettings = () => {
                             <ToggleSetting
                                 id="enable-user-in-game-race-agenda"
                                 title="Enable User In-Game Race Agenda"
-                                description="When enabled, the bot will load your selected in-game race agenda instead of using the racing plan settings. Note that this will disable the farming fans and racing plan settings."
+                                description="When enabled, the bot will load your selected in-game race agenda and race the turns it lists. Note that this will turn off the Smart Race Solver, since the two cannot both own the racing schedule."
                                 checked={enableUserInGameRaceAgenda}
                                 onCheckedChange={(checked) => updateRacingSetting("enableUserInGameRaceAgenda", checked)}
                             />

--- a/src/pages/Schedule/RaceSolverTab.tsx
+++ b/src/pages/Schedule/RaceSolverTab.tsx
@@ -14,6 +14,7 @@ import SearchableItem from "../../components/SearchableItem"
 import ToggleSetting from "../../components/ToggleSetting"
 import CustomSlider from "../../components/CustomSlider"
 import { AptitudeRow, EpithetChip } from "./components/Helpers"
+import RacingOverrideChips from "./components/RacingOverrideChips"
 import { isEpithetAllowed } from "./raceEditing"
 import { Trash2 } from "lucide-react-native"
 import { Section } from "../../components/ui/section"
@@ -382,6 +383,8 @@ function RaceSolverTab() {
                     />
                 </SearchableItem>
 
+                <RacingOverrideChips racing={racingSettings} />
+
                 <SearchableItem
                     id="smart-solver-how-it-works"
                     condition={enableSmartRaceSolver}
@@ -393,8 +396,16 @@ function RaceSolverTab() {
                         <InfoCallout title="How the solver works">
                             <SubTopic title="How it works">
                                 The solver searches the entire 72-turn career and picks, for every turn, the best decision (Race / Train / Rest) that maximizes your projected score against the target
-                                epithet rewards. The bot only races on the turns the solver has chosen in the calculated schedule - every other turn becomes training or rest, even when Farming Fans
-                                would otherwise add an extra race. Hard goal requirements (fan / trophy / goal-points) and the Force Racing setting are the only things that can override the schedule.
+                                epithet rewards. The bot only races on the turns the solver has chosen in the calculated schedule - every other turn becomes training or rest. Hard goal requirements
+                                (fan / trophy / goal-points) always take priority over the schedule, and several Racing settings can override it too - see below.
+                            </SubTopic>
+                            <SubTopic title="Racing settings that override the solver">
+                                Some settings on the Racing Settings page are checked before the solver's schedule is, so they can change or skip what it planned. Any that are currently on appear as
+                                chips under the toggle above, and tapping one jumps straight to it. "Force Racing" and "Enable User In-Game Race Agenda" disable the solver outright - the bot races
+                                every turn or follows your in-game agenda instead of the schedule. "Prefer Training on G1 Days" peeks at the trainings first and will train through a G1 the solver
+                                planned to race. "Stop on Mandatory Races" halts the bot at every mandatory race, so the schedule pauses until you resume it, and "Disable Race Retries" ends the career
+                                on a failed mandatory race, so the rest of the schedule never runs. "Ignore Consecutive Race Warning" is the mildest - the solver's own picks already bypass that popup,
+                                but leaving it off can cost the turn right after one appears.
                             </SubTopic>
                             <SubTopic title="What happens when you lose a race">
                                 A loss is recorded against that turn and the solver immediately re-plans the remaining turns. Epithets that depended on the lost race may shift to alternative paths or

--- a/src/pages/Schedule/__tests__/racingOverrideChips.test.tsx
+++ b/src/pages/Schedule/__tests__/racingOverrideChips.test.tsx
@@ -1,0 +1,23 @@
+import { RACING_OVERRIDES } from "../components/RacingOverrideChips"
+import searchConfig from "../../../context/searchConfig"
+import { defaultSettings } from "../../../context/BotStateContext"
+
+describe("RACING_OVERRIDES", () => {
+    it("every targetId points at a real Racing Settings search entry", () => {
+        const racingIds = new Set(searchConfig.filter((item) => item.page === "RacingSettings").map((item) => item.id))
+        const dangling = RACING_OVERRIDES.filter((override) => !racingIds.has(override.targetId)).map((override) => `${override.label} -> "${override.targetId}"`)
+        expect(dangling).toEqual([])
+    })
+
+    it("every key is a real racing setting that defaults to off", () => {
+        for (const override of RACING_OVERRIDES) {
+            expect(defaultSettings.racing).toHaveProperty(override.key)
+            expect(defaultSettings.racing[override.key]).toBe(false)
+        }
+    })
+
+    it("has no duplicate keys or labels", () => {
+        expect(new Set(RACING_OVERRIDES.map((override) => override.key)).size).toBe(RACING_OVERRIDES.length)
+        expect(new Set(RACING_OVERRIDES.map((override) => override.label)).size).toBe(RACING_OVERRIDES.length)
+    })
+})

--- a/src/pages/Schedule/components/RacingOverrideChips.tsx
+++ b/src/pages/Schedule/components/RacingOverrideChips.tsx
@@ -1,0 +1,98 @@
+import { memo, useMemo } from "react"
+import { View, Text, StyleSheet } from "react-native"
+import { useNavigation, CommonActions } from "@react-navigation/native"
+import { Dumbbell, ListChecks, OctagonX, Repeat, RotateCcw, Zap } from "lucide-react-native"
+import type { LucideIcon } from "lucide-react-native"
+import { useTheme } from "../../../context/ThemeContext"
+import { Settings } from "../../../context/BotStateContext"
+import { TintedChip } from "../../../components/ui/tinted-chip"
+import { SPACING } from "../../../lib/spacing"
+import { TYPE } from "../../../lib/type"
+
+/** How badly an override interferes with the solver: `critical` stops it from running at all, `warning` drops individual races, `info` is advisory. */
+type OverrideSeverity = "critical" | "warning" | "info"
+
+/** One Racing setting that changes how the Smart Race Solver behaves at runtime. */
+interface RacingOverride {
+    /** Key in the racing settings slice whose truthiness arms this chip. */
+    key: keyof Settings["racing"]
+    /** Uppercase mono label shown in the chip. */
+    label: string
+    /** Lucide icon rendered ahead of the label. */
+    icon: LucideIcon
+    /** Drives the chip tint. */
+    severity: OverrideSeverity
+    /** `SearchableItem` id on the Racing Settings page that the chip deep-links to. */
+    targetId: string
+}
+
+/**
+ * The Racing Settings toggles that override or perturb the solver, ordered by how much damage they do. Each one is checked in the bot before the solver's
+ * schedule is consulted, so an armed chip means the calculated schedule will not execute exactly as the calendar shows it.
+ */
+export const RACING_OVERRIDES: RacingOverride[] = [
+    { key: "enableForceRacing", label: "Force Racing", icon: Zap, severity: "critical", targetId: "enable-force-racing" },
+    { key: "enableUserInGameRaceAgenda", label: "In-Game Agenda", icon: ListChecks, severity: "critical", targetId: "enable-user-in-game-race-agenda" },
+    { key: "enableG1DayPreference", label: "G1 Training", icon: Dumbbell, severity: "warning", targetId: "enable-g1-day-preference" },
+    { key: "enableStopOnMandatoryRaces", label: "Stop on Mandatory", icon: OctagonX, severity: "warning", targetId: "enable-stop-on-mandatory-races" },
+    { key: "disableRaceRetries", label: "No Race Retries", icon: RotateCcw, severity: "warning", targetId: "disable-race-retries" },
+    { key: "ignoreConsecutiveRaceWarning", label: "Consecutive OK", icon: Repeat, severity: "info", targetId: "ignore-consecutive-race-warning" },
+]
+
+/** Props for `RacingOverrideChips`. */
+export interface RacingOverrideChipsProps {
+    /** The merged racing settings slice, used to decide which chips are armed. */
+    racing: Settings["racing"]
+}
+
+/**
+ * A wrapping row of chips naming the Racing Settings that are currently overriding the Smart Race Solver. Renders nothing when none are on. Each chip
+ * deep-links to the setting that armed it, and is tinted by how much it interferes: red kills the solver outright, amber drops individual races, muted is advisory.
+ * @param racing The merged racing settings slice.
+ * @returns The chip row, or null when no override is active.
+ */
+function RacingOverrideChips({ racing }: RacingOverrideChipsProps) {
+    const { colors } = useTheme()
+    const navigation = useNavigation()
+
+    // Severity is a fixed three-way scale, so resolve it against the theme here rather than baking colors into the module-level table.
+    const { styles, tints } = useMemo(
+        () => ({
+            styles: StyleSheet.create({
+                container: { paddingHorizontal: SPACING.md, paddingBottom: SPACING.md, gap: SPACING.sm },
+                caption: { ...TYPE.caption, color: colors.textMuted },
+                row: { flexDirection: "row", flexWrap: "wrap", gap: SPACING.xs },
+            }),
+            tints: { critical: colors.error, warning: colors.warning, info: colors.textMuted } as Record<OverrideSeverity, string>,
+        }),
+        [colors]
+    )
+
+    // Built once so each chip keeps a stable onPress and TintedChip's memo can bail out instead of re-rendering every chip on every parent render.
+    const handlers = useMemo(
+        () => new Map(RACING_OVERRIDES.map((override) => [override.key, () => navigation.dispatch(CommonActions.navigate({ name: "RacingSettings", params: { targetId: override.targetId } }))])),
+        [navigation]
+    )
+
+    // An override only means anything while the solver owns the schedule, so the "solver is off" case is this component's own invariant rather than the caller's.
+    const active = racing.enableSmartRaceSolver ? RACING_OVERRIDES.filter((override) => Boolean(racing[override.key])) : []
+    if (active.length === 0) return null
+
+    return (
+        <View style={styles.container}>
+            <Text style={styles.caption}>These Racing settings change how the solver runs:</Text>
+            <View style={styles.row}>
+                {active.map((override) => (
+                    <TintedChip key={override.key} icon={override.icon} label={override.label} tint={tints[override.severity]} onPress={handlers.get(override.key)} />
+                ))}
+            </View>
+        </View>
+    )
+}
+
+// `racing` is the whole racing slice, so it changes identity on any racing write - including the solver weights and epithet edits on this very tab. Compare only the
+// handful of fields this component reads so those edits skip the subtree entirely.
+export default memo(
+    RacingOverrideChips,
+    (prev, next) => prev.racing.enableSmartRaceSolver === next.racing.enableSmartRaceSolver && RACING_OVERRIDES.every((override) => prev.racing[override.key] === next.racing[override.key])
+)


### PR DESCRIPTION
## Description

- This PR removes the `Enable Farming Fans` and `Days to Run Extra Races` settings from the `Racing Settings` page. They had no effect whenever `Smart Race Solver` was enabled, since the solver's schedule was always consulted first, so the `Smart Race Solver` is now the only thing that schedules discretionary extra races.
- `Minimum Energy for Extra Races` is kept but renamed to `Minimum Energy for G1 Pre-Screen` and moved under `Prefer Training on G1 Days`, which is the only thing that was actually still reading it. Your saved value carries over.
- With the `Smart Race Solver` turned off, the bot no longer runs filler extra races - mandatory, maiden, scheduled, goal-requirement, and `Force Racing` entries all behave exactly as before.
- The Race Solver tab now shows a row of tappable chips naming any `Racing Settings` that are currently overriding the solver, colored by how much they interfere: red for `Force Racing` and `Enable User In-Game Race Agenda` (which switch the solver off entirely), amber for `Prefer Training on G1 Days`, `Stop on Mandatory Races` and `Disable Race Retries`, and grey for `Ignore Consecutive Race Warning`. Tapping a chip jumps straight to that setting.
- Also drops a per-turn OCR call that was only feeding a log line, and cleans the two removed keys out of previously saved settings so they stop being rewritten on every save.
