### PR TITLE
Fix the trainee name read and the log download filename

### DIFF
--- a/android/app/src/main/java/com/steve1316/uma_android_automation/types/Trainee.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/types/Trainee.kt
@@ -637,14 +637,15 @@ class Trainee {
         // Extract reference point coordinates from cached location or find it if not available.
         val refPoint = statTrackLocation ?: LabelStatTrackSurface.find(imageUtils = imageUtils).first
         if (refPoint == null) {
-            name = "null"
+            // Leave the name empty so the caller's isEmpty() guard retries next time. A placeholder here would block every later attempt.
+            MessageLog.w(TAG, "[WARN] readName:: Could not find the stat track surface label to anchor the name crop.")
             return
         }
 
         // Extract the coordinates from the reference point and cache the location.
         val refX = refPoint.x.toDouble()
         val refY = refPoint.y.toDouble()
-        if (statTrackLocation == null && refPoint != null) {
+        if (statTrackLocation == null) {
             statTrackLocation = refPoint
         }
 

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/utils/LogStreamServer.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/utils/LogStreamServer.kt
@@ -1188,19 +1188,14 @@ object LogStreamServer {
                             try {
                                 val fullLogs = MessageLog.getMessageLogCopy().joinToString("\n")
 
-                                // Set headers to trigger a file download in the browser.
-                                val datePart =
-                                    SimpleDateFormat(
-                                        "yyyy-MM-dd-HH-mm-ss",
-                                        Locale.getDefault(),
-                                    ).format(Date())
-
-                                // Prefix the download with the scraped trainee name (falling back to "uaa" before one is read),
-                                // matching how saved log files are named. MessageLog.logFileNamePrefix holds the underscore-joined name.
-                                val namePart = MessageLog.logFileNamePrefix.ifEmpty { "uaa" }
+                                // Name the download exactly like a saved log file, stamp and no-name form alike, so the Event Log Visualizer reads
+                                // the trainee back instead of treating the fallback as a name. Mirrors MessageLog.saveLogToFile().
+                                val datePart = SimpleDateFormat("yyyy-MM-dd HH_mm_ss", Locale.getDefault()).format(Date())
+                                val prefix = MessageLog.logFileNamePrefix
+                                val fileName = if (prefix.isEmpty()) "log @ $datePart" else "${prefix}_$datePart"
                                 call.response.header(
                                     HttpHeaders.ContentDisposition,
-                                    "attachment; filename=\"${namePart}_logs_$datePart.txt\"",
+                                    "attachment; filename=\"$fileName.txt\"",
                                 )
                                 call.respondText(fullLogs, ContentType.Text.Plain)
                             } catch (e: Exception) {


### PR DESCRIPTION
## Description

- This PR lets the trainee name be re-read on a later turn when the first attempt cannot find its anchor, instead of caching a placeholder that blocked every later attempt.
- Names the downloaded log file the same way saved log files are named, so the `Event Log Visualizer` reads the trainee back instead of treating the fallback as a name.
