### PR TITLE
Rank Grand Live Lessons by priority order instead of summed weights

### DIFF
--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/GrandLive.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/GrandLive.kt
@@ -11,17 +11,17 @@ import com.steve1316.uma_android_automation.components.ButtonCancel
 import com.steve1316.uma_android_automation.components.ButtonCareerEndSkillsMini
 import com.steve1316.uma_android_automation.components.ButtonClose
 import com.steve1316.uma_android_automation.components.ButtonCompleteCareer
-import com.steve1316.uma_android_automation.components.ButtonLearn
 import com.steve1316.uma_android_automation.components.ButtonGrandLiveConcert
 import com.steve1316.uma_android_automation.components.ButtonGrandLiveGrandConcert
+import com.steve1316.uma_android_automation.components.ButtonGrandLiveLessons
 import com.steve1316.uma_android_automation.components.ButtonGrandLiveLessonsBig
 import com.steve1316.uma_android_automation.components.ButtonGrandLiveStart
 import com.steve1316.uma_android_automation.components.ButtonInfirmaryMini
-import com.steve1316.uma_android_automation.components.ButtonGrandLiveLessons
+import com.steve1316.uma_android_automation.components.ButtonLearn
+import com.steve1316.uma_android_automation.components.ButtonNext
 import com.steve1316.uma_android_automation.components.ButtonRaceDayMini
 import com.steve1316.uma_android_automation.components.ButtonRacesMini
 import com.steve1316.uma_android_automation.components.ButtonRecreationMini
-import com.steve1316.uma_android_automation.components.ButtonNext
 import com.steve1316.uma_android_automation.components.ButtonSkip
 import com.steve1316.uma_android_automation.components.Checkbox
 import com.steve1316.uma_android_automation.components.ComponentInterface
@@ -237,6 +237,11 @@ class GrandLive(game: Game) : Campaign(game) {
      * @return True when the per-turn Lessons side-action should run.
      */
     private fun shouldOpenLessonsThisTurn(): Boolean {
+        // A misread date can land ahead of the real turn, which would otherwise hold the interval closed for as many turns as the date overshot.
+        if (lastLessonScanDay > date.day) {
+            MessageLog.i(TAG, "[GRAND_LIVE] Last Lessons scan is dated after the current turn (day ${date.day} < $lastLessonScanDay); re-checking now.")
+            lastLessonScanDay = -1
+        }
         if (lastLessonScanDay >= 0 && date.day - lastLessonScanDay < lessonRescanInterval) {
             MessageLog.i(TAG, "[GRAND_LIVE] Skipping Lessons: re-checked recently, next poll in ${lessonRescanInterval - (date.day - lastLessonScanDay)} turn(s).")
             return false
@@ -298,12 +303,12 @@ class GrandLive(game: Game) : Campaign(game) {
 
             val confirmSource = game.imageUtils.getSourceBitmap()
 
-            // For an Energy card away from the final concert, read the dialog's printed "<new> / 100" and cancel if it would cap out (wasted energy).
+            // For an Energy card away from the final concert, read the dialog's printed "<new> / <cap>" and cancel if it would cap out (wasted energy).
             // Reading the dialog avoids relying on the trainee's energy, which is unknown when the bot is started straight on a concert screen.
             if (!isFinalConcert && parseEnergyGain(choice.effectText) != null) {
                 val projected = readDialogProjectedEnergy(confirmSource)
-                if (projected != null && projected >= 100) {
-                    MessageLog.i(TAG, "[GRAND_LIVE] Skipping '${choice.name}': projected energy ${projected}/100 would overflow.")
+                if (projected != null && projected.first >= projected.second) {
+                    MessageLog.i(TAG, "[GRAND_LIVE] Skipping '${choice.name}': projected energy ${projected.first}/${projected.second} would overflow.")
                     ButtonCancel.click(game.imageUtils, sourceBitmap = confirmSource, tries = 5)
                     skippedEnergyCards.add(choice.name)
                     game.wait(game.dialogWaitDelay)
@@ -399,7 +404,10 @@ class GrandLive(game: Game) : Campaign(game) {
         if (anchors.isEmpty()) {
             // Probe a looser confidence so the log tells us whether the anchor is a threshold miss (loose > 0 -> lower the confidence) or a crop mismatch (loose == 0 -> recrop grandlive_performance_point_cost).
             val loose = LabelGrandLiveLessonCost.findAll(game.imageUtils, sourceBitmap = sourceBitmap, confidence = 0.7).size
-            MessageLog.i(TAG, "[GRAND_LIVE] Lessons scan: no cost-pill anchors at default confidence ($loose at 0.7). If >0, the crop matches but the threshold is too strict; if 0, recrop grandlive_performance_point_cost.")
+            MessageLog.i(
+                TAG,
+                "[GRAND_LIVE] Lessons scan: no cost-pill anchors at default confidence ($loose at 0.7). If >0, the crop matches but the threshold is too strict; if 0, recrop grandlive_performance_point_cost.",
+            )
             // Dump the exact frame the scan ran against (debug mode only) so the actual Lessons screen can be inspected.
             game.imageUtils.saveDebugScreenshot(sourceBitmap, "grandlive_lessons_scan_empty")
             return emptyList()
@@ -486,13 +494,13 @@ class GrandLive(game: Game) : Campaign(game) {
     }
 
     /**
-     * Read the projected new energy the Lessons purchase confirmation prints as "<new> / 100" above its energy bar. Used to cancel an
+     * Read the projected new energy the Lessons purchase confirmation prints as "<new> / <cap>" above its energy bar. Used to cancel an
      * Energy purchase that would cap out. Reads the dialog rather than the trainee's energy, which is unknown when the bot starts on a concert screen.
      *
      * @param sourceBitmap The confirmation-dialog screenshot.
-     * @return The projected new energy (0-100), or null when the readout could not be parsed.
+     * @return The projected new energy and the cap it was read against, or null when the readout could not be parsed.
      */
-    private fun readDialogProjectedEnergy(sourceBitmap: Bitmap): Int? {
+    private fun readDialogProjectedEnergy(sourceBitmap: Bitmap): Pair<Int, Int>? {
         val text =
             game.imageUtils.performOCROnRegion(
                 sourceBitmap,
@@ -507,7 +515,12 @@ class GrandLive(game: Game) : Campaign(game) {
                 debugName = "grandlive_lesson_projected_energy",
             )
         val projected = parseProjectedEnergy(text)
-        MessageLog.i(TAG, "[GRAND_LIVE] Projected-energy readout OCR'd as \"$text\" -> ${projected ?: "unparsed"}.")
+        if (projected == null) {
+            // Worth a warning: an unparsed readout disables the overflow check for this purchase, so energy can silently be wasted.
+            MessageLog.w(TAG, "[GRAND_LIVE] Projected-energy readout OCR'd as \"$text\" -> unparsed; buying without the overflow check.")
+        } else {
+            MessageLog.i(TAG, "[GRAND_LIVE] Projected-energy readout OCR'd as \"$text\" -> ${projected.first}/${projected.second}.")
+        }
         return projected
     }
 

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/GrandLiveLessons.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/GrandLiveLessons.kt
@@ -103,18 +103,40 @@ const val MAX_LESSON_PURCHASES_PER_VISIT = 20
 /** A locked card counts as "sought after" (worth holding tokens for) when it matches a category ranked within this many top spots of the user's priority order. */
 private const val SOUGHT_AFTER_TOP_RANKS = 2
 
-/** Tie-break nudge so a Technique is preferred over a Song of equal effect value (technique-priority). */
-private const val TECHNIQUE_BONUS = 0.5
-
 /** Matches a raw stat-gain effect that leads with the stat (e.g. "Speed +5"), distinguishing it from passives like "Training Power Gain +1". */
 private val RAW_STAT_GAIN_REGEX = Regex("^\\s*(speed|stamina|power|guts|wit)\\s*\\+?\\s*(\\d+)", RegexOption.IGNORE_CASE)
+
+/**
+ * The greyed-out warning the game overlays on a Song's effect line once the concert has passed. The effect crop picks it up instead of (or
+ * appended to) the real effect, so it is stripped before the text is parsed. The leading "O" is the bullet glyph as ML Kit reads it.
+ */
+private val CONCERT_OVER_OVERLAY_REGEX = Regex("O?\\s*This bonus won't take effect.*", RegexOption.IGNORE_CASE)
+
+/** Matches an effect line that OCR'd down to a bare percentage ("+10%"), losing the "Friendship Training Effectiveness" label in front of it. */
+private val BARE_PERCENT_REGEX = Regex("(^|\\s)\\+\\s*\\d+\\s*%", RegexOption.IGNORE_CASE)
+
+/**
+ * Smallest raw stat gain that only ever appears on a Friendship Training Effectiveness Song. Techniques top out well below this, so a card
+ * leading with a gain this large is a Training Effectiveness Song even when OCR lost the label.
+ */
+private const val TRAINING_EFFECTIVENESS_STAT_FLOOR = 20
+
+/** Matches an Energy gain effect (e.g. "Energy +20"). */
+private val ENERGY_GAIN_REGEX = Regex("energy\\s*\\+\\s*(\\d+)", RegexOption.IGNORE_CASE)
+
+/**
+ * Matches the resulting-energy readout on the Lessons purchase confirmation ("78 / 100"), capturing both the projected new energy and the
+ * cap. The cap is captured rather than hardcoded because OCR misreads it often enough to matter (a "100" read as "104" used to make the
+ * whole readout unparseable, which silently disabled the overflow guard).
+ */
+private val PROJECTED_ENERGY_REGEX = Regex("(\\d+)\\s*/\\s*(\\d+)")
 
 /** Kind of learnable item on the Grand Live Lessons screen. */
 enum class LessonKind { TECHNIQUE, SONG }
 
 /**
  * An effect category a Lessons card can match. The user ranks these via the Lesson Effect Priority setting (Scenario Overrides), and
- * purchases are ordered by that ranking. A category left out of the ranking scores zero, so it is only bought when nothing ranked is learnable.
+ * purchases are ordered by that ranking. A category left out of the ranking is ignored, so it is only bought when nothing ranked is learnable.
  *
  * @property displayName The user-facing name stored in the setting.
  */
@@ -166,21 +188,43 @@ data class LessonOption(
 )
 
 /**
+ * A card's effect text reduced to what the purchase ordering compares on.
+ *
+ * @property ranks The user-ranked positions of the categories the card matched, ascending, compared lexicographically.
+ * @property statTieBreak Value of the card's raw stat gain, higher is better, used only once [ranks] ties.
+ */
+private data class LessonEffectProfile(val ranks: List<Int>, val statTieBreak: Double)
+
+/**
+ * Strip the post-concert warning overlay the game paints over a Song's effect line. The effect crop reads it as trailing noise, which would
+ * otherwise mask the real effect.
+ *
+ * @param effectText The card's raw OCR'd effect line(s).
+ * @return The effect text with the overlay removed.
+ */
+private fun stripConcertOverOverlay(effectText: String): String = CONCERT_OVER_OVERLAY_REGEX.replace(effectText, "").trim()
+
+/**
  * Parse a raw stat-gain effect ("Speed +5") into its stat and amount. Passive effects that merely mention a stat
  * ("Training Power Gain +1") do not match, since the stat must lead the effect.
  *
  * @param effectText The card's effect line.
  * @return The (stat, amount) pair, or null when the effect is not a raw stat gain.
  */
-fun parseStatGain(effectText: String): Pair<StatName, Int>? {
-    val match = RAW_STAT_GAIN_REGEX.find(effectText.trim()) ?: return null
+fun parseStatGain(effectText: String): Pair<StatName, Int>? = parseStatGainIn(stripConcertOverOverlay(effectText))
+
+/**
+ * Parse a raw stat gain from text the overlay has already been stripped from, so a caller that cleans once does not pay for it again.
+ *
+ * @param cleaned The card's effect line(s), overlay already removed.
+ * @return The (stat, amount) pair, or null when the effect is not a raw stat gain.
+ */
+private fun parseStatGainIn(cleaned: String): Pair<StatName, Int>? {
+    val match = RAW_STAT_GAIN_REGEX.find(cleaned) ?: return null
     val stat = StatName.fromName(match.groupValues[1]) ?: return null
     val amount = match.groupValues[2].toIntOrNull() ?: return null
     return stat to amount
 }
-
-/** Matches an Energy gain effect (e.g. "Energy +20"). */
-private val ENERGY_GAIN_REGEX = Regex("energy\\s*\\+\\s*(\\d+)", RegexOption.IGNORE_CASE)
 
 /**
  * Parse an Energy gain effect ("Energy +20").
@@ -188,7 +232,7 @@ private val ENERGY_GAIN_REGEX = Regex("energy\\s*\\+\\s*(\\d+)", RegexOption.IGN
  * @param effectText The card's effect line(s).
  * @return The energy gain amount, or null when the card grants no energy.
  */
-fun parseEnergyGain(effectText: String): Int? = ENERGY_GAIN_REGEX.find(effectText)?.groupValues?.get(1)?.toIntOrNull()
+fun parseEnergyGain(effectText: String): Int? = ENERGY_GAIN_REGEX.find(stripConcertOverOverlay(effectText))?.groupValues?.get(1)?.toIntOrNull()
 
 /**
  * The running style named in a skill-hint effect (e.g. "Pace Chaser" in "Skill Hint Lvl +3 (Pace Chaser)"). Returns null for a
@@ -203,63 +247,108 @@ fun parseHintRunningStyle(effectText: String): RunningStyle? {
     return RunningStyle.entries.firstOrNull { style -> style.name.lowercase().split("_").all { it in t } }
 }
 
-/** Matches the resulting-energy readout on the Lessons purchase confirmation ("78 / 100"), capturing the projected new energy. */
-private val PROJECTED_ENERGY_REGEX = Regex("(\\d+)\\s*/\\s*100")
-
 /**
- * Parse the projected new energy the confirmation dialog prints as "<new> / 100" when buying an Energy card.
+ * Parse the projected new energy the confirmation dialog prints as "<new> / <cap>" when buying an Energy card.
  *
  * @param text The OCR'd text of the dialog's energy readout.
- * @return The projected new energy (0-100), or null when the readout could not be parsed.
+ * @return The projected new energy and the cap it was read against, or null when the readout could not be parsed.
  */
-fun parseProjectedEnergy(text: String): Int? = PROJECTED_ENERGY_REGEX.find(text)?.groupValues?.get(1)?.toIntOrNull()
+fun parseProjectedEnergy(text: String): Pair<Int, Int>? {
+    val match = PROJECTED_ENERGY_REGEX.find(text) ?: return null
+    val projected = match.groupValues[1].toIntOrNull() ?: return null
+    val cap = match.groupValues[2].toIntOrNull() ?: return null
+    return projected to cap
+}
 
 /**
  * Detect which effect categories a card's effect text matches. A card with two effect lines can match several.
  *
+ * Training Effectiveness is also inferred when OCR lost its label, which happens often enough to matter: the effect crop routinely reads
+ * the "+10%" cards down to a bare percentage, and the post-concert overlay can replace the line outright. A bare percentage and a raw stat
+ * gain at or above [TRAINING_EFFECTIVENESS_STAT_FLOOR] both only ever occur on these Songs, so either one stands in for the missing label.
+ *
  * @param effectText The card's effect line(s).
  * @return The matched categories (empty when nothing recognizable was read).
  */
-fun detectLessonCategories(effectText: String): Set<LessonEffectCategory> {
-    val t = effectText.lowercase()
+fun detectLessonCategories(effectText: String): Set<LessonEffectCategory> = detectLessonCategoriesIn(stripConcertOverOverlay(effectText))
+
+/**
+ * Match categories against text the overlay has already been stripped from, so a caller that cleans once does not pay for it again.
+ *
+ * @param cleaned The card's effect line(s), overlay already removed.
+ * @return The matched categories (empty when nothing recognizable was read).
+ */
+private fun detectLessonCategoriesIn(cleaned: String): Set<LessonEffectCategory> {
+    val t = cleaned.lowercase()
+    val statGain = parseStatGainIn(cleaned)
     val categories = mutableSetOf<LessonEffectCategory>()
-    if ("friendship" in t || "training effectiveness" in t) categories.add(LessonEffectCategory.TRAINING_EFFECTIVENESS)
+    val labelLost = BARE_PERCENT_REGEX.containsMatchIn(cleaned) || (statGain?.second ?: 0) >= TRAINING_EFFECTIVENESS_STAT_FLOOR
+    if ("friendship" in t || "training effectiveness" in t || labelLost) categories.add(LessonEffectCategory.TRAINING_EFFECTIVENESS)
     if ("training" in t && "gain" in t) categories.add(LessonEffectCategory.TRAINING_GAIN)
     if (("support" in t && "event" in t) || "specialty priority" in t) categories.add(LessonEffectCategory.SUPPORT_EVENTS)
-    if (parseStatGain(effectText) != null) categories.add(LessonEffectCategory.STAT_GAINS)
+    if (statGain != null) categories.add(LessonEffectCategory.STAT_GAINS)
     if ("hint" in t || "skill point" in t) categories.add(LessonEffectCategory.SKILL_HINTS)
-    if (parseEnergyGain(effectText) != null) categories.add(LessonEffectCategory.ENERGY)
+    if (ENERGY_GAIN_REGEX.containsMatchIn(cleaned)) categories.add(LessonEffectCategory.ENERGY)
     return categories
 }
 
 /**
- * Score a Lessons card by the user-ranked value of its matched effect categories, used to order purchases (the best affordable card is
- * bought first). Rank i of N ranked categories contributes N - i, and a card sums every category it matches, so multi-effect cards stack.
- * A Stat Gains match is additionally weighted by the stat's position in [statPriority] (a stat outside the list scores nothing) plus a
- * small nudge for the gain amount. Categories left out of [categoryOrder] contribute nothing.
+ * Reduce a Lessons card's effect text to everything the purchase ordering needs. Computed once per card so the comparator never re-parses.
+ *
+ * Categories left out of the ranking are dropped, as is a Stat Gains match whose stat is absent from the stat prioritization - such a card
+ * ranks below anything with a ranked effect, but is still bought when it is the only option.
  *
  * @param effectText The card's effect line(s).
  * @param statPriority The bot's ordered stat prioritization (index 0 = highest).
  * @param categoryOrder The user's ranked effect categories (index 0 = highest).
- * @return The additive effect value.
+ * @return The card's ranking profile.
  */
-fun scoreLessonEffect(effectText: String, statPriority: List<StatName>, categoryOrder: List<LessonEffectCategory> = DEFAULT_LESSON_EFFECT_PRIORITY): Double {
-    var score = 0.0
-    for (category in detectLessonCategories(effectText)) {
-        val rank = categoryOrder.indexOf(category)
-        if (rank < 0) continue
-        val weight = (categoryOrder.size - rank).toDouble()
-        score +=
-            if (category == LessonEffectCategory.STAT_GAINS) {
-                val (stat, amount) = parseStatGain(effectText)!!
-                val statRank = statPriority.indexOf(stat)
-                if (statRank >= 0 && statPriority.isNotEmpty()) weight * ((statPriority.size - statRank).toDouble() / statPriority.size) + amount * 0.01 else 0.0
-            } else {
-                weight
-            }
-    }
-    return score
+private fun profileLessonEffect(effectText: String, statPriority: List<StatName>, categoryOrder: List<LessonEffectCategory>): LessonEffectProfile {
+    val cleaned = stripConcertOverOverlay(effectText)
+    val statGain = parseStatGainIn(cleaned)
+    val statRank = statGain?.let { statPriority.indexOf(it.first) } ?: -1
+    val ranks =
+        detectLessonCategoriesIn(cleaned)
+            .filterNot { it == LessonEffectCategory.STAT_GAINS && statRank < 0 }
+            .mapNotNull { categoryOrder.indexOf(it).takeIf { rank -> rank >= 0 } }
+            .sorted()
+    val statTieBreak = if (statGain != null && statRank >= 0) (statPriority.size - statRank).toDouble() + statGain.second * 0.001 else 0.0
+    return LessonEffectProfile(ranks, statTieBreak)
 }
+
+/**
+ * Compare two cards' matched ranks. Element-wise, the lower rank wins. When one card's ranks are a prefix of the other's, the card
+ * matching more categories wins, so a strictly better card is never passed over.
+ *
+ * @param a The first card's ranks, ascending.
+ * @param b The second card's ranks, ascending.
+ * @return Negative when `a` ranks worse than `b`, positive when better, zero when equal.
+ */
+private fun compareLessonRanks(a: List<Int>, b: List<Int>): Int {
+    for (i in 0 until minOf(a.size, b.size)) {
+        if (a[i] != b[i]) return b[i] - a[i]
+    }
+    return a.size - b.size
+}
+
+/**
+ * Pick the best card, profiling each one exactly once. Category ranks decide first, then a Technique edges out a Song of equal effect
+ * value, then the better raw stat gain, and finally the earlier row.
+ *
+ * @param options The cards to choose between.
+ * @param statPriority The bot's ordered stat prioritization (index 0 = highest).
+ * @param categoryOrder The user's ranked effect categories (index 0 = highest).
+ * @return The best card, or null when `options` is empty.
+ */
+private fun bestLesson(options: List<LessonOption>, statPriority: List<StatName>, categoryOrder: List<LessonEffectCategory>): LessonOption? =
+    options
+        .map { it to profileLessonEffect(it.effectText, statPriority, categoryOrder) }
+        .maxWithOrNull(
+            Comparator<Pair<LessonOption, LessonEffectProfile>> { a, b -> compareLessonRanks(a.second.ranks, b.second.ranks) }
+                .thenBy { it.first.kind == LessonKind.TECHNIQUE }
+                .thenBy { it.second.statTieBreak }
+                .thenByDescending { it.first.rowIndex },
+        )?.first
 
 /**
  * Whether a card's effect is worth holding tokens for while it is locked: true when it matches a category ranked within the user's top
@@ -275,7 +364,7 @@ fun isSoughtAfter(effectText: String, categoryOrder: List<LessonEffectCategory>)
 /**
  * Choose the next Lessons purchase. We do not hoard tokens, so any affordable card is worth buying (spending tokens and refreshing
  * the static list to reveal new options). When `forceMaxHype` and Hype is not yet maxed, a Song is bought first (buying a Song raises the
- * Hype gauge). Otherwise the highest-scoring card wins - Techniques carry a small score bonus and ties break toward the earlier row.
+ * Hype gauge). Otherwise the best-ranked card wins - see [bestLesson] for the ordering.
  *
  * @param options The affordable, learnable items currently on screen.
  * @param statPriority The bot's ordered stat prioritization, used to value raw stat-gain techniques.
@@ -292,10 +381,9 @@ fun chooseLessonPurchase(
     categoryOrder: List<LessonEffectCategory> = DEFAULT_LESSON_EFFECT_PRIORITY,
 ): LessonOption? {
     if (forceMaxHype && !hypeMaxed) {
-        val hypeSong = options.filter { it.kind == LessonKind.SONG }.maxByOrNull { scoreLessonEffect(it.effectText, statPriority, categoryOrder) }
+        val hypeSong = bestLesson(options.filter { it.kind == LessonKind.SONG }, statPriority, categoryOrder)
         if (hypeSong != null) return hypeSong
     }
 
-    fun totalScore(option: LessonOption): Double = scoreLessonEffect(option.effectText, statPriority, categoryOrder) + if (option.kind == LessonKind.TECHNIQUE) TECHNIQUE_BONUS else 0.0
-    return options.maxWithOrNull(compareBy<LessonOption> { totalScore(it) }.thenByDescending { it.rowIndex })
+    return bestLesson(options, statPriority, categoryOrder)
 }

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/components/Button.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/components/Button.kt
@@ -68,6 +68,7 @@ val ButtonLearn = button("learn")
 val ButtonReset = button("reset", Region.bottomHalf)
 val ButtonRace = button("race", Region.bottomHalf)
 val ButtonRaceDayRace = button("race_day_race", Region.bottomHalf)
+
 // Grand Live's race-day bottom row is Skills / Race / Lessons, so its Race button renders smaller than the standard race-day template.
 val ButtonRaceDayMini = button("race_day_race_mini", Region.bottomHalf)
 val ButtonRaceAgain = button("race_again", Region.bottomHalf)
@@ -132,6 +133,7 @@ object ButtonMenuBarRace : MultiStateButtonInterface {
 
 val ButtonCompleteCareer = button("complete_career", Region.bottomHalf)
 val ButtonCareerEndSkills = button("career_end_skills")
+
 // Grand Live's career-end screen has a three-button bottom row (Skills / Complete Career / Lessons), so the Skills button renders smaller than the standard template.
 val ButtonCareerEndSkillsMini = button("career_end_skills_mini")
 val ButtonClawMachine = button("claw_machine", Region.bottomHalf)
@@ -153,6 +155,7 @@ val ButtonRest = button("rest", Region.bottomHalf)
 val ButtonRestAndRecreation = button("rest_and_recreation", Region.bottomHalf)
 val ButtonInfirmary = button("infirmary", Region.bottomHalf)
 val ButtonRecreation = button("recreation", Region.bottomHalf)
+
 // Grand Live shrinks the bottom action row to four buttons (Lessons is added), so Infirmary / Recreation / Races render smaller than the standard templates.
 val ButtonInfirmaryMini = button("infirmary_mini", Region.bottomHalf)
 val ButtonRecreationMini = button("recreation_mini", Region.bottomHalf)
@@ -166,6 +169,7 @@ val ButtonTrainingStamina = button("training_stamina", Region.bottomHalf)
 val ButtonTrainingPower = button("training_power", Region.bottomHalf)
 val ButtonTrainingGuts = button("training_guts", Region.bottomHalf)
 val ButtonTrainingWit = button("training_wit", Region.bottomHalf)
+
 // Grand Live's facility buttons do not match the standard templates above, so it uses this alternative crop.
 val ButtonTrainingSpeedAlt = button("training_speed_alt", Region.bottomHalf)
 val ButtonTrainingStaminaAlt = button("training_stamina_alt", Region.bottomHalf)

--- a/android/app/src/test/java/com/steve1316/uma_android_automation/bot/campaigns/GrandLiveLessonPolicyTest.kt
+++ b/android/app/src/test/java/com/steve1316/uma_android_automation/bot/campaigns/GrandLiveLessonPolicyTest.kt
@@ -103,11 +103,18 @@ class GrandLiveLessonPolicyTest {
     }
 
     @Test
-    @DisplayName("Projected energy is parsed from the dialog's '<new> / 100' readout")
+    @DisplayName("Projected energy is parsed from the dialog's '<new> / <cap>' readout")
     fun parsesProjectedEnergy() {
-        assertEquals(78, parseProjectedEnergy("78 / 100"))
-        assertEquals(100, parseProjectedEnergy("100/100"))
+        assertEquals(78 to 100, parseProjectedEnergy("78 / 100"))
+        assertEquals(100 to 100, parseProjectedEnergy("100/100"))
         assertNull(parseProjectedEnergy("no number here"))
+    }
+
+    @Test
+    @DisplayName("A misread energy cap still parses, so the overflow guard is not silently disabled")
+    fun parsesProjectedEnergyWithMisreadCap() {
+        // Observed on device: the cap OCR'd as "104", which the old hardcoded "/100" pattern could not match at all.
+        assertEquals(87 to 104, parseProjectedEnergy("87 /104"))
     }
 
     @Test
@@ -162,6 +169,50 @@ class GrandLiveLessonPolicyTest {
         val gainFirst = listOf(LessonEffectCategory.TRAINING_GAIN, LessonEffectCategory.STAT_GAINS)
         val chosen = chooseLessonPurchase(options, priority, forceMaxHype = true, hypeMaxed = false, categoryOrder = gainFirst)
         assertEquals(LessonKind.SONG, chosen?.kind)
+    }
+
+    @Test
+    @DisplayName("The top-ranked category beats two lower-ranked ones stacked on one card")
+    fun topRankBeatsStackedLowerRanks() {
+        // Observed on device: a Training Gain + Support Events song used to outscore a Training Effectiveness song because the weights summed.
+        val options =
+            listOf(
+                song("Power +22 Friendship Training Effectiveness +5%", 0),
+                song("Training Stamina Gain +1 Support Chain Event Frequency Lvl +1", 1),
+            )
+        val chosen = chooseLessonPurchase(options, priority, forceMaxHype = false, hypeMaxed = true)
+        assertEquals(0, chosen?.rowIndex)
+    }
+
+    @Test
+    @DisplayName("A card matching more categories wins when the better-ranked ones tie")
+    fun moreCategoriesWinsOnEqualPrefix() {
+        val options =
+            listOf(
+                song("Training Speed Gain +1", 0),
+                song("Training Speed Gain +1 Support Chain Event Frequency Lvl +1", 1),
+            )
+        val chosen = chooseLessonPurchase(options, priority, forceMaxHype = false, hypeMaxed = true)
+        assertEquals(1, chosen?.rowIndex)
+    }
+
+    @Test
+    @DisplayName("Training Effectiveness is inferred when OCR truncated the label to a bare percentage")
+    fun inferTrainingEffectivenessFromBarePercent() {
+        // Observed on device: "Precious Treasure Box" reads as "Speed +26" / "+10%", losing the label entirely.
+        assertTrue(detectLessonCategories("Speed +26 +10%").contains(LessonEffectCategory.TRAINING_EFFECTIVENESS))
+        assertTrue(detectLessonCategories("Guts +26 +10%").contains(LessonEffectCategory.TRAINING_EFFECTIVENESS))
+        // A small stat gain with no percentage is an ordinary technique, not a Training Effectiveness song.
+        assertFalse(detectLessonCategories("Speed +5").contains(LessonEffectCategory.TRAINING_EFFECTIVENESS))
+    }
+
+    @Test
+    @DisplayName("The post-concert overlay is stripped instead of masking the real effect")
+    fun stripsConcertOverOverlay() {
+        val effect = "Wit +22 O This bonus won't take effect, as the concert is over."
+        assertEquals(StatName.WIT to 22, parseStatGain(effect))
+        assertTrue(detectLessonCategories(effect).contains(LessonEffectCategory.TRAINING_EFFECTIVENESS))
+        assertTrue(detectLessonCategories(effect).contains(LessonEffectCategory.STAT_GAINS))
     }
 
     @Test

--- a/src/components/DraggablePriorityList/index.tsx
+++ b/src/components/DraggablePriorityList/index.tsx
@@ -33,8 +33,9 @@ interface DraggablePriorityListProps {
 }
 
 /**
- * A drag-to-reorder list paired with checkbox toggles. Selected items render on top with a numeric badge and grip handle. Unselected items render below
- * a dashed separator with a plain checkbox. Consumed inside `SheetModal` - the parent owns scroll so this component does not wrap its rows in a ScrollView.
+ * A drag-to-reorder list paired with checkbox toggles. Selected items render on top with a numeric badge, a remove button, and a grip handle, and the row
+ * body is the drag target. Unselected items render below a dashed separator with a plain checkbox and are appended to the end when selected.
+ * Consumed inside `SheetModal` - the parent owns scroll so this component does not wrap its rows in a ScrollView.
  * @param items All items.
  * @param selectedItems Selected items in priority order.
  * @param onSelectionChange Selection toggle callback.
@@ -79,6 +80,7 @@ const DraggablePriorityList = ({ items, selectedItems, onSelectionChange, onOrde
                 badgeText: { ...TYPE.monoValue, color: colors.onBrand, fontSize: 11, fontWeight: "700" as const },
                 selectedLabel: { ...TYPE.body, color: colors.text, flex: 1 },
                 grip: { opacity: 0.7 },
+                remove: { opacity: 0.7, paddingHorizontal: 2 },
                 separator: { borderTopWidth: 1, borderStyle: "dashed", borderColor: colors.borderHair, marginVertical: SPACING.sm },
                 unselectedList: { gap: SPACING.xs + 2 },
             }),
@@ -88,21 +90,32 @@ const DraggablePriorityList = ({ items, selectedItems, onSelectionChange, onOrde
     const renderSelectedItem = (info: DragListRenderItemInfo<PriorityItem>) => {
         const { item, onDragStart, onDragEnd } = info
         const priorityNumber = orderedSelected.indexOf(item.id) + 1
+        // The row body starts a drag rather than toggling selection. Removal lives on its own button, since a drag that the pan responder read as a
+        // tap used to silently deselect the item, and re-selecting it appended it to the bottom of the list.
         return (
             <Pressable
                 style={styles.selectedRow}
-                onPress={() => onSelectionChange(selectedItems.filter((id) => id !== item.id))}
+                onPressIn={onDragStart}
+                onPressOut={onDragEnd}
                 android_ripple={{ color: colors.ripple, foreground: true }}
-                accessibilityRole="button"
-                accessibilityLabel={`${item.label} priority ${priorityNumber}`}
+                accessibilityLabel={`${item.label} priority ${priorityNumber}, drag to reorder`}
             >
                 <View style={styles.badge}>
                     <Text style={styles.badgeText}>{priorityNumber}</Text>
                 </View>
                 <Text style={styles.selectedLabel}>{item.label}</Text>
-                <Pressable onPress={() => {}} onPressIn={onDragStart} onPressOut={onDragEnd} style={styles.grip} accessibilityLabel="Drag to reorder">
-                    <Ionicons name="reorder-three" size={20} color={colors.brand} />
+                <Pressable
+                    onPress={() => onSelectionChange(orderedSelected.filter((id) => id !== item.id))}
+                    hitSlop={SPACING.sm}
+                    style={styles.remove}
+                    accessibilityRole="button"
+                    accessibilityLabel={`Remove ${item.label} from the priority list`}
+                >
+                    <Ionicons name="close" size={18} color={colors.textMuted} />
                 </Pressable>
+                <View style={styles.grip}>
+                    <Ionicons name="reorder-three" size={20} color={colors.brand} />
+                </View>
             </Pressable>
         )
     }
@@ -115,8 +128,9 @@ const DraggablePriorityList = ({ items, selectedItems, onSelectionChange, onOrde
         onOrderChange(copy)
     }
 
+    // Both lists read `orderedSelected` so a reorder that has not yet propagated back through the parent cannot make an item appear in both or neither.
     const selectedData = orderedSelected.map((id) => items.find((it) => it.id === id)).filter((x): x is PriorityItem => !!x)
-    const unselected = items.filter((it) => !selectedItems.includes(it.id))
+    const unselected = items.filter((it) => !orderedSelected.includes(it.id))
 
     return (
         <View style={style}>
@@ -129,12 +143,12 @@ const DraggablePriorityList = ({ items, selectedItems, onSelectionChange, onOrde
             {unselected.length > 0 ? (
                 <View style={styles.unselectedList}>
                     {unselected.map((item) => (
-                        <ModalCheckRow key={item.id} label={item.label} checked={false} dim onPress={() => onSelectionChange([...selectedItems, item.id])} />
+                        <ModalCheckRow key={item.id} label={item.label} checked={false} dim onPress={() => onSelectionChange([...orderedSelected, item.id])} />
                     ))}
                 </View>
             ) : null}
 
-            {selectedItems.length === 0 ? <Text style={styles.empty}>NO ITEMS SELECTED - SELECT TO SET ORDER</Text> : null}
+            {selectedData.length === 0 ? <Text style={styles.empty}>NO ITEMS SELECTED - SELECT TO SET ORDER</Text> : null}
         </View>
     )
 }


### PR DESCRIPTION
## Description

- This PR resolves #415 by making the `Grand Live Lesson Effect Priority` list actually behave like a priority list. Previously each effect on a card added to a running total, so a card with two mid-ranked effects beat a card with your single top-ranked effect - the top choice now always wins.
- Priority list items are now removed with their own button, so a drag that registers as a tap no longer deletes the item and sends it to the bottom of the list.
- Also fixes the energy check being skipped without warning when the energy cap was misread, which allowed a purchase to overflow and waste energy.
