### PR TITLE
Fix empty Analytics charts and the Remote Log Viewer copy button

### DIFF
--- a/android/app/src/main/assets/log_viewer.html
+++ b/android/app/src/main/assets/log_viewer.html
@@ -2532,7 +2532,7 @@
                     <button id="compactBtn" class="toolbar-btn icon active" onclick="toggleCondensing()" title="Toggle log condensation (timestamps may appear out of order when enabled)">
                         <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.4"><path d="M3 5h10M3 8h10M3 11h10" /></svg>
                     </button>
-                    <button class="toolbar-btn icon" onclick="copyAllLogs()" title="Copy all logs">
+                    <button class="toolbar-btn icon" onclick="copyAllLogs(event)" title="Copy all logs">
                         <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.4"><rect x="5" y="5" width="8" height="9" rx="1.5" /><path d="M3 11V3.5A1.5 1.5 0 0 1 4.5 2H10" /></svg>
                     </button>
                     <button class="toolbar-btn icon" onclick="downloadLogs()" title="Download logs">
@@ -3816,9 +3816,49 @@
             }
 
             /**
-             * Copies the content of all currently stored log messages to the clipboard.
+             * Writes text to the clipboard. The viewer is served over plain http on the LAN, which is not a secure context, so navigator.clipboard is
+             * undefined in every browser. Fall back to a hidden textarea plus execCommand, which still works outside a secure context.
+             *
+             * @param {string} text - The text to place on the clipboard.
+             * @returns {Promise<boolean>} Resolves true when the copy succeeded.
              */
-            function copyAllLogs() {
+            function writeToClipboard(text) {
+                if (navigator.clipboard && window.isSecureContext) {
+                    return navigator.clipboard.writeText(text).then(
+                        function () {
+                            return true
+                        },
+                        function (e) {
+                            console.error("Clipboard write failed:", e)
+                            return false
+                        }
+                    )
+                }
+                var ta = document.createElement("textarea")
+                ta.value = text
+                // Keep the textarea off-screen but still selectable, and avoid scrolling the page when it gains focus.
+                ta.style.position = "fixed"
+                ta.style.top = "-1000px"
+                ta.setAttribute("readonly", "")
+                document.body.appendChild(ta)
+                var ok = false
+                try {
+                    ta.select()
+                    ta.setSelectionRange(0, text.length)
+                    ok = document.execCommand("copy")
+                } catch (e) {
+                    console.error("Clipboard fallback failed:", e)
+                }
+                document.body.removeChild(ta)
+                return Promise.resolve(ok)
+            }
+
+            /**
+             * Copies the content of all currently stored log messages to the clipboard.
+             *
+             * @param {Event} ev - The originating click event, used to find the button to flash.
+             */
+            function copyAllLogs(ev) {
                 var text = allMessages
                     .map(function (m) {
                         var line = ""
@@ -3828,16 +3868,16 @@
                         return m.parsed.newline + line
                     })
                     .join("\n")
-                navigator.clipboard.writeText(text).then(function () {
+                // Read the button up front since currentTarget is cleared once the event finishes dispatching.
+                var btn = ev.currentTarget
+                writeToClipboard(text).then(function (ok) {
                     // Briefly flash the icon button to confirm, then restore its original SVG.
-                    var btn = event.target.closest(".toolbar-btn")
-                    if (btn) {
-                        var original = btn.innerHTML
-                        btn.textContent = "✓"
-                        setTimeout(function () {
-                            btn.innerHTML = original
-                        }, 1500)
-                    }
+                    if (!ok || !btn) return
+                    var original = btn.innerHTML
+                    btn.textContent = "✓"
+                    setTimeout(function () {
+                        btn.innerHTML = original
+                    }, 1500)
                 })
             }
 

--- a/android/app/src/main/assets/log_viewer.html
+++ b/android/app/src/main/assets/log_viewer.html
@@ -5868,7 +5868,7 @@
                 // Races by grade.
                 var byGrade = totals.racesByGrade || {}
                 var grades = Object.keys(byGrade)
-                    .filter(function (k) { return byGrade[k] > 0 })
+                    .filter(function (k) { return k && byGrade[k] > 0 })
                     .sort(function (a, b) { return ANALYTIC_GRADE_RANK.indexOf(a) - ANALYTIC_GRADE_RANK.indexOf(b) })
                 analyticUpdateChart("racesByGrade", function (c) {
                     c.data.labels = grades.map(analyticGradeLabel)
@@ -5968,7 +5968,7 @@
 
 
                 var gradesSeen = []
-                races.forEach(function (r) { if (gradesSeen.indexOf(r.grade) < 0) gradesSeen.push(r.grade) })
+                races.forEach(function (r) { if (r.grade && gradesSeen.indexOf(r.grade) < 0) gradesSeen.push(r.grade) })
                 gradesSeen.sort(function (a, b) { return ANALYTIC_GRADE_RANK.indexOf(a) - ANALYTIC_GRADE_RANK.indexOf(b) })
                 analyticUpdateChart("winByGrade", function (c) {
                     c.data.labels = gradesSeen.map(analyticGradeLabel)

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Racing.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Racing.kt
@@ -203,6 +203,12 @@ class Racing(private val game: Game, private val campaign: Campaign) {
     /** Tracks the distance of the last race that was selected. */
     var lastRaceDistance: TrackDistance? = null
 
+    /** Tracks the name of the last race that was selected. Empty when the race was never matched against the database. */
+    var lastRaceName: String = ""
+
+    /** Tracks the surface of the last race that was selected. */
+    var lastRaceSurface: TrackSurface? = null
+
     /** Tracks if the last race selected was a Rival Race. */
     var lastRaceIsRival: Boolean = false
 
@@ -1311,6 +1317,27 @@ class Racing(private val game: Game, private val campaign: Campaign) {
     }
 
     /**
+     * Mirror a finished race into [RunAnalytics] for the Analytics tab. This is the sole recorder for the career racing flow, so it runs on every
+     * campaign whether or not the Smart Race Solver is enabled. Fields the racing flow never resolved are sent empty and simply go uncharted.
+     * Unity Cup team races take their own results path and are not covered here.
+     *
+     * @param won True when the trainee finished 1st.
+     * @param isExtra True when this was an extra race rather than a mandatory one.
+     */
+    private fun recordRaceForAnalytics(won: Boolean, isExtra: Boolean) {
+        RunAnalytics.recordRace(
+            turn = campaign.date.day,
+            name = lastRaceName,
+            grade = lastRaceGrade?.name ?: "",
+            surface = lastRaceSurface?.name ?: "",
+            distance = lastRaceDistance?.name ?: "",
+            fans = lastRaceFans,
+            won = won,
+            mandatory = !isExtra,
+        )
+    }
+
+    /**
      * Finishes up and confirms the results of the race and its success.
      *
      * @param isExtra Flag to determine the following actions to finish up this mandatory or extra race.
@@ -1327,6 +1354,7 @@ class Racing(private val game: Game, private val campaign: Campaign) {
         if (!ButtonNext.check(game.imageUtils, tries = 30)) {
             MessageLog.e(TAG, "[ERROR] finalizeRaceResults:: Cannot start the cleanup process for finishing the race. Moving on...")
             SmartRaceSolverIntegration.commitPendingRace(won = false)
+            recordRaceForAnalytics(won = false, isExtra = isExtra)
             return false
         }
 
@@ -1336,6 +1364,7 @@ class Racing(private val game: Game, private val campaign: Campaign) {
         val firstPlace = LabelCongratulations.check(game.imageUtils)
         MessageLog.i(TAG, "[RACE] Race result detected - 1st place: $firstPlace.")
         SmartRaceSolverIntegration.commitPendingRace(won = firstPlace)
+        recordRaceForAnalytics(won = firstPlace, isExtra = isExtra)
 
         // Max time limit for the while loop to attempt to finalize race results.
         // It really shouldn't ever take this long.
@@ -1629,6 +1658,8 @@ class Racing(private val game: Game, private val campaign: Campaign) {
             lastRaceGrade = null
             lastRaceFans = 0
             lastRaceDistance = null
+            lastRaceName = ""
+            lastRaceSurface = null
             lastRaceIsRival = false
             bRetriedCurrentRace = false
         }
@@ -1807,6 +1838,8 @@ class Racing(private val game: Game, private val campaign: Campaign) {
                 if (raceDataList.isNotEmpty()) {
                     val raceData = raceDataList[0]
                     lastRaceDistance = raceData.trackDistance
+                    lastRaceName = raceData.name
+                    lastRaceSurface = raceData.trackSurface
                     // Preserve any grade/fans already set above (e.g. by the Finale block).
                     if (lastRaceGrade == null) lastRaceGrade = raceData.grade
                     if (lastRaceFans == 0) lastRaceFans = raceData.fans
@@ -2179,6 +2212,8 @@ class Racing(private val game: Game, private val campaign: Campaign) {
                     lastRaceGrade = raceDataList[0].grade
                     lastRaceFans = raceDataList[0].fans
                     lastRaceDistance = raceDataList[0].trackDistance
+                    lastRaceName = raceDataList[0].name
+                    lastRaceSurface = raceDataList[0].trackSurface
                     MessageLog.i(TAG, "[RACE] Detected scheduled race grade: $lastRaceGrade.")
 
                     // Stage the scheduled race so finalizeRaceResults() records its win/loss in the solver's history. Without this, scheduled
@@ -2280,6 +2315,8 @@ class Racing(private val game: Game, private val campaign: Campaign) {
                     lastRaceGrade = match.grade
                     lastRaceFans = match.fans
                     lastRaceDistance = match.trackDistance
+                    lastRaceName = match.name
+                    lastRaceSurface = match.trackSurface
                     lastRaceIsRival = match.isRival
                     return true
                 }
@@ -2337,6 +2374,8 @@ class Racing(private val game: Game, private val campaign: Campaign) {
         lastRaceGrade = solverPick.grade
         lastRaceFans = solverPick.fans
         lastRaceDistance = solverPick.trackDistance
+        lastRaceName = solverPick.name
+        lastRaceSurface = solverPick.trackSurface
         lastRaceIsRival = solverPick.isRival
         return true
     }
@@ -2523,6 +2562,8 @@ class Racing(private val game: Game, private val campaign: Campaign) {
         lastRaceGrade = raceDataList.firstOrNull()?.grade
         lastRaceFans = raceDataList.firstOrNull()?.fans ?: 0
         lastRaceDistance = raceDataList.firstOrNull()?.trackDistance
+        lastRaceName = raceDataList.firstOrNull()?.name ?: selectedRaceName
+        lastRaceSurface = raceDataList.firstOrNull()?.trackSurface
         lastRaceIsRival = filteredRaces[index].isRival
 
         // Selects the determined race on screen.

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Racing.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Racing.kt
@@ -1827,10 +1827,10 @@ class Racing(private val game: Game, private val campaign: Campaign) {
             // Distance is unknown for Finale races; per-distance strategy will fall back to blanket.
         }
 
-        // OCR the mandatory race name via the on-screen double-star prediction icon so per-distance strategy uses the actual race distance. Without this,
-        // lastRaceDistance stays null and per-distance strategy falls back to the user's blanket strategy for every mandatory race. Gated on
-        // enablePerDistanceStrategy so users not using per-distance don't pay the OCR + DB lookup overhead.
-        if (enablePerDistanceStrategy && lastRaceDistance == null) {
+        // OCR the mandatory race name via the on-screen double-star prediction icon to resolve its name, grade, surface, and distance. Per-distance
+        // strategy needs the distance to avoid falling back to the user's blanket strategy, and the Analytics tab needs the rest to chart the race
+        // rather than just counting it. Skipped once the details are already known so the OCR + DB lookup only runs when it would add something.
+        if (lastRaceDistance == null) {
             val predictionLocations = IconRaceListPredictionDoubleStar.findAll(game.imageUtils)
             if (predictionLocations.isNotEmpty()) {
                 val raceName = game.imageUtils.extractRaceName(predictionLocations[0])
@@ -1846,7 +1846,7 @@ class Racing(private val game: Game, private val campaign: Campaign) {
                     MessageLog.i(TAG, "[RACE] Detected mandatory race \"${raceData.name}\" (Grade: ${raceData.grade}, Distance: ${raceData.trackDistance}).")
                 }
             } else {
-                MessageLog.i(TAG, "[RACE] No double-star prediction found on mandatory race screen. Per-distance strategy will fall back to blanket.")
+                MessageLog.i(TAG, "[RACE] No double-star prediction found on mandatory race screen. Per-distance strategy will fall back to blanket and the race goes uncharted.")
             }
         }
 

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/RunAnalytics.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/RunAnalytics.kt
@@ -274,19 +274,21 @@ object RunAnalytics {
     }
 
     /**
-     * Record one committed race outcome. Deduplicated by turn + name. Does not broadcast on its own - the turn-end `recordTurn` that follows picks it up.
+     * Record one committed race outcome. Deduplicated by turn. Does not broadcast on its own - the turn-end `recordTurn` that follows picks it up.
      *
      * @param turn Turn the race ran on.
-     * @param name Race name.
-     * @param grade Race grade enum name (e.g. "G1", "PRE_OP").
-     * @param surface Track surface enum name (e.g. "TURF").
-     * @param distance Track distance enum name (e.g. "MEDIUM").
+     * @param name Race name. Empty when the racing flow never matched the race against the database.
+     * @param grade Race grade enum name (e.g. "G1", "PRE_OP"). Empty when unresolved, which keeps it out of the grade charts.
+     * @param surface Track surface enum name (e.g. "TURF"). Empty when unresolved.
+     * @param distance Track distance enum name (e.g. "MEDIUM"). Empty when unresolved.
      * @param fans Fans awarded by the race.
      * @param won True when the trainee finished 1st.
      * @param mandatory True when the race was a locked mandatory race.
      */
     fun recordRace(turn: Int, name: String, grade: String, surface: String, distance: String, fans: Int, won: Boolean, mandatory: Boolean) {
-        if (races.any { it.turn == turn && it.name == name }) return
+        // Only one career race can run per turn, so the turn alone identifies it. Guards against a second record for the same race arriving
+        // under a different name, which OCR can easily produce.
+        if (races.any { it.turn == turn }) return
         races.add(RaceRecord(turn, name, grade, surface, distance, fans, won, mandatory))
     }
 

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Training.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/Training.kt
@@ -2767,11 +2767,14 @@ open class Training(protected val game: Game, protected val campaign: Campaign) 
                     if (trainingButtons.getValue(StatName.WIT).click(game.imageUtils, taps = 3)) {
                         game.waitForLoading()
                         MessageLog.v(TAG, "[TRAINING] Successfully forced Wit training during the Finale instead of recovering energy.")
+                        val (finalePickFail, finalePickGains) = pickedStatDetails(StatName.WIT)
                         campaign.decisionTracer.recordTrainingSelection(
                             selected = StatName.WIT,
                             source = SelectionSource.FORCED_DEFAULT,
                             reason = finaleReason,
                             runnerUps = buildRunnerUps(StatName.WIT),
+                            pickedFailureChance = finalePickFail,
+                            pickedStatGains = finalePickGains,
                         )
                         firstTrainingCheck = false
                     } else {
@@ -2825,6 +2828,7 @@ open class Training(protected val game: Game, protected val campaign: Campaign) 
                 }
             } else {
                 // Now select the training option with the highest weight.
+                val (pickFail, pickGains) = pickedStatDetails(trainingSelected)
                 campaign.decisionTracer.recordTrainingSelection(
                     selected = trainingSelected,
                     source = if (forceStat != null) SelectionSource.FORCED_DEFAULT else lastSelectionSource,
@@ -2835,6 +2839,8 @@ open class Training(protected val game: Game, protected val campaign: Campaign) 
                             "Selected by Training.handleTraining base flow (analyzer pick)"
                         },
                     runnerUps = buildRunnerUps(trainingSelected),
+                    pickedFailureChance = pickFail,
+                    pickedStatGains = pickGains,
                 )
                 executeTraining(trainingSelected)
                 firstTrainingCheck = false
@@ -2846,6 +2852,26 @@ open class Training(protected val game: Game, protected val campaign: Campaign) 
         }
         MessageLog.v(TAG, "********************")
         return trainingSelected
+    }
+
+    /**
+     * Looks up the failure chance and stat gains for the training that was picked this turn.
+     * Feeds both the Decision Report `Pick:` line and the Run Analytics charts.
+     *
+     * @param picked The stat selected this turn. Null when no training was picked.
+     * @param analysis Analyzed trainings to search. Defaults to the live cache. Trackblazer passes a snapshot since its cache is cleared mid-turn.
+     * @param skipped Skipped trainings to fall back on. Defaults to the live map, with the same Trackblazer caveat as `analysis`.
+     * @return A pair of (failure chance, stat gains) for the picked training, each null when neither source has an entry for it.
+     */
+    internal fun pickedStatDetails(
+        picked: StatName?,
+        analysis: List<TrainingAnalysisResult> = cachedAnalysisResults.orEmpty(),
+        skipped: Map<StatName, TrainingOption> = skippedTrainingMap,
+    ): Pair<Int?, Map<StatName, Int>?> {
+        if (picked == null) return null to null
+        analysis.firstOrNull { it.name == picked }?.let { return it.failureChance.takeIf { fc -> fc >= 0 } to it.statGains }
+        skipped[picked]?.let { return it.failureChance.takeIf { fc -> fc >= 0 } to it.statGains }
+        return null to null
     }
 
     /**

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/Trackblazer.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/Trackblazer.kt
@@ -1093,6 +1093,9 @@ class Trackblazer(game: Game) : Campaign(game) {
 
                 racing.lastRaceGrade = raceData.grade
                 racing.lastRaceDistance = raceData.trackDistance
+                racing.lastRaceFans = raceData.fans
+                racing.lastRaceName = raceData.name
+                racing.lastRaceSurface = raceData.trackSurface
                 racing.lastRaceIsRival = raceData.isRival
                 game.tap(suitableRaceLocation.x, suitableRaceLocation.y, "race_list_prediction_double_star", ignoreWaiting = true)
                 game.wait(0.5)

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/Trackblazer.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/Trackblazer.kt
@@ -1232,15 +1232,10 @@ class Trackblazer(game: Game) : Campaign(game) {
     }
 
     /**
-     * Pulls the picked stat's failure-chance and stat-gain map out of the snapshot so the Decision Report's `Pick:` line can show them. Returns
-     * (null, null) when the pick is null or absent from both snapshots. `failureChance < 0` is treated as "OCR did not measure" and surfaced as null.
+     * Pulls the picked stat's failure-chance and stat-gain map out of the snapshot so the Decision Report's `Pick:` line can show them.
+     * Reads the snapshots rather than the live analyzer state, which `confirmAndCloseItemDialog` clears later in the turn.
      */
-    private fun pickedStatDetails(picked: StatName?): Pair<Int?, Map<StatName, Int>?> {
-        if (picked == null) return null to null
-        analysisSnapshotForReport.firstOrNull { it.name == picked }?.let { return it.failureChance.takeIf { fc -> fc >= 0 } to it.statGains }
-        skippedSnapshotForReport[picked]?.let { return it.failureChance.takeIf { fc -> fc >= 0 } to it.statGains }
-        return null to null
-    }
+    private fun pickedStatDetails(picked: StatName?): Pair<Int?, Map<StatName, Int>?> = training.pickedStatDetails(picked, analysisSnapshotForReport, skippedSnapshotForReport)
 
     private fun buildTrainingRunnerUps(picked: StatName?): List<DecisionTracer.TrainingRunnerUp> {
         val analyzed = analysisSnapshotForReport

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/solver/SmartRaceSolverIntegration.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/solver/SmartRaceSolverIntegration.kt
@@ -5,7 +5,6 @@ import com.steve1316.automation_library.utils.SettingsHelper
 import com.steve1316.automation_library.utils.TextUtils
 import com.steve1316.uma_android_automation.bot.Game
 import com.steve1316.uma_android_automation.bot.Racing.RaceData
-import com.steve1316.uma_android_automation.bot.RunAnalytics
 import com.steve1316.uma_android_automation.types.Aptitude
 import com.steve1316.uma_android_automation.types.GameDate
 import com.steve1316.uma_android_automation.types.RaceGrade
@@ -249,7 +248,6 @@ object SmartRaceSolverIntegration {
     fun commitPendingRace(won: Boolean) {
         val pending = pendingRace ?: return
         pendingRace = null
-        recordRaceForAnalytics(pending, won)
         if (!won) {
             recordRaceLost(pending.raceKey, pending.name, pending.classYear, pending.turnNumber)
             MessageLog.i(TAG, "Race \"${pending.name}\" on turn ${pending.turnNumber} did not finish 1st; recorded as a loss.")
@@ -266,27 +264,6 @@ object SmartRaceSolverIntegration {
         logEpithetProgressAfterWin(pending.name, pending.turnNumber, historyBefore, historyAfter)
         broadcastCalendarSnapshot(reuseSchedule = true)
         logSyntheticDebutOnce(pending.turnNumber)
-    }
-
-    /**
-     * Mirror a committed race outcome into [RunAnalytics] for the Analytics tab. Looks up the full race details (grade, surface, distance, fans) from the
-     * cached candidate pool so the analytics snapshot carries the same data the calendar shows.
-     *
-     * @param pending The race that was just confirmed won or lost.
-     * @param won True when the trainee finished 1st.
-     */
-    private fun recordRaceForAnalytics(pending: RaceWin, won: Boolean) {
-        val candidate = cachedRaces?.let { findCandidate(pending.turnNumber, pending.raceKey, pending.name, it) }
-        RunAnalytics.recordRace(
-            turn = pending.turnNumber,
-            name = pending.name,
-            grade = candidate?.grade?.name ?: "",
-            surface = candidate?.terrain?.name ?: "",
-            distance = candidate?.distanceType?.name ?: "",
-            fans = candidate?.fans ?: 0,
-            won = won,
-            mandatory = candidate?.isMandatory == true,
-        )
     }
 
     /**

--- a/android/app/src/test/java/com/steve1316/uma_android_automation/bot/RunAnalyticsTest.kt
+++ b/android/app/src/test/java/com/steve1316/uma_android_automation/bot/RunAnalyticsTest.kt
@@ -83,6 +83,19 @@ class RunAnalyticsTest {
     }
 
     @Test
+    @DisplayName("a turn's race is recorded once even when a later record names it differently")
+    fun `dedupes repeated race by turn`() {
+        // OCR can read the same race under a different name, so the turn alone has to settle identity.
+        RunAnalytics.recordRace(15, "Hopeful Stakes", "G3", "TURF", "MILE", 1200, true, false)
+        RunAnalytics.recordRace(15, "hopeful stakes (OCR)", "", "", "", 0, true, false)
+
+        val races = snapshot(false).getJSONArray("races")
+        assertEquals(1, races.length())
+        assertEquals("Hopeful Stakes", races.getJSONObject(0).getString("name"))
+        assertEquals("G3", races.getJSONObject(0).getString("grade"))
+    }
+
+    @Test
     @DisplayName("races tally wins, grades, and bucket into the correct year")
     fun `aggregates races and per-year`() {
         recordTraining(gameDate(DateYear.JUNIOR, DateMonth.MARCH, DatePhase.EARLY, 5), trainee("A", 1, 1, 1, 1, 1, 80, 1), StatName.SPEED, mapOf(StatName.SPEED to 10), 0)


### PR DESCRIPTION
## Description

- This PR fixes the `Analytics` tab charts that were empty, including stat-gain, failure-chance, and every race chart, so they now populate on all campaigns instead of only on Trackblazer runs with the `Smart Race Solver` enabled.
- Races are now recorded for every career race regardless of whether the `Smart Race Solver` is turned on, which restores the win rate, race grade, surface, and distance charts.
- Mandatory race details are now read regardless of the per-distance strategy setting, so those races are charted rather than only counted.
- This PR also fixes the "Copy all logs" button in the `Remote Log Viewer`.
