### PR TITLE
Improve which Lessons the bot buys in Grand Live

### DIFF
--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/GrandLive.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/GrandLive.kt
@@ -75,6 +75,14 @@ class GrandLive(game: Game) : Campaign(game) {
     private val lessonEffectPriority: List<LessonEffectCategory> =
         SettingsHelper.getStringArraySetting("scenarioOverrides", "grandLiveLessonEffectPriority").mapNotNull { LessonEffectCategory.fromDisplayName(it) }.ifEmpty { DEFAULT_LESSON_EFFECT_PRIORITY }
 
+    /** Stat order applied to Lessons stat gains (Scenario Overrides). Falls back to the global training prioritization when the user has not set a Grand Live one. */
+    private val lessonStatPriority: List<StatName> =
+        SettingsHelper.getStringArraySetting("scenarioOverrides", "grandLiveLessonStatPriority").mapNotNull { StatName.fromName(it) }.ifEmpty { training.statPrioritization }
+
+    /** User-ranked skill-hint tags (Scenario Overrides). Empty means no hint preference, which is the original behavior. */
+    private val lessonHintPriority: List<LessonHintTag> =
+        SettingsHelper.getStringArraySetting("scenarioOverrides", "grandLiveLessonHintPriority").mapNotNull { LessonHintTag.fromDisplayName(it) }
+
     /** Turns between Lessons re-checks (Scenario Overrides). The list is static until a purchase, so polling more often than tokens grow wastes screen time. */
     private val lessonRescanInterval: Int = SettingsHelper.getIntSetting("scenarioOverrides", "grandLiveLessonRescanInterval", 2)
 
@@ -289,7 +297,7 @@ class GrandLive(game: Game) : Campaign(game) {
             // Prefer on-style options; a skill hint for a running style we cannot use is only bought when it is the sole affordable option.
             val onStyle = purchasable.filter { !isOffStyleHint(it.option.effectText) }
             val candidates = if (onStyle.isNotEmpty()) onStyle else purchasable
-            val choice = chooseLessonPurchase(candidates.map { it.option }, training.statPrioritization, forceMaxHype, hypeMaxed, lessonEffectPriority)
+            val choice = chooseLessonPurchase(candidates.map { it.option }, lessonStatPriority, forceMaxHype, hypeMaxed, lessonEffectPriority, lessonHintPriority)
             if (choice == null) {
                 MessageLog.i(TAG, "[GRAND_LIVE] No learnable Lessons purchase; leaving the Lessons screen.")
                 break
@@ -474,11 +482,15 @@ class GrandLive(game: Game) : Campaign(game) {
      * Whether a card's effect is a skill hint tied to a running style the trainee cannot use (aptitude below C), so it should not be
      * bought over an on-style option. A non-hint effect, a distance / generic hint, or an on-style hint all return false.
      *
+     * A tag the user ranked in the hint priority is never treated as off-style - an explicit choice outranks the aptitude guess.
+     *
      * @param effectText The card's effect line(s).
      * @return True when the effect is an off-style skill hint.
      */
     private fun isOffStyleHint(effectText: String): Boolean {
-        val style = parseHintRunningStyle(effectText) ?: return false
+        val tags = parseHintTags(effectText)
+        if (tags.any { it in lessonHintPriority }) return false
+        val style = tags.firstNotNullOfOrNull { it.runningStyle } ?: return false
         val aptitude = trainee.runningStyleAptitudes[style] ?: return false
         return aptitude < Aptitude.C
     }

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/GrandLiveLessons.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/GrandLiveLessons.kt
@@ -122,8 +122,12 @@ private const val SOUGHT_AFTER_TOP_RANKS = 2
 /** The stat names as a regex alternation, derived from [StatName] so the gain patterns below cannot drift from the enum. */
 private val STAT_ALTERNATION = StatName.entries.joinToString("|") { it.name.lowercase() }
 
-/** Matches a raw stat-gain effect that leads with the stat (e.g. "Speed +5"), distinguishing it from passives like "Training Power Gain +1". */
-private val RAW_STAT_GAIN_REGEX = Regex("^\\s*($STAT_ALTERNATION)\\s*\\+?\\s*(\\d+)", RegexOption.IGNORE_CASE)
+/**
+ * Matches a raw stat-gain effect (e.g. "Speed +5"), including a second one on a card that grants two ("Guts +6 Wit +6"). What separates these from a
+ * passive like "Training Power Gain +1" is the amount following the stat directly, so the stat is matched at a word boundary rather than at the start of
+ * the effect - anchoring at the start would read only the first stat and make the second invisible.
+ */
+private val RAW_STAT_GAIN_REGEX = Regex("(?:^|\\s)($STAT_ALTERNATION)\\s*\\+?\\s*(\\d+)", RegexOption.IGNORE_CASE)
 
 /**
  * The greyed-out warning the game overlays on a Song's effect line once the concert has passed. The effect crop picks it up instead of (or
@@ -299,26 +303,35 @@ private data class LessonEffectProfile(val ranks: List<Int>, val categoryValue: 
 private fun stripConcertOverOverlay(effectText: String): String = CONCERT_OVER_OVERLAY_REGEX.replace(effectText, "").trim()
 
 /**
- * Parse a raw stat-gain effect ("Speed +5") into its stat and amount. Passive effects that merely mention a stat
- * ("Training Power Gain +1") do not match, since the stat must lead the effect.
+ * Parse the first raw stat-gain effect ("Speed +5") into its stat and amount. Passive effects that merely mention a stat ("Training Power Gain +1") do not
+ * match, since a raw gain prints its amount directly after the stat.
  *
  * @param effectText The card's effect line.
- * @return The (stat, amount) pair, or null when the effect is not a raw stat gain.
+ * @return The (stat, amount) pair, or null when the effect grants no raw stat gain.
  */
-fun parseStatGain(effectText: String): Pair<StatName, Int>? = parseStatGainIn(stripConcertOverOverlay(effectText))
+fun parseStatGain(effectText: String): Pair<StatName, Int>? = parseStatGains(effectText).firstOrNull()
 
 /**
- * Parse a raw stat gain from text the overlay has already been stripped from, so a caller that cleans once does not pay for it again.
+ * Parse every raw stat-gain effect on a card. A Technique can grant two ("Guts +6 Wit +6"), and scoring only the first would hide the second from the
+ * stat prioritization entirely.
+ *
+ * @param effectText The card's effect line(s).
+ * @return The (stat, amount) pairs in printed order, empty when the card grants no raw stat gain.
+ */
+fun parseStatGains(effectText: String): List<Pair<StatName, Int>> = parseStatGainsIn(stripConcertOverOverlay(effectText))
+
+/**
+ * Parse raw stat gains from text the overlay has already been stripped from, so a caller that cleans once does not pay for it again.
  *
  * @param cleaned The card's effect line(s), overlay already removed.
- * @return The (stat, amount) pair, or null when the effect is not a raw stat gain.
+ * @return The (stat, amount) pairs in printed order, empty when the card grants no raw stat gain.
  */
-private fun parseStatGainIn(cleaned: String): Pair<StatName, Int>? {
-    val match = RAW_STAT_GAIN_REGEX.find(cleaned) ?: return null
-    val stat = StatName.fromName(match.groupValues[1]) ?: return null
-    val amount = match.groupValues[2].toIntOrNull() ?: return null
-    return stat to amount
-}
+private fun parseStatGainsIn(cleaned: String): List<Pair<StatName, Int>> =
+    RAW_STAT_GAIN_REGEX.findAll(cleaned).mapNotNull { match ->
+        val stat = StatName.fromName(match.groupValues[1]) ?: return@mapNotNull null
+        val amount = match.groupValues[2].toIntOrNull() ?: return@mapNotNull null
+        stat to amount
+    }.toList()
 
 /**
  * Parse a passive training-gain effect ("Training Wit Gain +2") into its stat and amount. This is the counterpart to [parseStatGain], which only accepts a
@@ -397,12 +410,12 @@ fun parseProjectedEnergy(text: String): Pair<Int, Int>? {
  *
  * @property magnitudes The matched categories, each mapped to how much of it the card grants. Support Events is flat and Stat Gains is ordered by the
  *   stat prioritization instead, so both map to 0.0.
- * @property rawStatGain The card's leading stat gain ("Speed +26"), or null.
+ * @property rawStatGains The card's raw stat gains ("Speed +26", or both of "Guts +6 Wit +6"), empty when it grants none.
  * @property trainingStatGain The card's named passive gain ("Training Wit Gain +2"), or null.
  */
 private data class LessonEffectReading(
     val magnitudes: Map<LessonEffectCategory, Double>,
-    val rawStatGain: Pair<StatName, Int>?,
+    val rawStatGains: List<Pair<StatName, Int>>,
     val trainingStatGain: Pair<StatName, Int>?,
 )
 
@@ -437,21 +450,21 @@ private fun firstAmount(regex: Regex, text: String): Double? = regex.find(text)?
  */
 private fun readLessonEffect(cleaned: String): LessonEffectReading {
     val t = cleaned.lowercase()
-    val rawStatGain = parseStatGainIn(cleaned)
+    val rawStatGains = parseStatGainsIn(cleaned)
     val trainingStatGain = parseTrainingStatGainIn(cleaned)
     val percent = firstAmount(EFFECTIVENESS_PERCENT_REGEX, cleaned)
     val energy = parseEnergyGainIn(cleaned)
     val magnitudes = mutableMapOf<LessonEffectCategory, Double>()
-    val labelLost = percent != null || (rawStatGain?.second ?: 0) >= TRAINING_EFFECTIVENESS_STAT_FLOOR
+    val labelLost = percent != null || (rawStatGains.maxOfOrNull { it.second } ?: 0) >= TRAINING_EFFECTIVENESS_STAT_FLOOR
     if ("friendship" in t || "training effectiveness" in t || labelLost) magnitudes[LessonEffectCategory.TRAINING_EFFECTIVENESS] = percent ?: 0.0
     if ("training" in t && "gain" in t) {
         magnitudes[LessonEffectCategory.TRAINING_GAIN] = trainingStatGain?.second?.toDouble() ?: firstAmount(TRAINING_GAIN_AMOUNT_REGEX, cleaned) ?: 0.0
     }
     if (("support" in t && "event" in t) || "specialty priority" in t) magnitudes[LessonEffectCategory.SUPPORT_EVENTS] = 0.0
-    if (rawStatGain != null) magnitudes[LessonEffectCategory.STAT_GAINS] = 0.0
+    if (rawStatGains.isNotEmpty()) magnitudes[LessonEffectCategory.STAT_GAINS] = 0.0
     if ("hint" in t || SKILL_POINT_REGEX.containsMatchIn(cleaned)) magnitudes[LessonEffectCategory.SKILL_HINTS] = firstAmount(SKILL_HINT_AMOUNT_REGEX, cleaned) ?: 0.0
     if (energy != null) magnitudes[LessonEffectCategory.ENERGY] = energy.toDouble()
-    return LessonEffectReading(magnitudes, rawStatGain, trainingStatGain)
+    return LessonEffectReading(magnitudes, rawStatGains, trainingStatGain)
 }
 
 /**
@@ -475,9 +488,14 @@ private fun profileLessonEffect(
 ): LessonEffectProfile {
     val cleaned = stripConcertOverOverlay(effectText)
     val reading = readLessonEffect(cleaned)
-    // A leading stat gain is what puts a card in Stat Gains, so it is preferred here; the named passive only stands in for the tie-break.
-    val statGain = reading.rawStatGain ?: reading.trainingStatGain
-    val statRank = statGain?.let { statPriority.indexOf(it.first) } ?: -1
+    // A card can grant two stats ("Guts +6 Wit +6"), so it is scored on the best-ranked one it grants rather than whichever prints first, with the larger
+    // amount breaking a tie between two equally ranked stats. A raw gain is what puts a card in Stat Gains; the named passive only feeds the tie-break.
+    val rankedStatGain =
+        reading.rawStatGains
+            .mapNotNull { gain -> statPriority.indexOf(gain.first).takeIf { it >= 0 }?.let { rank -> rank to gain } }
+            .minWithOrNull(compareBy({ it.first }, { -it.second.second }))
+    val statGain = rankedStatGain?.second ?: reading.trainingStatGain
+    val statRank = rankedStatGain?.first ?: reading.trainingStatGain?.let { statPriority.indexOf(it.first) } ?: -1
     // Scanning the tag table is only worth it once the user has ranked something, and an unrecognized tag must never count as an unwanted one.
     val hintTags = if (hintPriority.isEmpty()) emptySet() else parseHintTagsIn(cleaned)
     val hintRank = hintPriority.indexOfFirst { it in hintTags }.takeIf { it >= 0 }
@@ -486,7 +504,7 @@ private fun profileLessonEffect(
     val hintUnwanted = hintTags.isNotEmpty() && hintRank == null
     val ranks =
         reading.magnitudes.keys
-            .filterNot { (it == LessonEffectCategory.STAT_GAINS && statRank < 0) || (it == LessonEffectCategory.SKILL_HINTS && hintUnwanted) }
+            .filterNot { (it == LessonEffectCategory.STAT_GAINS && rankedStatGain == null) || (it == LessonEffectCategory.SKILL_HINTS && hintUnwanted) }
             .mapNotNull { categoryOrder.indexOf(it).takeIf { rank -> rank >= 0 } }
             .sorted()
     val categoryValue = ranks.firstOrNull()?.let { reading.magnitudes[categoryOrder[it]] } ?: 0.0

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/GrandLiveLessons.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/GrandLiveLessons.kt
@@ -217,6 +217,50 @@ val DEFAULT_LESSON_EFFECT_PRIORITY: List<LessonEffectCategory> =
     )
 
 /**
+ * A tag a skill-hint effect can name in parentheses (e.g. "Skill Hint Lvl +3 (Pace Chaser)"). The user ranks these via the Lesson Skill Hint Priority
+ * setting (Scenario Overrides), which decides between two otherwise equal hint cards. An empty ranking leaves hint cards ordered as before.
+ *
+ * @property displayName The user-facing name stored in the setting.
+ */
+enum class LessonHintTag(val displayName: String) {
+    FRONT_RUNNER("Front Runner"),
+    PACE_CHASER("Pace Chaser"),
+    LATE_SURGER("Late Surger"),
+    END_CLOSER("End Closer"),
+    SPRINT("Sprint"),
+    MILE("Mile"),
+    MEDIUM("Medium"),
+    LONG("Long"),
+    TURF("Turf"),
+    DIRT("Dirt"),
+    ;
+
+    /** The display name's lowercased words, precomputed because every tag is scanned against every hint card. */
+    private val lowerWords: List<String> = displayName.lowercase().split(" ")
+
+    /** The running style this tag names, or null for a distance / surface tag. Read off the entry name, which matches [RunningStyle]'s. */
+    val runningStyle: RunningStyle? get() = RunningStyle.fromName(name)
+
+    /**
+     * Whether an effect names this tag.
+     *
+     * @param lowercased The card's effect line(s), already lowercased.
+     * @return True when every word of the display name appears.
+     */
+    fun matches(lowercased: String): Boolean = lowerWords.all { it in lowercased }
+
+    companion object {
+        /**
+         * Resolve a setting string back to its tag.
+         *
+         * @param value The stored display name.
+         * @return The matching tag, or null for an unknown string.
+         */
+        fun fromDisplayName(value: String): LessonHintTag? = entries.firstOrNull { it.displayName.equals(value.trim(), ignoreCase = true) }
+    }
+}
+
+/**
  * One item (Technique or Song) on the Grand Live Lessons screen, read via the per-card cost-pill anchor.
  *
  * @property kind Whether the card is a Technique or a Song.
@@ -239,9 +283,11 @@ data class LessonOption(
  * @property ranks The user-ranked positions of the categories the card matched, ascending, compared lexicographically.
  * @property categoryValue How much of its best-ranked category the card grants (a "+2" gain, a "+10%" bonus), higher is better. Only ever compared between
  *   cards whose [ranks] already tied, which means they matched the same categories, so the value always compares like against like.
- * @property statTieBreak Value of the card's stat gain, higher is better, used only once [ranks] and [categoryValue] tie.
+ * @property statTieBreak Value of the card's stat gain, higher is better, used only once the earlier tie-breaks tie.
+ * @property hintTieBreak Value of the card's best user-ranked skill-hint tag, higher is better, zero when the card is not a ranked hint. Outranks
+ *   [categoryValue], since Skill Hints mixes hint levels with skill-point totals and an explicit ranking beats comparing those two as numbers.
  */
-private data class LessonEffectProfile(val ranks: List<Int>, val categoryValue: Double, val statTieBreak: Double)
+private data class LessonEffectProfile(val ranks: List<Int>, val categoryValue: Double, val statTieBreak: Double, val hintTieBreak: Double)
 
 /**
  * Strip the post-concert warning overlay the game paints over a Song's effect line. The effect crop reads it as trailing noise, which would
@@ -313,16 +359,24 @@ fun parseEnergyGain(effectText: String): Int? = parseEnergyGainIn(stripConcertOv
 private fun parseEnergyGainIn(cleaned: String): Int? = ENERGY_GAIN_REGEX.find(cleaned)?.groupValues?.get(1)?.toIntOrNull()
 
 /**
- * The running style named in a skill-hint effect (e.g. "Pace Chaser" in "Skill Hint Lvl +3 (Pace Chaser)"). Returns null for a
- * non-hint effect or a hint tied to a distance / generic category (e.g. "(Long)") rather than a running style.
+ * The tags named in a skill-hint effect (e.g. "Pace Chaser" in "Skill Hint Lvl +3 (Pace Chaser)"). Returns empty for a non-hint effect or a hint whose tag
+ * was not recognized, which OCR noise makes common enough that callers must treat empty as "unknown", never as "unwanted".
  *
  * @param effectText The card's effect line(s).
- * @return The referenced [RunningStyle], or null.
+ * @return The referenced tags, in enum order.
  */
-fun parseHintRunningStyle(effectText: String): RunningStyle? {
-    val t = effectText.lowercase()
-    if ("hint" !in t) return null
-    return RunningStyle.entries.firstOrNull { style -> style.name.lowercase().split("_").all { it in t } }
+fun parseHintTags(effectText: String): Set<LessonHintTag> = parseHintTagsIn(stripConcertOverOverlay(effectText))
+
+/**
+ * Match hint tags against text the overlay has already been stripped from, so a caller that cleans once does not pay for it again.
+ *
+ * @param cleaned The card's effect line(s), overlay already removed.
+ * @return The referenced tags, in enum order.
+ */
+private fun parseHintTagsIn(cleaned: String): Set<LessonHintTag> {
+    val t = cleaned.lowercase()
+    if ("hint" !in t) return emptySet()
+    return LessonHintTag.entries.filterTo(linkedSetOf()) { it.matches(t) }
 }
 
 /**
@@ -370,9 +424,9 @@ fun detectLessonCategories(effectText: String): Set<LessonEffectCategory> = read
 private fun firstAmount(regex: Regex, text: String): Double? = regex.find(text)?.groupValues?.get(1)?.toDoubleOrNull()
 
 /**
- * Read a card's categories and how much of each it grants, in one pass. Recognition and measurement live on the same line on purpose: a magnitude pattern
- * stricter than the keyword that recognized the category would let a card match and then score zero, silently falling back to screen position. Every
- * magnitude falls back to 0.0, so a lost amount only ever costs a tie-break, never the category.
+ * Read a card's categories and how much of each it grants, in one pass. Recognition and measurement live on the same line on purpose: when they were
+ * separate the magnitude patterns drifted stricter than the detection keywords, so a card read as "Hint Lvl +3" counted as a Skill Hint and then scored
+ * zero, silently falling back to screen position. Every magnitude falls back to 0.0, so a lost amount only ever costs a tie-break, never the category.
  *
  * Training Effectiveness is also inferred when OCR lost its label, which happens often enough to matter: the effect crop routinely reads the "+10%" cards
  * down to a bare percentage, and the post-concert overlay can replace the line outright. A bare percentage and a raw stat gain at or above
@@ -403,28 +457,42 @@ private fun readLessonEffect(cleaned: String): LessonEffectReading {
 /**
  * Reduce a Lessons card's effect text to everything the purchase ordering needs. Computed once per card so the comparator never re-parses.
  *
- * Categories left out of the ranking are dropped, as is a Stat Gains match whose stat is absent from the stat prioritization - such a card
- * ranks below anything with a ranked effect, but is still bought when it is the only option.
+ * Categories left out of the ranking are dropped, as is a Stat Gains match whose stat is absent from the stat prioritization, and a Skill Hints match
+ * whose tag is absent from a non-empty hint ranking - such a card ranks below anything with a ranked effect, but is still bought when it is the only
+ * option. A hint whose tag was not recognized at all is never dropped, so OCR noise cannot demote a card.
  *
  * @param effectText The card's effect line(s).
  * @param statPriority The bot's ordered stat prioritization (index 0 = highest).
  * @param categoryOrder The user's ranked effect categories (index 0 = highest).
+ * @param hintPriority The user's ranked skill-hint tags (index 0 = highest). Empty means no hint preference.
  * @return The card's ranking profile.
  */
-private fun profileLessonEffect(effectText: String, statPriority: List<StatName>, categoryOrder: List<LessonEffectCategory>): LessonEffectProfile {
+private fun profileLessonEffect(
+    effectText: String,
+    statPriority: List<StatName>,
+    categoryOrder: List<LessonEffectCategory>,
+    hintPriority: List<LessonHintTag>,
+): LessonEffectProfile {
     val cleaned = stripConcertOverOverlay(effectText)
     val reading = readLessonEffect(cleaned)
     // A leading stat gain is what puts a card in Stat Gains, so it is preferred here; the named passive only stands in for the tie-break.
     val statGain = reading.rawStatGain ?: reading.trainingStatGain
     val statRank = statGain?.let { statPriority.indexOf(it.first) } ?: -1
+    // Scanning the tag table is only worth it once the user has ranked something, and an unrecognized tag must never count as an unwanted one.
+    val hintTags = if (hintPriority.isEmpty()) emptySet() else parseHintTagsIn(cleaned)
+    val hintRank = hintPriority.indexOfFirst { it in hintTags }.takeIf { it >= 0 }
+    // Both guards say the same thing: a card whose specific target the user ranked away is demoted below anything ranked, never blocked outright, so it
+    // is still bought when it is the only option. Stat Gains needs no unrecognized-target escape, since detection already gates on the same parse.
+    val hintUnwanted = hintTags.isNotEmpty() && hintRank == null
     val ranks =
         reading.magnitudes.keys
-            .filterNot { it == LessonEffectCategory.STAT_GAINS && statRank < 0 }
+            .filterNot { (it == LessonEffectCategory.STAT_GAINS && statRank < 0) || (it == LessonEffectCategory.SKILL_HINTS && hintUnwanted) }
             .mapNotNull { categoryOrder.indexOf(it).takeIf { rank -> rank >= 0 } }
             .sorted()
     val categoryValue = ranks.firstOrNull()?.let { reading.magnitudes[categoryOrder[it]] } ?: 0.0
     val statTieBreak = if (statGain != null && statRank >= 0) (statPriority.size - statRank).toDouble() + statGain.second * 0.001 else 0.0
-    return LessonEffectProfile(ranks, categoryValue, statTieBreak)
+    val hintTieBreak = hintRank?.let { (hintPriority.size - it).toDouble() } ?: 0.0
+    return LessonEffectProfile(ranks, categoryValue, statTieBreak, hintTieBreak)
 }
 
 /**
@@ -443,22 +511,32 @@ private fun compareLessonRanks(a: List<Int>, b: List<Int>): Int {
 }
 
 /**
- * Pick the best card, profiling each one exactly once. Category ranks decide first, then how much of that category the card grants, then a Technique
- * edges out a Song of equal value, then the better stat gain, and finally the earlier row.
+ * Pick the best card, profiling each one exactly once. Category ranks decide first, then the better-ranked skill hint, then how much of that category the
+ * card grants, then a Technique edges out a Song of equal value, then the better stat gain, and finally the earlier row.
  *
  * Magnitude sits above the Technique preference on purpose: a "Training Wit Gain +2" Song is worth more than a "Training Guts Gain +1" Technique, and
  * before magnitude was read at all those two tied all the way down to screen position.
  *
+ * The hint ranking sits above magnitude because Skill Hints is the one category holding two different units - a hint level ("Skill Hint Lvl +1") and a
+ * skill-point total ("Skill Pts +5") - which are not comparable as numbers. An explicit tag ranking is the better signal, so it decides first.
+ *
  * @param options The cards to choose between.
  * @param statPriority The bot's ordered stat prioritization (index 0 = highest).
  * @param categoryOrder The user's ranked effect categories (index 0 = highest).
+ * @param hintPriority The user's ranked skill-hint tags (index 0 = highest).
  * @return The best card, or null when `options` is empty.
  */
-private fun bestLesson(options: List<LessonOption>, statPriority: List<StatName>, categoryOrder: List<LessonEffectCategory>): LessonOption? =
+private fun bestLesson(
+    options: List<LessonOption>,
+    statPriority: List<StatName>,
+    categoryOrder: List<LessonEffectCategory>,
+    hintPriority: List<LessonHintTag>,
+): LessonOption? =
     options
-        .map { it to profileLessonEffect(it.effectText, statPriority, categoryOrder) }
+        .map { it to profileLessonEffect(it.effectText, statPriority, categoryOrder, hintPriority) }
         .maxWithOrNull(
             Comparator<Pair<LessonOption, LessonEffectProfile>> { a, b -> compareLessonRanks(a.second.ranks, b.second.ranks) }
+                .thenBy { it.second.hintTieBreak }
                 .thenBy { it.second.categoryValue }
                 .thenBy { it.first.kind == LessonKind.TECHNIQUE }
                 .thenBy { it.second.statTieBreak }
@@ -486,6 +564,7 @@ fun isSoughtAfter(effectText: String, categoryOrder: List<LessonEffectCategory>)
  * @param forceMaxHype Whether the caller is at concert-day and wants Hype maxed before performing.
  * @param hypeMaxed Whether the Hype gauge is already full.
  * @param categoryOrder The user's ranked effect categories (index 0 = highest).
+ * @param hintPriority The user's ranked skill-hint tags (index 0 = highest). Empty means no hint preference.
  * @return The chosen option, or null when `options` is empty.
  */
 fun chooseLessonPurchase(
@@ -494,11 +573,12 @@ fun chooseLessonPurchase(
     forceMaxHype: Boolean,
     hypeMaxed: Boolean,
     categoryOrder: List<LessonEffectCategory> = DEFAULT_LESSON_EFFECT_PRIORITY,
+    hintPriority: List<LessonHintTag> = emptyList(),
 ): LessonOption? {
     if (forceMaxHype && !hypeMaxed) {
-        val hypeSong = bestLesson(options.filter { it.kind == LessonKind.SONG }, statPriority, categoryOrder)
+        val hypeSong = bestLesson(options.filter { it.kind == LessonKind.SONG }, statPriority, categoryOrder, hintPriority)
         if (hypeSong != null) return hypeSong
     }
 
-    return bestLesson(options, statPriority, categoryOrder)
+    return bestLesson(options, statPriority, categoryOrder, hintPriority)
 }

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/GrandLiveLessons.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/GrandLiveLessons.kt
@@ -159,10 +159,16 @@ private val TRAINING_STAT_GAIN_REGEX = Regex("training\\s+($STAT_ALTERNATION)\\s
 private val TRAINING_GAIN_AMOUNT_REGEX = Regex("gain[^+]*\\+\\s*(\\d+)", RegexOption.IGNORE_CASE)
 
 /**
- * Matches the amount on a skill-point or skill-hint effect ("Skill Point Bonus +3", "Skill Hint Lvl +2"), tolerating a lost leading word.
+ * Matches the skill-point wording a Lessons card uses. The game always abbreviates it ("Skill Pts +22", "Training Skill Pt Gain +2") and never spells the
+ * word out, so the original "skill point" keyword never fired and a card granting only skill points matched no category at all.
+ */
+private val SKILL_POINT_REGEX = Regex("skill\\s+p(?:ts?|oint)", RegexOption.IGNORE_CASE)
+
+/**
+ * Matches the amount on a skill-point or skill-hint effect ("Training Skill Pt Gain +3", "Skill Hint Lvl +2"), tolerating a lost leading word.
  * Anchored on the same keywords that recognize the category, so a card can never be read as a hint and then score no magnitude.
  */
-private val SKILL_HINT_AMOUNT_REGEX = Regex("(?:hint|skill\\s+point)[^+]*\\+\\s*(\\d+)", RegexOption.IGNORE_CASE)
+private val SKILL_HINT_AMOUNT_REGEX = Regex("(?:hint|skill\\s+p(?:ts?|oint))[^+]*\\+\\s*(\\d+)", RegexOption.IGNORE_CASE)
 
 /**
  * Matches the resulting-energy readout on the Lessons purchase confirmation ("78 / 100"), capturing both the projected new energy and the
@@ -389,7 +395,7 @@ private fun readLessonEffect(cleaned: String): LessonEffectReading {
     }
     if (("support" in t && "event" in t) || "specialty priority" in t) magnitudes[LessonEffectCategory.SUPPORT_EVENTS] = 0.0
     if (rawStatGain != null) magnitudes[LessonEffectCategory.STAT_GAINS] = 0.0
-    if ("hint" in t || "skill point" in t) magnitudes[LessonEffectCategory.SKILL_HINTS] = firstAmount(SKILL_HINT_AMOUNT_REGEX, cleaned) ?: 0.0
+    if ("hint" in t || SKILL_POINT_REGEX.containsMatchIn(cleaned)) magnitudes[LessonEffectCategory.SKILL_HINTS] = firstAmount(SKILL_HINT_AMOUNT_REGEX, cleaned) ?: 0.0
     if (energy != null) magnitudes[LessonEffectCategory.ENERGY] = energy.toDouble()
     return LessonEffectReading(magnitudes, rawStatGain, trainingStatGain)
 }

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/GrandLiveLessons.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/GrandLiveLessons.kt
@@ -119,8 +119,11 @@ const val MAX_LESSON_PURCHASES_PER_VISIT = 20
 /** A locked card counts as "sought after" (worth holding tokens for) when it matches a category ranked within this many top spots of the user's priority order. */
 private const val SOUGHT_AFTER_TOP_RANKS = 2
 
+/** The stat names as a regex alternation, derived from [StatName] so the gain patterns below cannot drift from the enum. */
+private val STAT_ALTERNATION = StatName.entries.joinToString("|") { it.name.lowercase() }
+
 /** Matches a raw stat-gain effect that leads with the stat (e.g. "Speed +5"), distinguishing it from passives like "Training Power Gain +1". */
-private val RAW_STAT_GAIN_REGEX = Regex("^\\s*(speed|stamina|power|guts|wit)\\s*\\+?\\s*(\\d+)", RegexOption.IGNORE_CASE)
+private val RAW_STAT_GAIN_REGEX = Regex("^\\s*($STAT_ALTERNATION)\\s*\\+?\\s*(\\d+)", RegexOption.IGNORE_CASE)
 
 /**
  * The greyed-out warning the game overlays on a Song's effect line once the concert has passed. The effect crop picks it up instead of (or
@@ -128,8 +131,11 @@ private val RAW_STAT_GAIN_REGEX = Regex("^\\s*(speed|stamina|power|guts|wit)\\s*
  */
 private val CONCERT_OVER_OVERLAY_REGEX = Regex("O?\\s*This bonus won't take effect.*", RegexOption.IGNORE_CASE)
 
-/** Matches an effect line that OCR'd down to a bare percentage ("+10%"), losing the "Friendship Training Effectiveness" label in front of it. */
-private val BARE_PERCENT_REGEX = Regex("(^|\\s)\\+\\s*\\d+\\s*%", RegexOption.IGNORE_CASE)
+/**
+ * Matches the percentage on a Friendship / Training Effectiveness effect, capturing it so the same pattern both recognizes the category and measures it.
+ * A percentage is also how the category is recovered when OCR truncated the line to a bare "+10%", losing the label in front of it.
+ */
+private val EFFECTIVENESS_PERCENT_REGEX = Regex("\\+\\s*(\\d+)\\s*%")
 
 /**
  * Smallest raw stat gain that only ever appears on a Friendship Training Effectiveness Song. Techniques top out well below this, so a card
@@ -139,6 +145,24 @@ private const val TRAINING_EFFECTIVENESS_STAT_FLOOR = 20
 
 /** Matches an Energy gain effect (e.g. "Energy +20"). */
 private val ENERGY_GAIN_REGEX = Regex("energy\\s*\\+\\s*(\\d+)", RegexOption.IGNORE_CASE)
+
+/**
+ * Matches a passive training-gain effect that names its stat ("Training Wit Gain +2"), which the leading-stat [RAW_STAT_GAIN_REGEX] deliberately refuses.
+ * Only the stat tie-break reads this. It must never decide the Training Gain category, or every such card would start matching Stat Gains too.
+ */
+private val TRAINING_STAT_GAIN_REGEX = Regex("training\\s+($STAT_ALTERNATION)\\s+gain\\s*\\+?\\s*(\\d+)", RegexOption.IGNORE_CASE)
+
+/**
+ * Matches the amount on a training-gain effect even when OCR lost the stat word ("Training Gain +2"). Anchored on "gain" so it reads this effect's amount
+ * and not a neighbouring line's, and kept as loose as the "training" plus "gain" keywords that recognize the category.
+ */
+private val TRAINING_GAIN_AMOUNT_REGEX = Regex("gain[^+]*\\+\\s*(\\d+)", RegexOption.IGNORE_CASE)
+
+/**
+ * Matches the amount on a skill-point or skill-hint effect ("Skill Point Bonus +3", "Skill Hint Lvl +2"), tolerating a lost leading word.
+ * Anchored on the same keywords that recognize the category, so a card can never be read as a hint and then score no magnitude.
+ */
+private val SKILL_HINT_AMOUNT_REGEX = Regex("(?:hint|skill\\s+point)[^+]*\\+\\s*(\\d+)", RegexOption.IGNORE_CASE)
 
 /**
  * Matches the resulting-energy readout on the Lessons purchase confirmation ("78 / 100"), capturing both the projected new energy and the
@@ -207,9 +231,11 @@ data class LessonOption(
  * A card's effect text reduced to what the purchase ordering compares on.
  *
  * @property ranks The user-ranked positions of the categories the card matched, ascending, compared lexicographically.
- * @property statTieBreak Value of the card's raw stat gain, higher is better, used only once [ranks] ties.
+ * @property categoryValue How much of its best-ranked category the card grants (a "+2" gain, a "+10%" bonus), higher is better. Only ever compared between
+ *   cards whose [ranks] already tied, which means they matched the same categories, so the value always compares like against like.
+ * @property statTieBreak Value of the card's stat gain, higher is better, used only once [ranks] and [categoryValue] tie.
  */
-private data class LessonEffectProfile(val ranks: List<Int>, val statTieBreak: Double)
+private data class LessonEffectProfile(val ranks: List<Int>, val categoryValue: Double, val statTieBreak: Double)
 
 /**
  * Strip the post-concert warning overlay the game paints over a Song's effect line. The effect crop reads it as trailing noise, which would
@@ -243,12 +269,42 @@ private fun parseStatGainIn(cleaned: String): Pair<StatName, Int>? {
 }
 
 /**
+ * Parse a passive training-gain effect ("Training Wit Gain +2") into its stat and amount. This is the counterpart to [parseStatGain], which only accepts a
+ * gain that leads the effect. A card matching here still belongs to Training Gain, never to Stat Gains.
+ *
+ * @param effectText The card's effect line(s).
+ * @return The (stat, amount) pair, or null when the effect is not a named training gain.
+ */
+fun parseTrainingStatGain(effectText: String): Pair<StatName, Int>? = parseTrainingStatGainIn(stripConcertOverOverlay(effectText))
+
+/**
+ * Parse a named training gain from text the overlay has already been stripped from, so a caller that cleans once does not pay for it again.
+ *
+ * @param cleaned The card's effect line(s), overlay already removed.
+ * @return The (stat, amount) pair, or null when the effect is not a named training gain.
+ */
+private fun parseTrainingStatGainIn(cleaned: String): Pair<StatName, Int>? {
+    val match = TRAINING_STAT_GAIN_REGEX.find(cleaned) ?: return null
+    val stat = StatName.fromName(match.groupValues[1]) ?: return null
+    val amount = match.groupValues[2].toIntOrNull() ?: return null
+    return stat to amount
+}
+
+/**
  * Parse an Energy gain effect ("Energy +20").
  *
  * @param effectText The card's effect line(s).
  * @return The energy gain amount, or null when the card grants no energy.
  */
-fun parseEnergyGain(effectText: String): Int? = ENERGY_GAIN_REGEX.find(stripConcertOverOverlay(effectText))?.groupValues?.get(1)?.toIntOrNull()
+fun parseEnergyGain(effectText: String): Int? = parseEnergyGainIn(stripConcertOverOverlay(effectText))
+
+/**
+ * Parse an Energy gain from text the overlay has already been stripped from, so a caller that cleans once does not pay for it again.
+ *
+ * @param cleaned The card's effect line(s), overlay already removed.
+ * @return The energy gain amount, or null when the card grants no energy.
+ */
+private fun parseEnergyGainIn(cleaned: String): Int? = ENERGY_GAIN_REGEX.find(cleaned)?.groupValues?.get(1)?.toIntOrNull()
 
 /**
  * The running style named in a skill-hint effect (e.g. "Pace Chaser" in "Skill Hint Lvl +3 (Pace Chaser)"). Returns null for a
@@ -277,35 +333,65 @@ fun parseProjectedEnergy(text: String): Pair<Int, Int>? {
 }
 
 /**
- * Detect which effect categories a card's effect text matches. A card with two effect lines can match several.
+ * Everything one pass over a card's effect text yields, so neither the categories, the magnitudes, nor the comparator ever re-parse it.
  *
- * Training Effectiveness is also inferred when OCR lost its label, which happens often enough to matter: the effect crop routinely reads
- * the "+10%" cards down to a bare percentage, and the post-concert overlay can replace the line outright. A bare percentage and a raw stat
- * gain at or above [TRAINING_EFFECTIVENESS_STAT_FLOOR] both only ever occur on these Songs, so either one stands in for the missing label.
+ * @property magnitudes The matched categories, each mapped to how much of it the card grants. Support Events is flat and Stat Gains is ordered by the
+ *   stat prioritization instead, so both map to 0.0.
+ * @property rawStatGain The card's leading stat gain ("Speed +26"), or null.
+ * @property trainingStatGain The card's named passive gain ("Training Wit Gain +2"), or null.
+ */
+private data class LessonEffectReading(
+    val magnitudes: Map<LessonEffectCategory, Double>,
+    val rawStatGain: Pair<StatName, Int>?,
+    val trainingStatGain: Pair<StatName, Int>?,
+)
+
+/**
+ * Detect which effect categories a card's effect text matches. A card with two effect lines can match several.
  *
  * @param effectText The card's effect line(s).
  * @return The matched categories (empty when nothing recognizable was read).
  */
-fun detectLessonCategories(effectText: String): Set<LessonEffectCategory> = detectLessonCategoriesIn(stripConcertOverOverlay(effectText))
+fun detectLessonCategories(effectText: String): Set<LessonEffectCategory> = readLessonEffect(stripConcertOverOverlay(effectText)).magnitudes.keys
 
 /**
- * Match categories against text the overlay has already been stripped from, so a caller that cleans once does not pay for it again.
+ * The first capture group of [regex] in [text], as a number.
+ *
+ * @param regex A pattern whose first group holds an amount.
+ * @param text The text to search.
+ * @return The parsed amount, or null when the pattern did not match.
+ */
+private fun firstAmount(regex: Regex, text: String): Double? = regex.find(text)?.groupValues?.get(1)?.toDoubleOrNull()
+
+/**
+ * Read a card's categories and how much of each it grants, in one pass. Recognition and measurement live on the same line on purpose: a magnitude pattern
+ * stricter than the keyword that recognized the category would let a card match and then score zero, silently falling back to screen position. Every
+ * magnitude falls back to 0.0, so a lost amount only ever costs a tie-break, never the category.
+ *
+ * Training Effectiveness is also inferred when OCR lost its label, which happens often enough to matter: the effect crop routinely reads the "+10%" cards
+ * down to a bare percentage, and the post-concert overlay can replace the line outright. A bare percentage and a raw stat gain at or above
+ * [TRAINING_EFFECTIVENESS_STAT_FLOOR] both only ever occur on these Songs, so either one stands in for the missing label.
  *
  * @param cleaned The card's effect line(s), overlay already removed.
- * @return The matched categories (empty when nothing recognizable was read).
+ * @return The card's reading, with empty magnitudes when nothing recognizable was read.
  */
-private fun detectLessonCategoriesIn(cleaned: String): Set<LessonEffectCategory> {
+private fun readLessonEffect(cleaned: String): LessonEffectReading {
     val t = cleaned.lowercase()
-    val statGain = parseStatGainIn(cleaned)
-    val categories = mutableSetOf<LessonEffectCategory>()
-    val labelLost = BARE_PERCENT_REGEX.containsMatchIn(cleaned) || (statGain?.second ?: 0) >= TRAINING_EFFECTIVENESS_STAT_FLOOR
-    if ("friendship" in t || "training effectiveness" in t || labelLost) categories.add(LessonEffectCategory.TRAINING_EFFECTIVENESS)
-    if ("training" in t && "gain" in t) categories.add(LessonEffectCategory.TRAINING_GAIN)
-    if (("support" in t && "event" in t) || "specialty priority" in t) categories.add(LessonEffectCategory.SUPPORT_EVENTS)
-    if (statGain != null) categories.add(LessonEffectCategory.STAT_GAINS)
-    if ("hint" in t || "skill point" in t) categories.add(LessonEffectCategory.SKILL_HINTS)
-    if (ENERGY_GAIN_REGEX.containsMatchIn(cleaned)) categories.add(LessonEffectCategory.ENERGY)
-    return categories
+    val rawStatGain = parseStatGainIn(cleaned)
+    val trainingStatGain = parseTrainingStatGainIn(cleaned)
+    val percent = firstAmount(EFFECTIVENESS_PERCENT_REGEX, cleaned)
+    val energy = parseEnergyGainIn(cleaned)
+    val magnitudes = mutableMapOf<LessonEffectCategory, Double>()
+    val labelLost = percent != null || (rawStatGain?.second ?: 0) >= TRAINING_EFFECTIVENESS_STAT_FLOOR
+    if ("friendship" in t || "training effectiveness" in t || labelLost) magnitudes[LessonEffectCategory.TRAINING_EFFECTIVENESS] = percent ?: 0.0
+    if ("training" in t && "gain" in t) {
+        magnitudes[LessonEffectCategory.TRAINING_GAIN] = trainingStatGain?.second?.toDouble() ?: firstAmount(TRAINING_GAIN_AMOUNT_REGEX, cleaned) ?: 0.0
+    }
+    if (("support" in t && "event" in t) || "specialty priority" in t) magnitudes[LessonEffectCategory.SUPPORT_EVENTS] = 0.0
+    if (rawStatGain != null) magnitudes[LessonEffectCategory.STAT_GAINS] = 0.0
+    if ("hint" in t || "skill point" in t) magnitudes[LessonEffectCategory.SKILL_HINTS] = firstAmount(SKILL_HINT_AMOUNT_REGEX, cleaned) ?: 0.0
+    if (energy != null) magnitudes[LessonEffectCategory.ENERGY] = energy.toDouble()
+    return LessonEffectReading(magnitudes, rawStatGain, trainingStatGain)
 }
 
 /**
@@ -321,15 +407,18 @@ private fun detectLessonCategoriesIn(cleaned: String): Set<LessonEffectCategory>
  */
 private fun profileLessonEffect(effectText: String, statPriority: List<StatName>, categoryOrder: List<LessonEffectCategory>): LessonEffectProfile {
     val cleaned = stripConcertOverOverlay(effectText)
-    val statGain = parseStatGainIn(cleaned)
+    val reading = readLessonEffect(cleaned)
+    // A leading stat gain is what puts a card in Stat Gains, so it is preferred here; the named passive only stands in for the tie-break.
+    val statGain = reading.rawStatGain ?: reading.trainingStatGain
     val statRank = statGain?.let { statPriority.indexOf(it.first) } ?: -1
     val ranks =
-        detectLessonCategoriesIn(cleaned)
+        reading.magnitudes.keys
             .filterNot { it == LessonEffectCategory.STAT_GAINS && statRank < 0 }
             .mapNotNull { categoryOrder.indexOf(it).takeIf { rank -> rank >= 0 } }
             .sorted()
+    val categoryValue = ranks.firstOrNull()?.let { reading.magnitudes[categoryOrder[it]] } ?: 0.0
     val statTieBreak = if (statGain != null && statRank >= 0) (statPriority.size - statRank).toDouble() + statGain.second * 0.001 else 0.0
-    return LessonEffectProfile(ranks, statTieBreak)
+    return LessonEffectProfile(ranks, categoryValue, statTieBreak)
 }
 
 /**
@@ -348,8 +437,11 @@ private fun compareLessonRanks(a: List<Int>, b: List<Int>): Int {
 }
 
 /**
- * Pick the best card, profiling each one exactly once. Category ranks decide first, then a Technique edges out a Song of equal effect
- * value, then the better raw stat gain, and finally the earlier row.
+ * Pick the best card, profiling each one exactly once. Category ranks decide first, then how much of that category the card grants, then a Technique
+ * edges out a Song of equal value, then the better stat gain, and finally the earlier row.
+ *
+ * Magnitude sits above the Technique preference on purpose: a "Training Wit Gain +2" Song is worth more than a "Training Guts Gain +1" Technique, and
+ * before magnitude was read at all those two tied all the way down to screen position.
  *
  * @param options The cards to choose between.
  * @param statPriority The bot's ordered stat prioritization (index 0 = highest).
@@ -361,6 +453,7 @@ private fun bestLesson(options: List<LessonOption>, statPriority: List<StatName>
         .map { it to profileLessonEffect(it.effectText, statPriority, categoryOrder) }
         .maxWithOrNull(
             Comparator<Pair<LessonOption, LessonEffectProfile>> { a, b -> compareLessonRanks(a.second.ranks, b.second.ranks) }
+                .thenBy { it.second.categoryValue }
                 .thenBy { it.first.kind == LessonKind.TECHNIQUE }
                 .thenBy { it.second.statTieBreak }
                 .thenByDescending { it.first.rowIndex },

--- a/android/app/src/test/java/com/steve1316/uma_android_automation/bot/campaigns/GrandLiveLessonPolicyTest.kt
+++ b/android/app/src/test/java/com/steve1316/uma_android_automation/bot/campaigns/GrandLiveLessonPolicyTest.kt
@@ -248,6 +248,7 @@ class GrandLiveLessonPolicyTest {
         assertFalse(hasLearnableRibbon(ribbonYs, 673.0, 337))
         assertEquals(2, ribbonYs.count { it in (1081.0 - 746)..1081.0 })
     }
+
     @Test
     @DisplayName("A bigger Training Gain wins over a smaller one, even for a lower-priority stat")
     fun prefersBiggerTrainingGain() {
@@ -315,6 +316,50 @@ class GrandLiveLessonPolicyTest {
     }
 
     @Test
+    @DisplayName("Hint tags are parsed from the effect's parenthetical")
+    fun parsesHintTags() {
+        assertEquals(setOf(LessonHintTag.PACE_CHASER), parseHintTags("Skill Hint Lvl +3 (Pace Chaser)"))
+        assertEquals(setOf(LessonHintTag.MEDIUM), parseHintTags("Energy +20 Skill Hint Lvl +3 (Medium)"))
+        assertTrue(parseHintTags("Training Speed Gain +1").isEmpty())
+    }
+
+    @Test
+    @DisplayName("A ranked skill-hint tag wins over an unranked one")
+    fun rankedHintTagWins() {
+        val options =
+            listOf(
+                tech("Skill Hint Lvl +1 (Sprint)", 0),
+                tech("Skill Hint Lvl +1 (Long)", 1),
+            )
+        // With no hint ranking the two are indistinguishable, so the earlier row wins.
+        assertEquals(0, chooseLessonPurchase(options, priority, forceMaxHype = false, hypeMaxed = true)?.rowIndex)
+
+        val longFirst = listOf(LessonHintTag.LONG)
+        assertEquals(1, chooseLessonPurchase(options, priority, forceMaxHype = false, hypeMaxed = true, hintPriority = longFirst)?.rowIndex)
+    }
+
+    @Test
+    @DisplayName("A hint whose tag is unranked is still bought when it is the only option")
+    fun unrankedHintIsLastResort() {
+        val options = listOf(tech("Skill Hint Lvl +1 (Sprint)", 0))
+        val longFirst = listOf(LessonHintTag.LONG)
+        assertEquals(0, chooseLessonPurchase(options, priority, forceMaxHype = false, hypeMaxed = true, hintPriority = longFirst)?.rowIndex)
+    }
+
+    @Test
+    @DisplayName("A hint with no recognizable tag is never demoted by the hint ranking")
+    fun untaggedHintIsNotDemoted() {
+        // OCR routinely loses the parenthetical, and a card that reads as a bare hint must not fall below an unrelated unranked card.
+        val options =
+            listOf(
+                tech("Skill Hint Lvl +2", 0),
+                tech("Energy +20", 1),
+            )
+        val longFirst = listOf(LessonHintTag.LONG)
+        assertEquals(0, chooseLessonPurchase(options, priority, forceMaxHype = false, hypeMaxed = true, hintPriority = longFirst)?.rowIndex)
+    }
+
+    @Test
     @DisplayName("Magnitude survives OCR losing a leading word, so a card never scores zero for a category it matched")
     fun magnitudeToleratesLostLabel() {
         // Detection accepts a bare "hint" or a bare "training" plus "gain", so measurement has to accept the same. When it did not, a card read as
@@ -335,6 +380,22 @@ class GrandLiveLessonPolicyTest {
     }
 
     @Test
+    @DisplayName("Skill point cards are recognized through the abbreviated wording the game actually prints")
+    fun recognizesAbbreviatedSkillPoints() {
+        // Observed on device: the game only ever prints "Skill Pts +12" or "Training Skill Pt Gain +3", never "Skill Point". The old keyword looked for
+        // the spelled-out form, so a card granting only skill points matched no category at all and fell through to screen position.
+        assertTrue(detectLessonCategories("Skill Pts +12").contains(LessonEffectCategory.SKILL_HINTS))
+        assertTrue(detectLessonCategories("Training Skill Pt Gain +3").contains(LessonEffectCategory.SKILL_HINTS))
+
+        val options =
+            listOf(
+                tech("Skill Pts +5", 0),
+                tech("Skill Pts +12", 1),
+            )
+        assertEquals(1, chooseLessonPurchase(options, priority, forceMaxHype = false, hypeMaxed = true)?.rowIndex)
+    }
+
+    @Test
     @DisplayName("Effect text captured from a real run scores the way the log shows it should")
     fun scoresRealDeviceEffectText() {
         // Every string here is verbatim from a Grand Live run, OCR noise included. The bare "+10%" is a card whose Friendship Training Effectiveness
@@ -351,19 +412,18 @@ class GrandLiveLessonPolicyTest {
         assertTrue(detectLessonCategories(expired).contains(LessonEffectCategory.TRAINING_GAIN))
         assertTrue(detectLessonCategories(expired).contains(LessonEffectCategory.SUPPORT_EVENTS))
     }
-    @Test
-    @DisplayName("Skill point cards are recognized through the abbreviated wording the game actually prints")
-    fun recognizesAbbreviatedSkillPoints() {
-        // Observed on device: the game only ever prints "Skill Pts +12" or "Training Skill Pt Gain +3", never "Skill Point". The old keyword looked for
-        // the spelled-out form, so a card granting only skill points matched no category at all and fell through to screen position.
-        assertTrue(detectLessonCategories("Skill Pts +12").contains(LessonEffectCategory.SKILL_HINTS))
-        assertTrue(detectLessonCategories("Training Skill Pt Gain +3").contains(LessonEffectCategory.SKILL_HINTS))
 
+    @Test
+    @DisplayName("A ranked hint tag beats a bigger skill-point total, whose magnitude is a different unit")
+    fun rankedHintBeatsSkillPointTotal() {
+        // Taken from a device scan. Both cards are Skill Hints, but one measures a hint level and the other a skill-point total, so their magnitudes are
+        // not comparable as numbers. The tag the user ranked is the better signal and has to win.
         val options =
             listOf(
-                tech("Skill Pts +5", 0),
-                tech("Skill Pts +12", 1),
+                tech("Skill Hint Lvl +1 (End Closer)", 0),
+                tech("Skill Pts +5", 1),
             )
-        assertEquals(1, chooseLessonPurchase(options, priority, forceMaxHype = false, hypeMaxed = true)?.rowIndex)
+        val endCloserRanked = listOf(LessonHintTag.LONG, LessonHintTag.END_CLOSER)
+        assertEquals(0, chooseLessonPurchase(options, priority, forceMaxHype = false, hypeMaxed = true, hintPriority = endCloserRanked)?.rowIndex)
     }
 }

--- a/android/app/src/test/java/com/steve1316/uma_android_automation/bot/campaigns/GrandLiveLessonPolicyTest.kt
+++ b/android/app/src/test/java/com/steve1316/uma_android_automation/bot/campaigns/GrandLiveLessonPolicyTest.kt
@@ -351,4 +351,19 @@ class GrandLiveLessonPolicyTest {
         assertTrue(detectLessonCategories(expired).contains(LessonEffectCategory.TRAINING_GAIN))
         assertTrue(detectLessonCategories(expired).contains(LessonEffectCategory.SUPPORT_EVENTS))
     }
+    @Test
+    @DisplayName("Skill point cards are recognized through the abbreviated wording the game actually prints")
+    fun recognizesAbbreviatedSkillPoints() {
+        // Observed on device: the game only ever prints "Skill Pts +12" or "Training Skill Pt Gain +3", never "Skill Point". The old keyword looked for
+        // the spelled-out form, so a card granting only skill points matched no category at all and fell through to screen position.
+        assertTrue(detectLessonCategories("Skill Pts +12").contains(LessonEffectCategory.SKILL_HINTS))
+        assertTrue(detectLessonCategories("Training Skill Pt Gain +3").contains(LessonEffectCategory.SKILL_HINTS))
+
+        val options =
+            listOf(
+                tech("Skill Pts +5", 0),
+                tech("Skill Pts +12", 1),
+            )
+        assertEquals(1, chooseLessonPurchase(options, priority, forceMaxHype = false, hypeMaxed = true)?.rowIndex)
+    }
 }

--- a/android/app/src/test/java/com/steve1316/uma_android_automation/bot/campaigns/GrandLiveLessonPolicyTest.kt
+++ b/android/app/src/test/java/com/steve1316/uma_android_automation/bot/campaigns/GrandLiveLessonPolicyTest.kt
@@ -248,4 +248,107 @@ class GrandLiveLessonPolicyTest {
         assertFalse(hasLearnableRibbon(ribbonYs, 673.0, 337))
         assertEquals(2, ribbonYs.count { it in (1081.0 - 746)..1081.0 })
     }
+    @Test
+    @DisplayName("A bigger Training Gain wins over a smaller one, even for a lower-priority stat")
+    fun prefersBiggerTrainingGain() {
+        // Reported on device: the bot bought "Training Guts Gain +1" over "Training Wit Gain +2". Both cards match the same categories, so the
+        // ranks tied and the pick fell through to screen position. Guts also outranks Wit in this priority, so only the magnitude can decide.
+        val options =
+            listOf(
+                song("Training Guts Gain +1 Support Chain Event Frequency Lvl +1", 0),
+                song("Training Wit Gain +2 Support Chain Event Frequency Lvl +1", 1),
+            )
+        assertEquals(1, chooseLessonPurchase(options, priority, forceMaxHype = false, hypeMaxed = true)?.rowIndex)
+
+        // Swapping the rows must not change the answer, which is what proves the choice no longer rides on screen position.
+        val swapped =
+            listOf(
+                song("Training Wit Gain +2 Support Chain Event Frequency Lvl +1", 0),
+                song("Training Guts Gain +1 Support Chain Event Frequency Lvl +1", 1),
+            )
+        assertEquals(0, chooseLessonPurchase(swapped, priority, forceMaxHype = false, hypeMaxed = true)?.rowIndex)
+    }
+
+    @Test
+    @DisplayName("A +10% Training Effectiveness song beats a +5% one carrying a better stat")
+    fun prefersBiggerTrainingEffectiveness() {
+        // "Full Speed Ahead! Umadol Power" (Speed +22, +5%) used to beat "Fanfare for the Future!" (Guts +26, +10%) because the percentage was
+        // never read, so the tie fell to the raw stat riding along on the card and Speed outranks Guts.
+        val options =
+            listOf(
+                song("Speed +22 Friendship Training Effectiveness +5%", 0),
+                song("Guts +26 Friendship Training Effectiveness +10%", 1),
+            )
+        assertEquals(1, chooseLessonPurchase(options, priority, forceMaxHype = false, hypeMaxed = true)?.rowIndex)
+    }
+
+    @Test
+    @DisplayName("A bigger gain on a Song outranks the Technique preference")
+    fun magnitudeBeatsTechniquePreference() {
+        val options =
+            listOf(
+                tech("Training Speed Gain +1", 0),
+                song("Training Speed Gain +2", 1),
+            )
+        assertEquals(1, chooseLessonPurchase(options, priority, forceMaxHype = false, hypeMaxed = true)?.rowIndex)
+    }
+
+    @Test
+    @DisplayName("Equal Training Gain magnitudes fall through to the stat prioritization")
+    fun equalTrainingGainFallsToStat() {
+        val options =
+            listOf(
+                song("Training Wit Gain +2", 0),
+                song("Training Speed Gain +2", 1),
+            )
+        assertEquals(1, chooseLessonPurchase(options, priority, forceMaxHype = false, hypeMaxed = true)?.rowIndex)
+    }
+
+    @Test
+    @DisplayName("A named training gain is parsed without becoming a raw stat gain")
+    fun parsesTrainingStatGain() {
+        assertEquals(StatName.WIT to 2, parseTrainingStatGain("Training Wit Gain +2"))
+        assertNull(parseTrainingStatGain("Speed +22"))
+        // The named gain must never leak into Stat Gains, or the category ranks would shift for every Training Gain card.
+        assertFalse(detectLessonCategories("Training Wit Gain +2").contains(LessonEffectCategory.STAT_GAINS))
+        assertTrue(detectLessonCategories("Training Wit Gain +2").contains(LessonEffectCategory.TRAINING_GAIN))
+    }
+
+    @Test
+    @DisplayName("Magnitude survives OCR losing a leading word, so a card never scores zero for a category it matched")
+    fun magnitudeToleratesLostLabel() {
+        // Detection accepts a bare "hint" or a bare "training" plus "gain", so measurement has to accept the same. When it did not, a card read as
+        // "Hint Lvl +3" counted as a Skill Hint, scored zero, and fell back to screen position - the very failure this ordering exists to prevent.
+        val hints =
+            listOf(
+                tech("Hint Lvl +1", 0),
+                tech("Hint Lvl +3", 1),
+            )
+        assertEquals(1, chooseLessonPurchase(hints, priority, forceMaxHype = false, hypeMaxed = true)?.rowIndex)
+
+        val gains =
+            listOf(
+                song("Training Gain +1", 0),
+                song("Training Gain +2", 1),
+            )
+        assertEquals(1, chooseLessonPurchase(gains, priority, forceMaxHype = false, hypeMaxed = true)?.rowIndex)
+    }
+
+    @Test
+    @DisplayName("Effect text captured from a real run scores the way the log shows it should")
+    fun scoresRealDeviceEffectText() {
+        // Every string here is verbatim from a Grand Live run, OCR noise included. The bare "+10%" is a card whose Friendship Training Effectiveness
+        // label was lost entirely, and it still has to outrank a Training Gain song.
+        val options =
+            listOf(
+                song("Training Skill Pt Gain +2 Specialty Priority +5", 0),
+                song("Guts +26 +10%", 1),
+            )
+        assertEquals(1, chooseLessonPurchase(options, priority, forceMaxHype = false, hypeMaxed = true)?.rowIndex)
+
+        // The post-concert overlay trails the real effect and must not mask it.
+        val expired = "Training Skill Pt Gain +3 Support Chain Event Frequency Lvl +1 O This bonus won't take effect, as the concert is over."
+        assertTrue(detectLessonCategories(expired).contains(LessonEffectCategory.TRAINING_GAIN))
+        assertTrue(detectLessonCategories(expired).contains(LessonEffectCategory.SUPPORT_EVENTS))
+    }
 }

--- a/android/app/src/test/java/com/steve1316/uma_android_automation/bot/campaigns/GrandLiveLessonPolicyTest.kt
+++ b/android/app/src/test/java/com/steve1316/uma_android_automation/bot/campaigns/GrandLiveLessonPolicyTest.kt
@@ -426,4 +426,31 @@ class GrandLiveLessonPolicyTest {
         val endCloserRanked = listOf(LessonHintTag.LONG, LessonHintTag.END_CLOSER)
         assertEquals(0, chooseLessonPurchase(options, priority, forceMaxHype = false, hypeMaxed = true, hintPriority = endCloserRanked)?.rowIndex)
     }
+
+    @Test
+    @DisplayName("A two-stat Technique is scored on the best-ranked stat it grants, not the one printed first")
+    fun scoresMultiStatCardOnBestRankedStat() {
+        // Observed on device: "Guts +6 Wit +6" read as a Guts card, so with Guts unranked the whole card was demoted even though it grants ranked Wit.
+        val statPriority = listOf(StatName.STAMINA, StatName.WIT)
+        assertEquals(listOf(StatName.GUTS to 6, StatName.WIT to 6), parseStatGains("Guts +6 Wit +6"))
+        assertTrue(detectLessonCategories("Guts +6 Wit +6").contains(LessonEffectCategory.STAT_GAINS))
+
+        val options =
+            listOf(
+                tech("Power +12", 0),
+                tech("Guts +6 Wit +6", 1),
+            )
+        assertEquals(1, chooseLessonPurchase(options, statPriority, forceMaxHype = false, hypeMaxed = true)?.rowIndex)
+    }
+
+    @Test
+    @DisplayName("A passive that names a stat is still not a raw stat gain")
+    fun passiveIsNotARawStatGain() {
+        // The amount has to follow the stat directly. Widening the match to a second stat must not start pulling passives into Stat Gains.
+        assertTrue(parseStatGains("Training Power Gain +1").isEmpty())
+        assertTrue(parseStatGains("Training Skill Pt Gain +2 Specialty Priority +5").isEmpty())
+        assertFalse(detectLessonCategories("Training Wit Gain +2").contains(LessonEffectCategory.STAT_GAINS))
+        // A stat gain riding alongside a passive is still found.
+        assertEquals(listOf(StatName.WIT to 6), parseStatGains("Wit +6 Skill Pts +6"))
+    }
 }

--- a/src/context/BotStateContext.tsx
+++ b/src/context/BotStateContext.tsx
@@ -258,6 +258,8 @@ export interface Settings {
         unityCupRetryRaces: boolean
         uraHappyMeekDuelBias: string
         grandLiveLessonEffectPriority: string[]
+        grandLiveLessonStatPriority: string[]
+        grandLiveLessonHintPriority: string[]
         grandLiveLessonRescanInterval: number
     }
 }
@@ -541,6 +543,8 @@ export const defaultSettings: Settings = {
         unityCupRetryRaces: true,
         uraHappyMeekDuelBias: "Moderate",
         grandLiveLessonEffectPriority: ["Training Effectiveness", "Training Gain", "Support Events", "Stat Gains", "Skill Hints"],
+        grandLiveLessonStatPriority: [],
+        grandLiveLessonHintPriority: [],
         grandLiveLessonRescanInterval: 2,
     },
 }

--- a/src/context/searchConfig.ts
+++ b/src/context/searchConfig.ts
@@ -1065,6 +1065,18 @@ const searchConfig: SearchOption[] = [
         page: "ScenarioOverridesSettings",
     },
     {
+        id: "grand-live-lesson-stat-priority",
+        title: "Grand Live Lesson Stat Priority",
+        description: "Stat order applied to stat gains in Lessons. Leave empty to reuse the global Training stat prioritization.",
+        page: "ScenarioOverridesSettings",
+    },
+    {
+        id: "grand-live-lesson-hint-priority",
+        title: "Grand Live Lesson Skill Hint Priority",
+        description: "Rank which skill hints the bot favors in Lessons. Ranked hints are also bought even when the running style is off-aptitude.",
+        page: "ScenarioOverridesSettings",
+    },
+    {
         id: "grand-live-lesson-rescan-interval",
         title: "Grand Live Lessons Re-check Interval",
         description: "How many turns to wait between Lessons re-checks for newly learnable cards. The list only refreshes after a purchase, so checking every turn wastes time.",

--- a/src/lib/messageLog/buildSettingsBanner.ts
+++ b/src/lib/messageLog/buildSettingsBanner.ts
@@ -247,6 +247,8 @@ ${longTargetsString}${formatAdvancedScoringSection(settings.training)}
 🔄 Unity Cup Retry Races: ${settings.scenarioOverrides?.unityCupRetryRaces ? "✅" : "❌"}
 ⚔️ URA Happy Meek Duel Bias: ${settings.scenarioOverrides?.uraHappyMeekDuelBias ?? "Moderate"}
 🎤 Grand Live Lesson Effect Priority: ${(settings.scenarioOverrides?.grandLiveLessonEffectPriority ?? []).length === 0 ? "None" : (settings.scenarioOverrides?.grandLiveLessonEffectPriority ?? []).join(" > ")}
+🎚️ Grand Live Lesson Stat Priority: ${(settings.scenarioOverrides?.grandLiveLessonStatPriority ?? []).length === 0 ? "Global" : (settings.scenarioOverrides?.grandLiveLessonStatPriority ?? []).join(" > ")}
+💡 Grand Live Lesson Skill Hint Priority: ${(settings.scenarioOverrides?.grandLiveLessonHintPriority ?? []).length === 0 ? "None" : (settings.scenarioOverrides?.grandLiveLessonHintPriority ?? []).join(" > ")}
 🎶 Grand Live Lessons Re-check Interval: Every ${settings.scenarioOverrides?.grandLiveLessonRescanInterval ?? 2} turn(s)
 
 ---------- Misc Options ----------

--- a/src/pages/ScenarioOverridesSettings/index.tsx
+++ b/src/pages/ScenarioOverridesSettings/index.tsx
@@ -44,6 +44,18 @@ const DUEL_BIAS_OPTIONS = [
 /** The Grand Live Lesson effect categories rankable in the Lesson Effect Priority list. The ids double as the strings stored in the setting. */
 const GRAND_LIVE_LESSON_CATEGORIES = ["Training Effectiveness", "Training Gain", "Support Events", "Stat Gains", "Skill Hints", "Energy"].map((name) => ({ id: name, label: name }))
 
+/** Track distance labels, shared by the Trackblazer preferred-distance chips and the Grand Live hint priority list. */
+const TRACK_DISTANCE_OPTIONS = ["Sprint", "Mile", "Medium", "Long"]
+
+/** Track surface labels, shared by the Trackblazer preferred-surface chips and the Grand Live hint priority list. */
+const TRACK_SURFACE_OPTIONS = ["Turf", "Dirt"]
+
+/** Running style labels, as a skill hint's parenthetical prints them on a Lessons card. */
+const RUNNING_STYLE_OPTIONS = ["Front Runner", "Pace Chaser", "Late Surger", "End Closer"]
+
+/** The Grand Live skill-hint tags rankable in the Lesson Skill Hint Priority list. These are the parentheticals the Lessons cards print, and the ids double as the strings stored in the setting. */
+const GRAND_LIVE_HINT_TAGS = [...RUNNING_STYLE_OPTIONS, ...TRACK_DISTANCE_OPTIONS, ...TRACK_SURFACE_OPTIONS].map((name) => ({ id: name, label: name }))
+
 /** Options for the Grand Live Lessons re-check interval picker, in turns. */
 const GRAND_LIVE_INTERVAL_OPTIONS = [1, 2, 3, 4, 5] as const
 
@@ -120,7 +132,12 @@ const ScenarioOverridesSettings = () => {
     const [scenarioPickerOpen, setScenarioPickerOpen] = useState(false)
     const [duelBiasPickerOpen, setDuelBiasPickerOpen] = useState(false)
     const [lessonPriorityPickerOpen, setLessonPriorityPickerOpen] = useState(false)
+    const [lessonStatPriorityPickerOpen, setLessonStatPriorityPickerOpen] = useState(false)
+    const [lessonHintPriorityPickerOpen, setLessonHintPriorityPickerOpen] = useState(false)
     const [lessonIntervalPickerOpen, setLessonIntervalPickerOpen] = useState(false)
+
+    // Built once so the memoized priority list is not handed a fresh array on every render, matching the module-level constants its sibling pickers use.
+    const statPriorityItems = useMemo(() => defaultSettings.training.statPrioritization.map((stat) => ({ id: stat, label: stat })), [defaultSettings.training.statPrioritization])
 
     // Which scenario the page is currently editing overrides for. Seeded from the bot's active scenario and re-synced whenever it changes.
     // Switching campaigns here stays local to the page and does not change the bot's actual run target (`general.scenario`).
@@ -252,6 +269,8 @@ const ScenarioOverridesSettings = () => {
     /** Reset the Grand Live Lessons section to defaults. */
     const resetGrandLiveDefaults = useCallback(() => {
         updateOverrideSetting("grandLiveLessonEffectPriority", defaultSettings.scenarioOverrides.grandLiveLessonEffectPriority)
+        updateOverrideSetting("grandLiveLessonStatPriority", defaultSettings.scenarioOverrides.grandLiveLessonStatPriority)
+        updateOverrideSetting("grandLiveLessonHintPriority", defaultSettings.scenarioOverrides.grandLiveLessonHintPriority)
         updateOverrideSetting("grandLiveLessonRescanInterval", defaultSettings.scenarioOverrides.grandLiveLessonRescanInterval)
     }, [updateOverrideSetting, defaultSettings])
 
@@ -398,7 +417,7 @@ const ScenarioOverridesSettings = () => {
                                             <ChipMultiSelect
                                                 title="Preferred Track Distances"
                                                 description="Select preferred track distances for extra race selection. Matching races will be prioritized. Leave empty for no preference."
-                                                options={["Sprint", "Mile", "Medium", "Long"]}
+                                                options={TRACK_DISTANCE_OPTIONS}
                                                 selected={scenarioOverrides.trackblazerPreferredDistances}
                                                 onToggle={(next) => updateOverrideSetting("trackblazerPreferredDistances", next)}
                                             />
@@ -406,7 +425,7 @@ const ScenarioOverridesSettings = () => {
                                             <ChipMultiSelect
                                                 title="Preferred Track Surfaces"
                                                 description="Select preferred track surfaces for extra race selection. Matching races will be prioritized. Leave empty for no preference."
-                                                options={["Turf", "Dirt"]}
+                                                options={TRACK_SURFACE_OPTIONS}
                                                 selected={scenarioOverrides.trackblazerPreferredSurfaces}
                                                 onToggle={(next) => updateOverrideSetting("trackblazerPreferredSurfaces", next)}
                                             />
@@ -894,6 +913,38 @@ const ScenarioOverridesSettings = () => {
                                             />
                                         </SearchableItem>
                                         <SearchableItem
+                                            id="grand-live-lesson-stat-priority"
+                                            title="Lesson Stat Priority"
+                                            description="Stat order applied to stat gains in Lessons. Leave empty to reuse the global Training stat prioritization."
+                                        >
+                                            <Row
+                                                title="Lesson Stat Priority"
+                                                description="Drag to rank which stats Lessons favors. Leave empty to follow the global Training stat prioritization."
+                                                onPress={() => setLessonStatPriorityPickerOpen(true)}
+                                                right={
+                                                    <ValuePill
+                                                        label={scenarioOverrides.grandLiveLessonStatPriority.length === 0 ? "Global" : `${scenarioOverrides.grandLiveLessonStatPriority.length} ranked`}
+                                                    />
+                                                }
+                                            />
+                                        </SearchableItem>
+                                        <SearchableItem
+                                            id="grand-live-lesson-hint-priority"
+                                            title="Lesson Skill Hint Priority"
+                                            description="Rank which skill hints the bot favors in Lessons. Ranked hints are also bought even when the running style is off-aptitude."
+                                        >
+                                            <Row
+                                                title="Lesson Skill Hint Priority"
+                                                description="Drag to rank which skill hints Lessons favors. Deselected hints become last-resort purchases."
+                                                onPress={() => setLessonHintPriorityPickerOpen(true)}
+                                                right={
+                                                    <ValuePill
+                                                        label={scenarioOverrides.grandLiveLessonHintPriority.length === 0 ? "None" : `${scenarioOverrides.grandLiveLessonHintPriority.length} ranked`}
+                                                    />
+                                                }
+                                            />
+                                        </SearchableItem>
+                                        <SearchableItem
                                             id="grand-live-lesson-rescan-interval"
                                             title="Lessons Re-check Interval"
                                             description="How many turns to wait between Lessons re-checks for newly learnable cards. The list only refreshes after a purchase, so checking every turn wastes time."
@@ -1012,6 +1063,34 @@ const ScenarioOverridesSettings = () => {
                     selectedItems={scenarioOverrides.grandLiveLessonEffectPriority}
                     onSelectionChange={(next) => updateOverrideSetting("grandLiveLessonEffectPriority", next)}
                     onOrderChange={(orderedItems) => updateOverrideSetting("grandLiveLessonEffectPriority", orderedItems)}
+                />
+            </SheetModal>
+
+            <SheetModal
+                visible={lessonStatPriorityPickerOpen}
+                onRequestClose={() => setLessonStatPriorityPickerOpen(false)}
+                header={<ModalHeader title="LESSON STAT PRIORITY" onClose={() => setLessonStatPriorityPickerOpen(false)} />}
+                footer={null}
+            >
+                <DraggablePriorityList
+                    items={statPriorityItems}
+                    selectedItems={scenarioOverrides.grandLiveLessonStatPriority}
+                    onSelectionChange={(next) => updateOverrideSetting("grandLiveLessonStatPriority", next)}
+                    onOrderChange={(orderedItems) => updateOverrideSetting("grandLiveLessonStatPriority", orderedItems)}
+                />
+            </SheetModal>
+
+            <SheetModal
+                visible={lessonHintPriorityPickerOpen}
+                onRequestClose={() => setLessonHintPriorityPickerOpen(false)}
+                header={<ModalHeader title="LESSON SKILL HINT PRIORITY" onClose={() => setLessonHintPriorityPickerOpen(false)} />}
+                footer={null}
+            >
+                <DraggablePriorityList
+                    items={GRAND_LIVE_HINT_TAGS}
+                    selectedItems={scenarioOverrides.grandLiveLessonHintPriority}
+                    onSelectionChange={(next) => updateOverrideSetting("grandLiveLessonHintPriority", next)}
+                    onOrderChange={(orderedItems) => updateOverrideSetting("grandLiveLessonHintPriority", orderedItems)}
                 />
             </SheetModal>
 


### PR DESCRIPTION
## Description

- This PR resolves #425 by adding `Lesson Stat Priority` and `Lesson Skill Hint Priority` to `Scenario Overrides Settings`, letting you steer which stats and which skill hints Lessons favors independently of your global training setup.
- Along the way it fixes the bot picking the wrong Lessons card, since cards granting different amounts of the same effect were treated as identical and the winner came down to on-screen position.
- The bot now reads how much of an effect a card grants, so a bigger training gain or a `+10%` friendship bonus beats a smaller one.
- Skill point cards are now recognized instead of being ignored outright, and a card granting two stats such as `Guts +6 Wit +6` is judged on the best stat it actually gives you rather than only the first one printed.

Every card on this screen scored as worthless, so the purchase fell through to whichever card happened to be listed first:

```
[GRAND_LIVE] Lessons scan found 3 card(s) and 3 Learnable ribbon(s):
[GRAND_LIVE]   Watch a Top-Tier ldol's Concert (Technique Learnable)
[GRAND_LIVE]     Skill Pts +12
[GRAND_LIVE]   Makeup Advanced Class (Technique Learnable)
[GRAND_LIVE]     Guts +12
[GRAND_LIVE]   Facial-Slimming Massage (Technique Learnable)
[GRAND_LIVE]     ) Energy +20
[GRAND_LIVE] Buying TECHNIQUE 'Watch a Top-Tier ldol's Concert' at row 0: 'Skill Pts +12 None'.
```