### PR TITLE
Let Grand Live Lessons prioritize specific Songs

### DIFF
--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/GrandLive.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/GrandLive.kt
@@ -83,6 +83,9 @@ class GrandLive(game: Game) : Campaign(game) {
     private val lessonHintPriority: List<LessonHintTag> =
         SettingsHelper.getStringArraySetting("scenarioOverrides", "grandLiveLessonHintPriority").mapNotNull { LessonHintTag.fromDisplayName(it) }
 
+    /** User-ranked Song titles (Scenario Overrides). A ranked Song is bought ahead of anything else learnable. Empty means no song preference. */
+    private val lessonSongPriority: List<String> = SettingsHelper.getStringArraySetting("scenarioOverrides", "grandLiveSongPriority")
+
     /** Turns between Lessons re-checks (Scenario Overrides). The list is static until a purchase, so polling more often than tokens grow wastes screen time. */
     private val lessonRescanInterval: Int = SettingsHelper.getIntSetting("scenarioOverrides", "grandLiveLessonRescanInterval", 2)
 
@@ -297,7 +300,8 @@ class GrandLive(game: Game) : Campaign(game) {
             // Prefer on-style options; a skill hint for a running style we cannot use is only bought when it is the sole affordable option.
             val onStyle = purchasable.filter { !isOffStyleHint(it.option.effectText) }
             val candidates = if (onStyle.isNotEmpty()) onStyle else purchasable
-            val choice = chooseLessonPurchase(candidates.map { it.option }, lessonStatPriority, forceMaxHype, hypeMaxed, lessonEffectPriority, lessonHintPriority)
+            val choice =
+                chooseLessonPurchase(candidates.map { it.option }, lessonStatPriority, forceMaxHype, hypeMaxed, lessonEffectPriority, lessonHintPriority, lessonSongPriority)
             if (choice == null) {
                 MessageLog.i(TAG, "[GRAND_LIVE] No learnable Lessons purchase; leaving the Lessons screen.")
                 break
@@ -446,6 +450,12 @@ class GrandLive(game: Game) : Campaign(game) {
             val effectText = listOf(effect1, effect2).filter { it.isNotBlank() }.joinToString(" ")
             val tapPoint = Point(game.imageUtils.relX(anchor.x, 200).toDouble(), game.imageUtils.relY(anchor.y, -150).toDouble())
 
+            // A Song the shipped list does not know cannot be ranked, and a title the game reworded would otherwise go unnoticed until someone
+            // wondered why their Song Priority stopped applying.
+            if (kind == LessonKind.SONG && name.isNotBlank() && matchSongRank(name, GRAND_LIVE_SONGS) == null) {
+                MessageLog.w(TAG, "[GRAND_LIVE]   Song \"$name\" matches no known Song, so Song Priority cannot rank it. Recheck the shipped song list if this repeats.")
+            }
+
             val status = if (purchasable) "Learnable" else "Locked"
             val kindLabel = kind.name.lowercase().replaceFirstChar { it.uppercase() }
             MessageLog.i(TAG, "[GRAND_LIVE]   ${name.ifBlank { "?" }} ($kindLabel $status)")
@@ -505,7 +515,7 @@ class GrandLive(game: Game) : Campaign(game) {
      */
     private fun shouldWaitForLockedLesson(scanned: List<ScannedLesson>): Boolean {
         if (!isHypeMaxed || date.bIsFinaleSeason) return false
-        return scanned.any { !it.option.purchasable && isSoughtAfter(it.option.effectText, lessonEffectPriority) }
+        return scanned.any { !it.option.purchasable && isSoughtAfter(it.option, lessonEffectPriority, lessonSongPriority) }
     }
 
     /**

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/GrandLiveLessons.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/bot/campaigns/GrandLiveLessons.kt
@@ -3,6 +3,7 @@ package com.steve1316.uma_android_automation.bot.campaigns
 import android.graphics.Bitmap
 import com.steve1316.uma_android_automation.types.RunningStyle
 import com.steve1316.uma_android_automation.types.StatName
+import com.steve1316.uma_android_automation.types.fuzzyBestMatchIndex
 import com.steve1316.uma_android_automation.utils.CustomImageUtils
 import org.opencv.core.Point
 
@@ -116,8 +117,51 @@ val LESSON_CARD_CROPS =
 /** Upper bound on purchases per Lessons visit, as a runaway guard on the buy-and-rescan loop. */
 const val MAX_LESSON_PURCHASES_PER_VISIT = 20
 
-/** A locked card counts as "sought after" (worth holding tokens for) when it matches a category ranked within this many top spots of the user's priority order. */
+/** A locked card counts as "sought after" (worth holding tokens for) when it matches a category, or is a Song, ranked within this many top spots. */
 private const val SOUGHT_AFTER_TOP_RANKS = 2
+
+/**
+ * Every Song that can be learned in Lessons, spelled as the game prints it. The user ranks a subset via the Song Priority setting (Scenario Overrides).
+ * "Make Debut!" and "GIRLS' LEGEND U" are deliberately absent: both are granted automatically and never appear as a purchasable card. The two
+ * decorative glyphs are written as escapes to keep this file plain ASCII - \u2606 is a star and \u266a is a musical note.
+ */
+val GRAND_LIVE_SONGS: List<String> =
+    listOf(
+        "Believe in Miracles!",
+        "Run n' Run!",
+        "Full Speed Ahead! Umadol Power\u2606",
+        "Here Comes Our Time",
+        "Zero Is Where the Center Stands!",
+        "Go This Way",
+        "Ring Ring Diary",
+        "Getaway! Fallin' Love",
+        "Run for Our Dream!",
+        "Our Blue Bird Days",
+        "Hey, Guess What!",
+        "Grow Up and Shine!",
+        "Seven Colors Scenery",
+        "Sunbeam Cheer",
+        "Hoppity Sunny Days\u266a",
+        "Precious Treasure Box",
+        "Fanfare for the Future!",
+        "Present March\u266a",
+        "Dream Sky",
+        "The World's at Our Whim",
+        "Sky-Blue Spring",
+    )
+
+/**
+ * Everything outside letters and digits, dropped before two song titles are compared. OCR reads the game's decorative glyphs inconsistently - one run
+ * returned the same song as both "Hoppity Sunny Days )" and "Hoppity Sunny Days d" - so punctuation and spacing carry no signal.
+ */
+private val SONG_NAME_NOISE_REGEX = Regex("[^a-z0-9]")
+
+/**
+ * Lowest Jaro-Winkler score accepted as a title match. Measured against every corrupted read observed on device: the worst true match was
+ * "So This Way" for "Go This Way" at 0.93, and the closest two distinct titles ("Run n' Run!" against "Run for Our Dream!") scored 0.78. This sits
+ * between the two, so it tolerates unseen OCR noise without letting one song stand in for another.
+ */
+private const val SONG_MATCH_THRESHOLD = 0.85
 
 /** The stat names as a regex alternation, derived from [StatName] so the gain patterns below cannot drift from the enum. */
 private val STAT_ALTERNATION = StatName.entries.joinToString("|") { it.name.lowercase() }
@@ -290,8 +334,16 @@ data class LessonOption(
  * @property statTieBreak Value of the card's stat gain, higher is better, used only once the earlier tie-breaks tie.
  * @property hintTieBreak Value of the card's best user-ranked skill-hint tag, higher is better, zero when the card is not a ranked hint. Outranks
  *   [categoryValue], since Skill Hints mixes hint levels with skill-point totals and an explicit ranking beats comparing those two as numbers.
+ * @property songRank The card's position in the user's ranked song list, or null when it is not a ranked Song. Decided before everything else, since
+ *   naming a song is a more direct instruction than any ranking of its effects.
  */
-private data class LessonEffectProfile(val ranks: List<Int>, val categoryValue: Double, val statTieBreak: Double, val hintTieBreak: Double)
+private data class LessonProfile(
+    val ranks: List<Int>,
+    val categoryValue: Double,
+    val statTieBreak: Double,
+    val hintTieBreak: Double,
+    val songRank: Int?,
+)
 
 /**
  * Strip the post-concert warning overlay the game paints over a Song's effect line. The effect crop reads it as trailing noise, which would
@@ -468,25 +520,49 @@ private fun readLessonEffect(cleaned: String): LessonEffectReading {
 }
 
 /**
- * Reduce a Lessons card's effect text to everything the purchase ordering needs. Computed once per card so the comparator never re-parses.
+ * Reduce a song title to the letters and digits OCR can be trusted on, so punctuation and the game's decorative glyphs cannot break a match.
+ *
+ * @param raw The title as printed or as OCR read it.
+ * @return The normalized form, empty when the title held nothing comparable.
+ */
+fun normalizeSongName(raw: String): String = SONG_NAME_NOISE_REGEX.replace(raw.lowercase(), "")
+
+/**
+ * Find where an OCR'd card title sits in the user's ranked song list. The closest title above [SONG_MATCH_THRESHOLD] wins, which is what absorbs the
+ * routine misreads ("Jur Blue Bird Days" for "Our Blue Bird Days"). An exact read needs no special case: it scores 1.0 and nothing can beat it.
+ *
+ * @param name The card's OCR'd title.
+ * @param songPriority The user's ranked song titles (index 0 = highest).
+ * @return The matching rank, or null when the title is not one of the ranked songs.
+ */
+fun matchSongRank(name: String, songPriority: List<String>): Int? {
+    val normalized = normalizeSongName(name)
+    if (normalized.isEmpty() || songPriority.isEmpty()) return null
+    return fuzzyBestMatchIndex(normalized, songPriority.map { normalizeSongName(it) }, SONG_MATCH_THRESHOLD)
+}
+
+/**
+ * Reduce a Lessons card to everything the purchase ordering needs. Computed once per card so the comparator never re-parses.
  *
  * Categories left out of the ranking are dropped, as is a Stat Gains match whose stat is absent from the stat prioritization, and a Skill Hints match
  * whose tag is absent from a non-empty hint ranking - such a card ranks below anything with a ranked effect, but is still bought when it is the only
  * option. A hint whose tag was not recognized at all is never dropped, so OCR noise cannot demote a card.
  *
- * @param effectText The card's effect line(s).
+ * @param option The card to profile.
  * @param statPriority The bot's ordered stat prioritization (index 0 = highest).
  * @param categoryOrder The user's ranked effect categories (index 0 = highest).
  * @param hintPriority The user's ranked skill-hint tags (index 0 = highest). Empty means no hint preference.
+ * @param songPriority The user's ranked song titles (index 0 = highest). Empty means no song preference.
  * @return The card's ranking profile.
  */
-private fun profileLessonEffect(
-    effectText: String,
+private fun profileLesson(
+    option: LessonOption,
     statPriority: List<StatName>,
     categoryOrder: List<LessonEffectCategory>,
     hintPriority: List<LessonHintTag>,
-): LessonEffectProfile {
-    val cleaned = stripConcertOverOverlay(effectText)
+    songPriority: List<String>,
+): LessonProfile {
+    val cleaned = stripConcertOverOverlay(option.effectText)
     val reading = readLessonEffect(cleaned)
     // A card can grant two stats ("Guts +6 Wit +6"), so it is scored on the best-ranked one it grants rather than whichever prints first, with the larger
     // amount breaking a tie between two equally ranked stats. A raw gain is what puts a card in Stat Gains; the named passive only feeds the tie-break.
@@ -510,7 +586,8 @@ private fun profileLessonEffect(
     val categoryValue = ranks.firstOrNull()?.let { reading.magnitudes[categoryOrder[it]] } ?: 0.0
     val statTieBreak = if (statGain != null && statRank >= 0) (statPriority.size - statRank).toDouble() + statGain.second * 0.001 else 0.0
     val hintTieBreak = hintRank?.let { (hintPriority.size - it).toDouble() } ?: 0.0
-    return LessonEffectProfile(ranks, categoryValue, statTieBreak, hintTieBreak)
+    val songRank = if (option.kind == LessonKind.SONG) matchSongRank(option.name, songPriority) else null
+    return LessonProfile(ranks, categoryValue, statTieBreak, hintTieBreak, songRank)
 }
 
 /**
@@ -529,8 +606,9 @@ private fun compareLessonRanks(a: List<Int>, b: List<Int>): Int {
 }
 
 /**
- * Pick the best card, profiling each one exactly once. Category ranks decide first, then the better-ranked skill hint, then how much of that category the
- * card grants, then a Technique edges out a Song of equal value, then the better stat gain, and finally the earlier row.
+ * Pick the best card, profiling each one exactly once. A song the user ranked by name wins outright; after that category ranks decide, then the
+ * better-ranked skill hint, then how much of that category the card grants, then a Technique edges out a Song of equal value, then the better stat gain,
+ * and finally the earlier row.
  *
  * Magnitude sits above the Technique preference on purpose: a "Training Wit Gain +2" Song is worth more than a "Training Guts Gain +1" Technique, and
  * before magnitude was read at all those two tied all the way down to screen position.
@@ -542,6 +620,7 @@ private fun compareLessonRanks(a: List<Int>, b: List<Int>): Int {
  * @param statPriority The bot's ordered stat prioritization (index 0 = highest).
  * @param categoryOrder The user's ranked effect categories (index 0 = highest).
  * @param hintPriority The user's ranked skill-hint tags (index 0 = highest).
+ * @param songPriority The user's ranked song titles (index 0 = highest).
  * @return The best card, or null when `options` is empty.
  */
 private fun bestLesson(
@@ -549,11 +628,13 @@ private fun bestLesson(
     statPriority: List<StatName>,
     categoryOrder: List<LessonEffectCategory>,
     hintPriority: List<LessonHintTag>,
+    songPriority: List<String>,
 ): LessonOption? =
     options
-        .map { it to profileLessonEffect(it.effectText, statPriority, categoryOrder, hintPriority) }
+        .map { it to profileLesson(it, statPriority, categoryOrder, hintPriority, songPriority) }
         .maxWithOrNull(
-            Comparator<Pair<LessonOption, LessonEffectProfile>> { a, b -> compareLessonRanks(a.second.ranks, b.second.ranks) }
+            compareByDescending<Pair<LessonOption, LessonProfile>> { it.second.songRank ?: Int.MAX_VALUE }
+                .then { a, b -> compareLessonRanks(a.second.ranks, b.second.ranks) }
                 .thenBy { it.second.hintTieBreak }
                 .thenBy { it.second.categoryValue }
                 .thenBy { it.first.kind == LessonKind.TECHNIQUE }
@@ -562,15 +643,22 @@ private fun bestLesson(
         )?.first
 
 /**
- * Whether a card's effect is worth holding tokens for while it is locked: true when it matches a category ranked within the user's top
- * [SOUGHT_AFTER_TOP_RANKS] priority spots.
+ * Whether a card is worth holding tokens for while it is locked: true when it is a Song ranked within the user's top [SOUGHT_AFTER_TOP_RANKS] song
+ * spots, or when its effect matches a category ranked that highly. Only the top spots count, unlike the purchase ordering which honors every ranked
+ * song: sitting on tokens costs a turn, so it takes more than a mild preference to justify.
  *
- * @param effectText The card's effect line(s).
+ * @param option The locked card.
  * @param categoryOrder The user's ranked effect categories (index 0 = highest).
+ * @param songPriority The user's ranked song titles (index 0 = highest). Empty means no song preference.
  * @return True when the card is sought after.
  */
-fun isSoughtAfter(effectText: String, categoryOrder: List<LessonEffectCategory>): Boolean =
-    detectLessonCategories(effectText).any { category -> categoryOrder.indexOf(category).let { it in 0 until SOUGHT_AFTER_TOP_RANKS } }
+fun isSoughtAfter(option: LessonOption, categoryOrder: List<LessonEffectCategory>, songPriority: List<String> = emptyList()): Boolean {
+    if (option.kind == LessonKind.SONG) {
+        val songRank = matchSongRank(option.name, songPriority)
+        if (songRank != null && songRank < SOUGHT_AFTER_TOP_RANKS) return true
+    }
+    return detectLessonCategories(option.effectText).any { category -> categoryOrder.indexOf(category).let { it in 0 until SOUGHT_AFTER_TOP_RANKS } }
+}
 
 /**
  * Choose the next Lessons purchase. We do not hoard tokens, so any affordable card is worth buying (spending tokens and refreshing
@@ -583,6 +671,7 @@ fun isSoughtAfter(effectText: String, categoryOrder: List<LessonEffectCategory>)
  * @param hypeMaxed Whether the Hype gauge is already full.
  * @param categoryOrder The user's ranked effect categories (index 0 = highest).
  * @param hintPriority The user's ranked skill-hint tags (index 0 = highest). Empty means no hint preference.
+ * @param songPriority The user's ranked song titles (index 0 = highest). Empty means no song preference.
  * @return The chosen option, or null when `options` is empty.
  */
 fun chooseLessonPurchase(
@@ -592,11 +681,12 @@ fun chooseLessonPurchase(
     hypeMaxed: Boolean,
     categoryOrder: List<LessonEffectCategory> = DEFAULT_LESSON_EFFECT_PRIORITY,
     hintPriority: List<LessonHintTag> = emptyList(),
+    songPriority: List<String> = emptyList(),
 ): LessonOption? {
     if (forceMaxHype && !hypeMaxed) {
-        val hypeSong = bestLesson(options.filter { it.kind == LessonKind.SONG }, statPriority, categoryOrder, hintPriority)
+        val hypeSong = bestLesson(options.filter { it.kind == LessonKind.SONG }, statPriority, categoryOrder, hintPriority, songPriority)
         if (hypeSong != null) return hypeSong
     }
 
-    return bestLesson(options, statPriority, categoryOrder, hintPriority)
+    return bestLesson(options, statPriority, categoryOrder, hintPriority, songPriority)
 }

--- a/android/app/src/main/java/com/steve1316/uma_android_automation/types/StatusMatching.kt
+++ b/android/app/src/main/java/com/steve1316/uma_android_automation/types/StatusMatching.kt
@@ -17,8 +17,28 @@ const val STATUS_QUERY_THRESHOLD = 0.8
 private val SIMILARITY_SERVICE = StringSimilarityServiceImpl(JaroWinklerStrategy())
 
 /**
+ * The index of the entry in [names] that best Jaro-Winkler matches [candidate], provided it meets [threshold]. Ties resolve to the earliest entry, so a
+ * caller whose list is ranked gets the highest-ranked match.
+ *
+ * @param candidate The raw or canonical name to test.
+ * @param names The names to compare against.
+ * @param threshold The similarity floor (0.0 to 1.0).
+ * @return The best matching index, or null when nothing met the threshold.
+ */
+fun fuzzyBestMatchIndex(candidate: String, names: List<String>, threshold: Double): Int? {
+    if (candidate.isBlank() || names.isEmpty()) return null
+    val lowered = candidate.lowercase()
+    return names
+        .mapIndexed { index, name -> index to SIMILARITY_SERVICE.score(lowered, name.lowercase()) }
+        .filter { it.second >= threshold }
+        .maxByOrNull { it.second }
+        ?.first
+}
+
+/**
  * Returns true when [candidate] Jaro-Winkler matches any entry in [names] at or above [threshold].
  * Pure and list-free: used both to dedup raw OCR reads and to answer canonical-name membership queries.
+ * Kept separate from [fuzzyBestMatchIndex] so a membership check can stop at the first hit instead of scoring the whole list.
  *
  * @param candidate The raw or canonical name to test.
  * @param names The names to compare against.

--- a/android/app/src/test/java/com/steve1316/uma_android_automation/bot/campaigns/GrandLiveLessonPolicyTest.kt
+++ b/android/app/src/test/java/com/steve1316/uma_android_automation/bot/campaigns/GrandLiveLessonPolicyTest.kt
@@ -21,6 +21,8 @@ class GrandLiveLessonPolicyTest {
 
     private fun song(effect: String, row: Int) = LessonOption(LessonKind.SONG, name = "", effectText = effect, purchasable = true, rowIndex = row)
 
+    private fun namedSong(name: String, effect: String, row: Int) = LessonOption(LessonKind.SONG, name = name, effectText = effect, purchasable = true, rowIndex = row)
+
     @Test
     @DisplayName("Buys a basic stat technique for the top-priority stat")
     fun buysTopPriorityStatTechnique() {
@@ -218,12 +220,12 @@ class GrandLiveLessonPolicyTest {
     @Test
     @DisplayName("Sought-after means matching a category in the top 2 ranks")
     fun soughtAfterFollowsTopRanks() {
-        assertTrue(isSoughtAfter("Friendship Training Effectiveness +10%", DEFAULT_LESSON_EFFECT_PRIORITY))
-        assertFalse(isSoughtAfter("Speed +5", DEFAULT_LESSON_EFFECT_PRIORITY))
+        assertTrue(isSoughtAfter(song("Friendship Training Effectiveness +10%", 0), DEFAULT_LESSON_EFFECT_PRIORITY))
+        assertFalse(isSoughtAfter(tech("Speed +5", 0), DEFAULT_LESSON_EFFECT_PRIORITY))
 
         val statFirst = listOf(LessonEffectCategory.STAT_GAINS, LessonEffectCategory.SKILL_HINTS, LessonEffectCategory.TRAINING_GAIN)
-        assertTrue(isSoughtAfter("Speed +5", statFirst))
-        assertFalse(isSoughtAfter("Training Power Gain +1", statFirst))
+        assertTrue(isSoughtAfter(tech("Speed +5", 0), statFirst))
+        assertFalse(isSoughtAfter(tech("Training Power Gain +1", 0), statFirst))
     }
 
     @Test
@@ -452,5 +454,99 @@ class GrandLiveLessonPolicyTest {
         assertFalse(detectLessonCategories("Training Wit Gain +2").contains(LessonEffectCategory.STAT_GAINS))
         // A stat gain riding alongside a passive is still found.
         assertEquals(listOf(StatName.WIT to 6), parseStatGains("Wit +6 Skill Pts +6"))
+    }
+
+    @Test
+    @DisplayName("Song titles normalize down to the letters OCR can be trusted on")
+    fun normalizesSongTitles() {
+        // The game's decorative glyphs came back as ")" and "d" for the same song in one run, so nothing outside letters and digits can carry signal.
+        assertEquals(normalizeSongName("Hoppity Sunny Days\u266a"), normalizeSongName("Hoppity Sunny Days )"))
+        assertEquals(normalizeSongName("Present March\u266a"), normalizeSongName("Present March >"))
+        assertEquals("gothisway", normalizeSongName("Go This Way"))
+    }
+
+    @Test
+    @DisplayName("Every corrupted title read on device still resolves to its song")
+    fun matchesCorruptedTitlesFromDevice() {
+        // Each of these is a real read from a run log, paired with the title it has to resolve to.
+        val reads =
+            listOf(
+                "Beven Colors Scenery" to "Seven Colors Scenery",
+                "Jur Blue Bird Days" to "Our Blue Bird Days",
+                "ley, Guess What!" to "Hey, Guess What!",
+                "So This Way" to "Go This Way",
+                "Hoppity Sunny Days d" to "Hoppity Sunny Days\u266a",
+                "Full Speed Ahead! Umadol Powert" to "Full Speed Ahead! Umadol Power\u2606",
+            )
+        reads.forEach { (read, truth) ->
+            assertEquals(0, matchSongRank(read, listOf(truth)), "expected '$read' to match '$truth'")
+        }
+    }
+
+    @Test
+    @DisplayName("A title close to a ranked song but not it is left unmatched")
+    fun rejectsNearMissTitles() {
+        // The closest pair of distinct titles in the game. Letting one stand in for the other would buy the wrong song outright.
+        assertNull(matchSongRank("Run n' Run!", listOf("Run for Our Dream!")))
+        assertNull(matchSongRank("Dream Sky", listOf("Sky-Blue Spring")))
+        assertNull(matchSongRank("", listOf("Go This Way")))
+        assertNull(matchSongRank("Go This Way", emptyList()))
+    }
+
+    @Test
+    @DisplayName("A ranked song is bought ahead of a better-ranked effect on another card")
+    fun rankedSongWinsOutright() {
+        val options =
+            listOf(
+                namedSong("Precious Treasure Box", "Speed +26 Friendship Training Effectiveness +10%", 0),
+                namedSong("Go This Way", "Training Power Gain +1 Support Chain Event Frequency Lvl +1", 1),
+            )
+        // Without a song ranking the Training Effectiveness card wins on category rank.
+        assertEquals(0, chooseLessonPurchase(options, priority, forceMaxHype = false, hypeMaxed = true)?.rowIndex)
+
+        // Naming the weaker song promotes it above every effect ranking.
+        val goThisWayFirst = listOf("Go This Way")
+        assertEquals(1, chooseLessonPurchase(options, priority, forceMaxHype = false, hypeMaxed = true, songPriority = goThisWayFirst)?.rowIndex)
+    }
+
+    @Test
+    @DisplayName("Between two ranked songs the higher-ranked title wins, and unranked songs fall back to effect order")
+    fun ordersRankedSongsAmongThemselves() {
+        val options =
+            listOf(
+                namedSong("Sunbeam Cheer", "Training Wit Gain +2 Support Chain Event Frequency Lvl +1", 0),
+                namedSong("Go This Way", "Training Power Gain +1 Support Chain Event Frequency Lvl +1", 1),
+            )
+        val order = listOf("Go This Way", "Sunbeam Cheer")
+        assertEquals(1, chooseLessonPurchase(options, priority, forceMaxHype = false, hypeMaxed = true, songPriority = order)?.rowIndex)
+
+        // A song nobody ranked is still ordered by its effects, so the bigger Training Gain wins.
+        val unrelated = listOf("Dream Sky")
+        assertEquals(0, chooseLessonPurchase(options, priority, forceMaxHype = false, hypeMaxed = true, songPriority = unrelated)?.rowIndex)
+    }
+
+    @Test
+    @DisplayName("A locked song ranked in the top spots is worth holding tokens for")
+    fun topRankedLockedSongIsSoughtAfter() {
+        // A plain stat gain is not a top-2 category, so only the song ranking can make these cards sought after.
+        val order = listOf("Go This Way", "Sunbeam Cheer", "Dream Sky")
+        assertTrue(isSoughtAfter(namedSong("So This Way", "Speed +5", 0), DEFAULT_LESSON_EFFECT_PRIORITY, order))
+        // Ranked, but below the top spots, so it does not justify sitting on tokens.
+        assertFalse(isSoughtAfter(namedSong("Dream Sky", "Speed +5", 0), DEFAULT_LESSON_EFFECT_PRIORITY, order))
+    }
+
+    @Test
+    @DisplayName("The shipped song list holds every learnable song and none of the automatic ones")
+    fun songListIsComplete() {
+        assertEquals(21, GRAND_LIVE_SONGS.size)
+        assertEquals(GRAND_LIVE_SONGS.size, GRAND_LIVE_SONGS.map { normalizeSongName(it) }.toSet().size)
+        // Both of these are granted automatically and never appear as a purchasable card.
+        assertFalse(GRAND_LIVE_SONGS.any { normalizeSongName(it) == normalizeSongName("Make Debut!") })
+        assertFalse(GRAND_LIVE_SONGS.any { normalizeSongName(it) == normalizeSongName("GIRLS' LEGEND U") })
+        // No two shipped titles may be close enough to match each other, or a ranked song could stand in for its neighbour.
+        GRAND_LIVE_SONGS.forEach { title ->
+            val others = GRAND_LIVE_SONGS.filter { it != title }
+            assertNull(matchSongRank(title, others), "'$title' matched another shipped title")
+        }
     }
 }

--- a/src/components/DraggablePriorityList/index.tsx
+++ b/src/components/DraggablePriorityList/index.tsx
@@ -14,7 +14,7 @@ export interface PriorityItem {
     id: string
     /** Visible label. */
     label: string
-    /** Optional secondary line. */
+    /** Optional muted second line, rendered under the label on both the ranked and unranked rows. */
     description?: string
 }
 
@@ -34,7 +34,8 @@ interface DraggablePriorityListProps {
 
 /**
  * A drag-to-reorder list paired with checkbox toggles. Selected items render on top with a numeric badge, a remove button, and a grip handle, and the row
- * body is the drag target. Unselected items render below a dashed separator with a plain checkbox and are appended to the end when selected.
+ * body is the drag target. Unselected items render below a dashed separator with a plain checkbox and are appended to the end when selected. An item
+ * carrying a description shows it as a muted second line on both lists, so a choice can be made without leaving the sheet.
  * Consumed inside `SheetModal` - the parent owns scroll so this component does not wrap its rows in a ScrollView.
  * @param items All items.
  * @param selectedItems Selected items in priority order.
@@ -78,7 +79,9 @@ const DraggablePriorityList = ({ items, selectedItems, onSelectionChange, onOrde
                     justifyContent: "center",
                 },
                 badgeText: { ...TYPE.monoValue, color: colors.onBrand, fontSize: 11, fontWeight: "700" as const },
-                selectedLabel: { ...TYPE.body, color: colors.text, flex: 1 },
+                selectedTextBlock: { flex: 1, gap: 2 },
+                selectedLabel: { ...TYPE.body, color: colors.text },
+                selectedDescription: { ...TYPE.caption, color: colors.textMuted },
                 grip: { opacity: 0.7 },
                 remove: { opacity: 0.7, paddingHorizontal: 2 },
                 separator: { borderTopWidth: 1, borderStyle: "dashed", borderColor: colors.borderHair, marginVertical: SPACING.sm },
@@ -103,7 +106,10 @@ const DraggablePriorityList = ({ items, selectedItems, onSelectionChange, onOrde
                 <View style={styles.badge}>
                     <Text style={styles.badgeText}>{priorityNumber}</Text>
                 </View>
-                <Text style={styles.selectedLabel}>{item.label}</Text>
+                <View style={styles.selectedTextBlock}>
+                    <Text style={styles.selectedLabel}>{item.label}</Text>
+                    {item.description ? <Text style={styles.selectedDescription}>{item.description}</Text> : null}
+                </View>
                 <Pressable
                     onPress={() => onSelectionChange(orderedSelected.filter((id) => id !== item.id))}
                     hitSlop={SPACING.sm}
@@ -143,7 +149,7 @@ const DraggablePriorityList = ({ items, selectedItems, onSelectionChange, onOrde
             {unselected.length > 0 ? (
                 <View style={styles.unselectedList}>
                     {unselected.map((item) => (
-                        <ModalCheckRow key={item.id} label={item.label} checked={false} dim onPress={() => onSelectionChange([...orderedSelected, item.id])} />
+                        <ModalCheckRow key={item.id} label={item.label} description={item.description} checked={false} dim onPress={() => onSelectionChange([...orderedSelected, item.id])} />
                     ))}
                 </View>
             ) : null}

--- a/src/components/DraggablePriorityList/index.tsx
+++ b/src/components/DraggablePriorityList/index.tsx
@@ -9,7 +9,7 @@ import { SPACING } from "../../lib/spacing"
 import { RADII } from "../../lib/radii"
 
 /** A single priority list item. */
-interface PriorityItem {
+export interface PriorityItem {
     /** Stable identifier used by the drag list. */
     id: string
     /** Visible label. */

--- a/src/components/ui/modal-list.tsx
+++ b/src/components/ui/modal-list.tsx
@@ -10,6 +10,8 @@ import { RADII } from "../../lib/radii"
 export interface ModalCheckRowProps {
     /** The visible label. */
     label: string
+    /** Optional muted line rendered below the label. Use to say what the option grants, so the choice can be made without leaving the screen. */
+    description?: string
     /** Whether the row is currently selected. */
     checked: boolean
     /** Called when the row is tapped. */
@@ -23,13 +25,14 @@ export interface ModalCheckRowProps {
 /**
  * A card-tile row with a 18x18 check box, used by multi-select and priority modals.
  * @param label Visible label.
+ * @param description Optional muted line rendered below the label.
  * @param checked Whether selected.
  * @param onPress Tap handler.
  * @param dim Render the label at 60% opacity when true.
  * @param style Optional outer style override.
  * @returns A Pressable card tile.
  */
-const ModalCheckRowImpl = ({ label, checked, onPress, dim, style }: ModalCheckRowProps) => {
+const ModalCheckRowImpl = ({ label, description, checked, onPress, dim, style }: ModalCheckRowProps) => {
     const { colors } = useTheme()
     const styles = useMemo(
         () =>
@@ -57,7 +60,9 @@ const ModalCheckRowImpl = ({ label, checked, onPress, dim, style }: ModalCheckRo
                     justifyContent: "center",
                 },
                 boxActive: { borderColor: colors.brand, backgroundColor: colors.brand },
-                label: { ...TYPE.body, color: colors.text, flex: 1 },
+                textBlock: { flex: 1, gap: 2 },
+                label: { ...TYPE.body, color: colors.text },
+                description: { ...TYPE.caption, color: colors.textMuted },
                 labelDim: { opacity: 0.6 },
             }),
         [colors]
@@ -71,7 +76,10 @@ const ModalCheckRowImpl = ({ label, checked, onPress, dim, style }: ModalCheckRo
             accessibilityState={{ checked }}
         >
             <View style={[styles.box, checked && styles.boxActive]}>{checked ? <Ionicons name="checkmark" size={14} color={colors.onBrand} /> : null}</View>
-            <Text style={[styles.label, dim && !checked && styles.labelDim]}>{label}</Text>
+            <View style={[styles.textBlock, dim && !checked && styles.labelDim]}>
+                <Text style={styles.label}>{label}</Text>
+                {description ? <Text style={styles.description}>{description}</Text> : null}
+            </View>
         </Pressable>
     )
 }

--- a/src/context/BotStateContext.tsx
+++ b/src/context/BotStateContext.tsx
@@ -260,6 +260,7 @@ export interface Settings {
         grandLiveLessonEffectPriority: string[]
         grandLiveLessonStatPriority: string[]
         grandLiveLessonHintPriority: string[]
+        grandLiveSongPriority: string[]
         grandLiveLessonRescanInterval: number
     }
 }
@@ -545,6 +546,7 @@ export const defaultSettings: Settings = {
         grandLiveLessonEffectPriority: ["Training Effectiveness", "Training Gain", "Support Events", "Stat Gains", "Skill Hints"],
         grandLiveLessonStatPriority: [],
         grandLiveLessonHintPriority: [],
+        grandLiveSongPriority: [],
         grandLiveLessonRescanInterval: 2,
     },
 }

--- a/src/context/searchConfig.ts
+++ b/src/context/searchConfig.ts
@@ -1077,6 +1077,12 @@ const searchConfig: SearchOption[] = [
         page: "ScenarioOverridesSettings",
     },
     {
+        id: "grand-live-song-priority",
+        title: "Grand Live Song Priority",
+        description: "Rank which Songs the bot buys first in Lessons. A ranked Song is bought ahead of anything else learnable, whatever its effects.",
+        page: "ScenarioOverridesSettings",
+    },
+    {
         id: "grand-live-lesson-rescan-interval",
         title: "Grand Live Lessons Re-check Interval",
         description: "How many turns to wait between Lessons re-checks for newly learnable cards. The list only refreshes after a purchase, so checking every turn wastes time.",

--- a/src/lib/messageLog/buildSettingsBanner.ts
+++ b/src/lib/messageLog/buildSettingsBanner.ts
@@ -249,6 +249,7 @@ ${longTargetsString}${formatAdvancedScoringSection(settings.training)}
 🎤 Grand Live Lesson Effect Priority: ${(settings.scenarioOverrides?.grandLiveLessonEffectPriority ?? []).length === 0 ? "None" : (settings.scenarioOverrides?.grandLiveLessonEffectPriority ?? []).join(" > ")}
 🎚️ Grand Live Lesson Stat Priority: ${(settings.scenarioOverrides?.grandLiveLessonStatPriority ?? []).length === 0 ? "Global" : (settings.scenarioOverrides?.grandLiveLessonStatPriority ?? []).join(" > ")}
 💡 Grand Live Lesson Skill Hint Priority: ${(settings.scenarioOverrides?.grandLiveLessonHintPriority ?? []).length === 0 ? "None" : (settings.scenarioOverrides?.grandLiveLessonHintPriority ?? []).join(" > ")}
+🎵 Grand Live Song Priority: ${(settings.scenarioOverrides?.grandLiveSongPriority ?? []).length === 0 ? "None" : (settings.scenarioOverrides?.grandLiveSongPriority ?? []).join(" > ")}
 🎶 Grand Live Lessons Re-check Interval: Every ${settings.scenarioOverrides?.grandLiveLessonRescanInterval ?? 2} turn(s)
 
 ---------- Misc Options ----------

--- a/src/pages/ScenarioOverridesSettings/index.tsx
+++ b/src/pages/ScenarioOverridesSettings/index.tsx
@@ -56,6 +56,34 @@ const RUNNING_STYLE_OPTIONS = ["Front Runner", "Pace Chaser", "Late Surger", "En
 /** The Grand Live skill-hint tags rankable in the Lesson Skill Hint Priority list. These are the parentheticals the Lessons cards print, and the ids double as the strings stored in the setting. */
 const GRAND_LIVE_HINT_TAGS = [...RUNNING_STYLE_OPTIONS, ...TRACK_DISTANCE_OPTIONS, ...TRACK_SURFACE_OPTIONS].map((name) => ({ id: name, label: name }))
 
+/**
+ * The Grand Live Songs rankable in the Song Priority list, each shown with the effect it grants. The ids double as the strings stored in the setting and
+ * must stay in step with the song list the bot matches OCR'd card titles against.
+ */
+const GRAND_LIVE_SONGS = [
+    { id: "Believe in Miracles!", label: "Believe in Miracles!", description: "Training Wit Gain +1, Specialty Priority +5" },
+    { id: "Run n' Run!", label: "Run n' Run!", description: "Skill Pts +22, Friendship Training Effectiveness +5%" },
+    { id: "Full Speed Ahead! Umadol Power☆", label: "Full Speed Ahead! Umadol Power☆", description: "Speed +22, Friendship Training Effectiveness +5%" },
+    { id: "Here Comes Our Time", label: "Here Comes Our Time", description: "Power +22, Friendship Training Effectiveness +5%" },
+    { id: "Zero Is Where the Center Stands!", label: "Zero Is Where the Center Stands!", description: "Training Speed Gain +1, Support Chain Event Frequency Lvl +1" },
+    { id: "Go This Way", label: "Go This Way", description: "Training Power Gain +1, Support Chain Event Frequency Lvl +1" },
+    { id: "Ring Ring Diary", label: "Ring Ring Diary", description: "Training Stamina Gain +1, Support Chain Event Frequency Lvl +1" },
+    { id: "Getaway! Fallin' Love", label: "Getaway! Fallin' Love", description: "Training Guts Gain +1, Support Chain Event Frequency Lvl +1" },
+    { id: "Run for Our Dream!", label: "Run for Our Dream!", description: "Training Skill Pt Gain +2, Specialty Priority +5" },
+    { id: "Our Blue Bird Days", label: "Our Blue Bird Days", description: "Training Speed Gain +2, Specialty Priority +5" },
+    { id: "Hey, Guess What!", label: "Hey, Guess What!", description: "Training Guts Gain +2, Specialty Priority +5" },
+    { id: "Grow Up and Shine!", label: "Grow Up and Shine!", description: "Training Skill Pt Gain +3, Support Chain Event Frequency Lvl +1" },
+    { id: "Seven Colors Scenery", label: "Seven Colors Scenery", description: "Training Power Gain +2, Specialty Priority +5" },
+    { id: "Sunbeam Cheer", label: "Sunbeam Cheer", description: "Training Wit Gain +2, Support Chain Event Frequency Lvl +1" },
+    { id: "Hoppity Sunny Days♪", label: "Hoppity Sunny Days♪", description: "Training Stamina Gain +2, Specialty Priority +5" },
+    { id: "Precious Treasure Box", label: "Precious Treasure Box", description: "Speed +26, Friendship Training Effectiveness +10%" },
+    { id: "Fanfare for the Future!", label: "Fanfare for the Future!", description: "Guts +26, Friendship Training Effectiveness +10%" },
+    { id: "Present March♪", label: "Present March♪", description: "Power +22, Friendship Training Effectiveness +5%" },
+    { id: "Dream Sky", label: "Dream Sky", description: "Wit +22, Friendship Training Effectiveness +5%" },
+    { id: "The World's at Our Whim", label: "The World's at Our Whim", description: "Stamina +22, Friendship Training Effectiveness +5%" },
+    { id: "Sky-Blue Spring", label: "Sky-Blue Spring", description: "Guts +22, Friendship Training Effectiveness +5%" },
+]
+
 /** Options for the Grand Live Lessons re-check interval picker, in turns. */
 const GRAND_LIVE_INTERVAL_OPTIONS = [1, 2, 3, 4, 5] as const
 
@@ -168,6 +196,7 @@ const ScenarioOverridesSettings = () => {
     const [lessonPriorityPickerOpen, setLessonPriorityPickerOpen] = useState(false)
     const [lessonStatPriorityPickerOpen, setLessonStatPriorityPickerOpen] = useState(false)
     const [lessonHintPriorityPickerOpen, setLessonHintPriorityPickerOpen] = useState(false)
+    const [songPriorityPickerOpen, setSongPriorityPickerOpen] = useState(false)
     const [lessonIntervalPickerOpen, setLessonIntervalPickerOpen] = useState(false)
 
     // Built once so the memoized priority list is not handed a fresh array on every render, matching the module-level constants its sibling pickers use.
@@ -305,6 +334,7 @@ const ScenarioOverridesSettings = () => {
         updateOverrideSetting("grandLiveLessonEffectPriority", defaultSettings.scenarioOverrides.grandLiveLessonEffectPriority)
         updateOverrideSetting("grandLiveLessonStatPriority", defaultSettings.scenarioOverrides.grandLiveLessonStatPriority)
         updateOverrideSetting("grandLiveLessonHintPriority", defaultSettings.scenarioOverrides.grandLiveLessonHintPriority)
+        updateOverrideSetting("grandLiveSongPriority", defaultSettings.scenarioOverrides.grandLiveSongPriority)
         updateOverrideSetting("grandLiveLessonRescanInterval", defaultSettings.scenarioOverrides.grandLiveLessonRescanInterval)
     }, [updateOverrideSetting, defaultSettings])
 
@@ -979,6 +1009,18 @@ const ScenarioOverridesSettings = () => {
                                             />
                                         </SearchableItem>
                                         <SearchableItem
+                                            id="grand-live-song-priority"
+                                            title="Song Priority"
+                                            description="Rank which Songs the bot buys first in Lessons. A ranked Song is bought ahead of anything else learnable, whatever its effects."
+                                        >
+                                            <Row
+                                                title="Song Priority"
+                                                description="Drag to rank which Songs Lessons buys first. A ranked Song outranks every effect ordering below."
+                                                onPress={() => setSongPriorityPickerOpen(true)}
+                                                right={<ValuePill label={scenarioOverrides.grandLiveSongPriority.length === 0 ? "None" : `${scenarioOverrides.grandLiveSongPriority.length} ranked`} />}
+                                            />
+                                        </SearchableItem>
+                                        <SearchableItem
                                             id="grand-live-lesson-rescan-interval"
                                             title="Lessons Re-check Interval"
                                             description="How many turns to wait between Lessons re-checks for newly learnable cards. The list only refreshes after a purchase, so checking every turn wastes time."
@@ -1111,6 +1153,15 @@ const ScenarioOverridesSettings = () => {
                 items={GRAND_LIVE_HINT_TAGS}
                 selected={scenarioOverrides.grandLiveLessonHintPriority}
                 onChange={(next) => updateOverrideSetting("grandLiveLessonHintPriority", next)}
+            />
+
+            <PriorityPickerSheet
+                visible={songPriorityPickerOpen}
+                onClose={() => setSongPriorityPickerOpen(false)}
+                title="SONG PRIORITY"
+                items={GRAND_LIVE_SONGS}
+                selected={scenarioOverrides.grandLiveSongPriority}
+                onChange={(next) => updateOverrideSetting("grandLiveSongPriority", next)}
             />
 
             <SheetModal

--- a/src/pages/ScenarioOverridesSettings/index.tsx
+++ b/src/pages/ScenarioOverridesSettings/index.tsx
@@ -17,7 +17,7 @@ import { ValuePill } from "../../components/ui/value-pill"
 import { ModalHeader } from "../../components/ui/modal-header"
 import SearchableItem from "../../components/SearchableItem"
 import ToggleSetting from "../../components/ToggleSetting"
-import DraggablePriorityList from "../../components/DraggablePriorityList"
+import DraggablePriorityList, { PriorityItem } from "../../components/DraggablePriorityList"
 import { CircleCheckBig, Trash2 } from "lucide-react-native"
 import { usePerformanceLogging } from "../../hooks/usePerformanceLogging"
 import trackblazerIcons from "./icons"
@@ -112,6 +112,40 @@ function ChipMultiSelect({ title, description, options, selected, onToggle }: Ch
         </View>
     )
 }
+
+/** Props for `PriorityPickerSheet`. */
+interface PriorityPickerSheetProps {
+    /** Whether the sheet is currently open. */
+    visible: boolean
+    /** Called when the sheet should close, from either the header or a back gesture. */
+    onClose: () => void
+    /** Uppercase heading shown in the sheet's header. */
+    title: string
+    /** Every rankable item, each with the id stored in the setting and an optional second line of detail. */
+    items: PriorityItem[]
+    /** The currently ranked ids, index 0 = highest. */
+    selected: string[]
+    /** Called with the next ranked order whenever a row is toggled or dragged. */
+    onChange: (next: string[]) => void
+}
+
+/**
+ * A sheet wrapping a drag-to-rank list. The Grand Live overrides open four of these and they differ only in heading, item list, and the setting they
+ * write, so the shell lives here once.
+ *
+ * @param visible Whether the sheet is open.
+ * @param onClose Close callback.
+ * @param title Header text.
+ * @param items Every rankable item.
+ * @param selected The currently ranked ids.
+ * @param onChange Called with the next ranked order.
+ * @returns The sheet containing the priority list.
+ */
+const PriorityPickerSheet = ({ visible, onClose, title, items, selected, onChange }: PriorityPickerSheetProps) => (
+    <SheetModal visible={visible} onRequestClose={onClose} header={<ModalHeader title={title} onClose={onClose} />} footer={null}>
+        <DraggablePriorityList items={items} selectedItems={selected} onSelectionChange={onChange} onOrderChange={onChange} />
+    </SheetModal>
+)
 
 /**
  * The Scenario Overrides Settings page.
@@ -1052,47 +1086,32 @@ const ScenarioOverridesSettings = () => {
                 </View>
             </SheetModal>
 
-            <SheetModal
+            <PriorityPickerSheet
                 visible={lessonPriorityPickerOpen}
-                onRequestClose={() => setLessonPriorityPickerOpen(false)}
-                header={<ModalHeader title="LESSON EFFECT PRIORITY" onClose={() => setLessonPriorityPickerOpen(false)} />}
-                footer={null}
-            >
-                <DraggablePriorityList
-                    items={GRAND_LIVE_LESSON_CATEGORIES}
-                    selectedItems={scenarioOverrides.grandLiveLessonEffectPriority}
-                    onSelectionChange={(next) => updateOverrideSetting("grandLiveLessonEffectPriority", next)}
-                    onOrderChange={(orderedItems) => updateOverrideSetting("grandLiveLessonEffectPriority", orderedItems)}
-                />
-            </SheetModal>
+                onClose={() => setLessonPriorityPickerOpen(false)}
+                title="LESSON EFFECT PRIORITY"
+                items={GRAND_LIVE_LESSON_CATEGORIES}
+                selected={scenarioOverrides.grandLiveLessonEffectPriority}
+                onChange={(next) => updateOverrideSetting("grandLiveLessonEffectPriority", next)}
+            />
 
-            <SheetModal
+            <PriorityPickerSheet
                 visible={lessonStatPriorityPickerOpen}
-                onRequestClose={() => setLessonStatPriorityPickerOpen(false)}
-                header={<ModalHeader title="LESSON STAT PRIORITY" onClose={() => setLessonStatPriorityPickerOpen(false)} />}
-                footer={null}
-            >
-                <DraggablePriorityList
-                    items={statPriorityItems}
-                    selectedItems={scenarioOverrides.grandLiveLessonStatPriority}
-                    onSelectionChange={(next) => updateOverrideSetting("grandLiveLessonStatPriority", next)}
-                    onOrderChange={(orderedItems) => updateOverrideSetting("grandLiveLessonStatPriority", orderedItems)}
-                />
-            </SheetModal>
+                onClose={() => setLessonStatPriorityPickerOpen(false)}
+                title="LESSON STAT PRIORITY"
+                items={statPriorityItems}
+                selected={scenarioOverrides.grandLiveLessonStatPriority}
+                onChange={(next) => updateOverrideSetting("grandLiveLessonStatPriority", next)}
+            />
 
-            <SheetModal
+            <PriorityPickerSheet
                 visible={lessonHintPriorityPickerOpen}
-                onRequestClose={() => setLessonHintPriorityPickerOpen(false)}
-                header={<ModalHeader title="LESSON SKILL HINT PRIORITY" onClose={() => setLessonHintPriorityPickerOpen(false)} />}
-                footer={null}
-            >
-                <DraggablePriorityList
-                    items={GRAND_LIVE_HINT_TAGS}
-                    selectedItems={scenarioOverrides.grandLiveLessonHintPriority}
-                    onSelectionChange={(next) => updateOverrideSetting("grandLiveLessonHintPriority", next)}
-                    onOrderChange={(orderedItems) => updateOverrideSetting("grandLiveLessonHintPriority", orderedItems)}
-                />
-            </SheetModal>
+                onClose={() => setLessonHintPriorityPickerOpen(false)}
+                title="LESSON SKILL HINT PRIORITY"
+                items={GRAND_LIVE_HINT_TAGS}
+                selected={scenarioOverrides.grandLiveLessonHintPriority}
+                onChange={(next) => updateOverrideSetting("grandLiveLessonHintPriority", next)}
+            />
 
             <SheetModal
                 visible={lessonIntervalPickerOpen}


### PR DESCRIPTION
## Description

- This PR resolves #426 by adding `Song Priority` to `Scenario Overrides Settings`, where you rank the Grand Live Songs you want and the bot buys a ranked Song ahead of anything else learnable, whatever its effects.
- Titles are matched loosely against what the game shows, so the routine misreads still resolve to the right Song, and the bot warns in the log if a title it does not recognize appears.
- Every ranked list on the page now shows what each option grants, so each Song is listed with its effect instead of just its name.
- Also holds tokens for a top-ranked Song that is not yet affordable, rather than spending them on a weaker card first.